### PR TITLE
[#79] MacOS 환경에서의 launchd 데몬 구성

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ sudo ln -s /home/$USER/.cargo/bin/rrdb /usr/bin/rrdb
 sudo rrdb init
 ```
 
+- 플랫폼별 초기화 (MacOS)
+
+심볼릭 링크를 생성하고 초기화를 수행합니다.
+
+```
+sudo ln -s /home/$USER/.cargo/bin/rrdb /usr/local/bin/rrdb
+sudo rrdb init
+```
+
 - 플랫폼별 초기화 (Windows)
 
 powershell을 관리자 권한으로 실행하고 다음 명령어를 수행합니다.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -16,3 +16,9 @@ pub const DEFAULT_CONFIG_BASEPATH: &str = "C:\\Program Files\\rrdb";
 
 #[cfg(target_os = "macos")]
 pub const DEFAULT_CONFIG_BASEPATH: &str = "/var/lib/rrdb";
+
+#[cfg(target_os = "macos")]
+pub const LAUNCHD_PLIST_PATH: &str = "/Library/LaunchDaemons/io.github.myyrakle.rrdb.plist";
+
+#[cfg(other)]
+pub const LAUNCHD_PLIST_PATH: &str = "";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -17,8 +17,4 @@ pub const DEFAULT_CONFIG_BASEPATH: &str = "C:\\Program Files\\rrdb";
 #[cfg(target_os = "macos")]
 pub const DEFAULT_CONFIG_BASEPATH: &str = "/var/lib/rrdb";
 
-#[cfg(target_os = "macos")]
 pub const LAUNCHD_PLIST_PATH: &str = "/Library/LaunchDaemons/io.github.myyrakle.rrdb.plist";
-
-#[cfg(other)]
-pub const LAUNCHD_PLIST_PATH: &str = "";

--- a/src/executor/initializer.rs
+++ b/src/executor/initializer.rs
@@ -107,12 +107,7 @@ StandardError=file:/var/log/rrdb.stderr.log
 [Install]
 WantedBy=multi-user.target"#;
 
-        if let Err(error) = tokio::fs::write(base_path, script).await {
-            if error.kind() != std::io::ErrorKind::AlreadyExists {
-                return Err(ExecuteError::wrap(error.to_string()));
-            }
-        }
-        Ok(())
+        self.write_and_check_err(base_path, script).await
     }
 
     #[cfg(target_os = "macos")]
@@ -137,7 +132,15 @@ WantedBy=multi-user.target"#;
 </dict>
 </plist>"#;
 
-        if let Err(error) = tokio::fs::write(base_path, script).await {
+        self.write_and_check_err(base_path, script).await
+    }
+
+    async fn write_and_check_err(
+        &self,
+        base_path: PathBuf,
+        contents: &str,
+    ) -> Result<(), RRDBError> {
+        if let Err(error) = tokio::fs::write(base_path, contents).await {
             if error.kind() != std::io::ErrorKind::AlreadyExists {
                 return Err(ExecuteError::wrap(error.to_string()));
             }

--- a/src/executor/initializer.rs
+++ b/src/executor/initializer.rs
@@ -119,6 +119,8 @@ WantedBy=multi-user.target"#;
 <dict>
         <key>Label</key>
         <string>myyrakle.github.io.rrdb</string>
+        <key>UserName</key>
+        <string>root</string>
         <key>Program</key>
         <string>/usr/local/bin/rrdb</string>
         <key>RunAtLoad</key>

--- a/src/executor/initializer.rs
+++ b/src/executor/initializer.rs
@@ -101,6 +101,8 @@ Restart=on-failure
 ExecStart=/usr/bin/rrdb run
 RemainAfterExit=on
 User=root
+StandardOutput=file:/var/log/rrdb.stdout.log
+StandardError=file:/var/log/rrdb.stderr.log
 
 [Install]
 WantedBy=multi-user.target"#;
@@ -126,7 +128,9 @@ WantedBy=multi-user.target"#;
         <key>RunAtLoad</key>
         <true/>
         <key>StandardOutPath</key>
-        <string>/var/log/rrdb.log</string>
+        <string>/var/log/rrdb.stdout.log</string>
+        <key>StandardErrorPath</key>
+        <string>/var/log/rrdb.stderr.log</string>
 </dict>
 </plist>"#;
 


### PR DESCRIPTION
resolved: #79 

## 설명

* launchd 관련 plist 추가 및 launch_daemon 연동
* DRY를 위해 `LAUNCHD_PLIST_PATH` constants 구성
* launchd / systemd 환경에서 /var/log/rrdb.{stdout|stderr}.log 파일 구성
  * macos에서는 journalctl처럼 service stdout을 편하게 볼 수 있는 방법이 없어서 구성하였습니다.
* 조건부 로직 공통화
* 플랫폼별 초기화 (MacOS) 파트 작성
  * /usr/bin에 write하려고 하면 [SIP](https://developer.apple.com/documentation/security/disabling_and_enabling_system_integrity_protection) Disable을 요해 /usr/local/bin에 구성하였습니다 :)