### PR TITLE
[#114] CI Actions result에 binary 업로드 및 tag에 대한 Release 구성

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -32,3 +32,10 @@ jobs:
 
       - run: cargo build --verbose
       - run: cargo test --verbose
+
+      - name: Upload binary as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rrdb${{ runner.os == 'Windows' && '.exe' || ''}}
+          path: target/build/rrdb${{ runner.os == 'Windows' && '.exe' || ''}}
+          if-no-files-found: error

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -36,6 +36,6 @@ jobs:
       - name: Upload binary as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: rrdb${{ runner.os == 'Windows' && '.exe' || ''}}
-          path: target/build/rrdb${{ runner.os == 'Windows' && '.exe' || ''}}
+          name: ${{ runner.os }}-rrdb${{ runner.os == 'Windows' && '.exe' || ''}}
+          path: target/debug/rrdb${{ runner.os == 'Windows' && '.exe' || ''}}
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    tags:        
+      - 'v**'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  create-release:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: gh release create ${{ github.ref_name }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+  upload-binaries-to-release:
+    name: Upload
+    strategy:
+      max-parallel: 3
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        toolchain:
+          - stable
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+
+      - run: cargo build --verbose --release
+
+      - name: Upload binary to release
+        continue-on-error: true
+        run: >
+          mv $file $name &&
+          gh release upload ${{ github.ref_name }} $name
+        shell:
+          bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          name: ${{ runner.os }}-rrdb${{ runner.os == 'Windows' && '.exe' || ''}}
+          file: target/release/rrdb${{ runner.os == 'Windows' && '.exe' || ''}}


### PR DESCRIPTION
resolves: #114 

## 설명

다음과 같은 workflow를 구현합니다.
* CI Actions result에 대한 binary 업로드
* `v**` 기반 tag push에 따른 Release 및 rrdb binary 업로드