### PR TITLE
컬럼이 not null이고 default도 null이면 value가 제공돼도 에러 반환 

### DIFF
--- a/src/executor/implements/dml/insert.rs
+++ b/src/executor/implements/dml/insert.rs
@@ -93,14 +93,6 @@ impl Executor {
                         let default_value = match &column_config_info.default {
                             Some(default) => default.to_owned(),
                             None => {
-                                if column_config_info.not_null {
-                                    return Err(ExecuteError::new(format!(
-                                        "column '{}' is not null column
-                                        ",
-                                        column_name
-                                    )));
-                                }
-
                                 SQLExpression::Null
                             }
                         };
@@ -111,6 +103,14 @@ impl Executor {
 
                         match columns_map.get(column_name) {
                             Some(column) => {
+                                if (column.not_null && data.type_code() == 0) {
+                                    return Err(ExecuteError::new(format!(
+                                        "column '{}' is not null column
+                                        ",
+                                        column_name
+                                    )));
+                                }
+
                                 if column.data_type.type_code() != data.type_code()
                                     && data.type_code() != 0
                                 {

--- a/src/executor/implements/dml/insert.rs
+++ b/src/executor/implements/dml/insert.rs
@@ -103,7 +103,7 @@ impl Executor {
 
                         match columns_map.get(column_name) {
                             Some(column) => {
-                                if (column.not_null && data.type_code() == 0) {
+                                if column.not_null && data.type_code() == 0 {
                                     return Err(ExecuteError::new(format!(
                                         "column '{}' is not null column
                                         ",


### PR DESCRIPTION
resolved: #85

## 설명
default 값에서 비교하던 코드를

```rust
match columns_map.get(column_name) {
    Some(column) => {
        if (column.not_null && data.type_code() == 0) {
            return Err(ExecuteError::new(format!(
                "column '{}' is not null column
                ",
                column_name
            )));
        }
       // ...
``` 

위 코드와 같이 실질적 컬럼 값에서 비교하게 코드를 옮겼습니다.