### PR TITLE
[#101] Default Port를 22208로 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cargo run --bin rrdb run
 #### Client
 
 ```
-psql -U rrdb -p 55555 --host 0.0.0.0
+psql -U rrdb -p 22208 --host 0.0.0.0
 ```
 
 ---

--- a/src/executor/config/global.rs
+++ b/src/executor/config/global.rs
@@ -17,7 +17,7 @@ impl std::default::Default for GlobalConfig {
         let base_path = PathBuf::from(DEFAULT_CONFIG_BASEPATH);
 
         Self {
-            port: 55555,
+            port: 22208,
             host: "0.0.0.0".to_string(),
             data_directory: base_path
                 .join(DEFAULT_DATA_DIRNAME)


### PR DESCRIPTION
resolves: #101 

## 설명

MacOS 환경에서 Port Allocation 실패 이슈를 방지하기 위해, Default Port를 55555에서 22208로 변경합니다.

## 비고

2208은 rrdb를 number로 표현한 값입니다 :)
named by @boxqkrtm 