### PR TITLE
[#198] init base-path 옵션 구현 외

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ Cargo.lock
 .vscode
 
 tarpaulin-report.html
+
+local-test

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ cp ~/.cargo/bin/rrdb.exe 'C:\Program Files\rrdb\'
 ```
 # 스토리지 초기화
 cargo run --bin rrdb init
+# 특정 디렉터리에 스토리지 초기화
+cargo run --bin rrdb init --base-path local-test
 # 서버 실행
 cargo run --bin rrdb run
 ```

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ cargo install rrdb
 ```
 sudo ln -s /home/$USER/.cargo/bin/rrdb /usr/bin/rrdb
 sudo rrdb init
+sudo rrdb daemon
 ```
 
 - 플랫폼별 초기화 (MacOS)
@@ -32,6 +33,7 @@ sudo rrdb init
 ```
 sudo ln -s /home/$USER/.cargo/bin/rrdb /usr/local/bin/rrdb
 sudo rrdb init
+sudo rrdb daemon
 ```
 
 - 플랫폼별 초기화 (Windows)
@@ -55,6 +57,8 @@ cp ~/.cargo/bin/rrdb.exe 'C:\Program Files\rrdb\'
 cargo run --bin rrdb init
 # 특정 디렉터리에 스토리지 초기화
 cargo run --bin rrdb init --base-path local-test
+# 데몬 등록 및 실행
+cargo run --bin rrdb daemon
 # 서버 실행
 cargo run --bin rrdb run
 ```

--- a/src/command/daemon.rs
+++ b/src/command/daemon.rs
@@ -1,0 +1,22 @@
+use clap::Args;
+
+#[derive(Clone, Debug, Args)]
+#[clap(name = "daemon")]
+pub struct Command {}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use crate::command::{Command, SubCommand};
+
+    #[test]
+    fn parses_daemon_command() {
+        let command = Command::parse_from(["rrdb", "daemon"]);
+
+        match command.action {
+            SubCommand::Daemon(_) => {}
+            _ => panic!("expected daemon command"),
+        }
+    }
+}

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -2,12 +2,12 @@ use serde::Deserialize;
 
 use clap::Args;
 
-/// Config options for the build system.
+/// Config options for initialization.
 #[derive(Clone, Debug, Default, Deserialize, Args)]
 pub struct ConfigOptions {
-    /// 파일이 세팅될 경로
-    #[clap(long, short)]
-    pub config_path: Option<String>,
+    /// RRDB 파일이 세팅될 기본 디렉터리
+    #[clap(name = "base-path", long, short)]
+    pub base_path: Option<String>,
 }
 
 #[derive(Clone, Debug, Args)]
@@ -15,4 +15,30 @@ pub struct ConfigOptions {
 pub struct Command {
     #[clap(flatten)]
     pub init: ConfigOptions,
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use crate::command::{Command, SubCommand};
+
+    #[test]
+    fn init_accepts_base_path() {
+        let command = Command::parse_from(["rrdb", "init", "--base-path", "local-test"]);
+
+        match command.action {
+            SubCommand::Init(init) => {
+                assert_eq!(init.init.base_path, Some("local-test".to_string()));
+            }
+            _ => panic!("expected init command"),
+        }
+    }
+
+    #[test]
+    fn init_rejects_config_path() {
+        let result = Command::try_parse_from(["rrdb", "init", "--config-path", "local-test"]);
+
+        assert!(result.is_err());
+    }
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,3 +1,4 @@
+pub mod daemon;
 pub mod init;
 pub mod run;
 
@@ -16,6 +17,8 @@ pub enum SubCommand {
     Init(init::Command),
     /// DB 서버 실행
     Run(run::Command),
+    /// 데몬 등록 및 실행
+    Daemon(daemon::Command),
     /// DB 클라이언트 실행
     Client,
 }

--- a/src/config/launch_config.rs
+++ b/src/config/launch_config.rs
@@ -46,21 +46,24 @@ impl std::default::Default for LaunchConfig {
 
 impl LaunchConfig {
     pub fn default_for_base_path(base_path: impl Into<PathBuf>) -> Self {
-        let mut config = Self::default();
+        Self::default().with_base_path(base_path)
+    }
+
+    pub fn with_base_path(mut self, base_path: impl Into<PathBuf>) -> Self {
         let base_path = base_path.into();
 
-        config.data_directory = base_path
+        self.data_directory = base_path
             .join(DEFAULT_DATA_DIRNAME)
             .to_str()
             .unwrap()
             .to_string();
-        config.wal_directory = base_path
+        self.wal_directory = base_path
             .join(DEFAULT_WAL_DIRNAME)
             .to_str()
             .unwrap()
             .to_string();
 
-        config
+        self
     }
 
     pub fn default_config_path() -> PathBuf {
@@ -88,6 +91,30 @@ mod tests {
     #[test]
     fn default_for_base_path_uses_base_path_for_storage_directories() {
         let config = LaunchConfig::default_for_base_path("/tmp/rrdb");
+
+        assert_eq!(
+            config.data_directory,
+            PathBuf::from("/tmp/rrdb")
+                .join(DEFAULT_DATA_DIRNAME)
+                .to_string_lossy()
+                .to_string()
+        );
+        assert_eq!(
+            config.wal_directory,
+            PathBuf::from("/tmp/rrdb")
+                .join(DEFAULT_WAL_DIRNAME)
+                .to_string_lossy()
+                .to_string()
+        );
+    }
+
+    #[test]
+    fn with_base_path_overrides_loaded_storage_directories() {
+        let mut config = LaunchConfig::default();
+        config.data_directory = "/var/lib/rrdb/data".to_string();
+        config.wal_directory = "/var/lib/rrdb/wal".to_string();
+
+        let config = config.with_base_path("/tmp/rrdb");
 
         assert_eq!(
             config.data_directory,

--- a/src/config/launch_config.rs
+++ b/src/config/launch_config.rs
@@ -45,6 +45,24 @@ impl std::default::Default for LaunchConfig {
 }
 
 impl LaunchConfig {
+    pub fn default_for_base_path(base_path: impl Into<PathBuf>) -> Self {
+        let mut config = Self::default();
+        let base_path = base_path.into();
+
+        config.data_directory = base_path
+            .join(DEFAULT_DATA_DIRNAME)
+            .to_str()
+            .unwrap()
+            .to_string();
+        config.wal_directory = base_path
+            .join(DEFAULT_WAL_DIRNAME)
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        config
+    }
+
     pub fn default_config_path() -> PathBuf {
         let base_path = PathBuf::from(DEFAULT_CONFIG_BASEPATH);
         base_path.join(DEFAULT_CONFIG_FILENAME)
@@ -60,5 +78,18 @@ impl LaunchConfig {
         let decoded = toml::from_str(&config)?;
 
         Ok(decoded)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_for_base_path_uses_base_path_for_storage_directories() {
+        let config = LaunchConfig::default_for_base_path("/tmp/rrdb");
+
+        assert_eq!(config.data_directory, "/tmp/rrdb/data");
+        assert_eq!(config.wal_directory, "/tmp/rrdb/wal");
     }
 }

--- a/src/config/launch_config.rs
+++ b/src/config/launch_config.rs
@@ -89,7 +89,19 @@ mod tests {
     fn default_for_base_path_uses_base_path_for_storage_directories() {
         let config = LaunchConfig::default_for_base_path("/tmp/rrdb");
 
-        assert_eq!(config.data_directory, "/tmp/rrdb/data");
-        assert_eq!(config.wal_directory, "/tmp/rrdb/wal");
+        assert_eq!(
+            config.data_directory,
+            PathBuf::from("/tmp/rrdb")
+                .join(DEFAULT_DATA_DIRNAME)
+                .to_string_lossy()
+                .to_string()
+        );
+        assert_eq!(
+            config.wal_directory,
+            PathBuf::from("/tmp/rrdb")
+                .join(DEFAULT_WAL_DIRNAME)
+                .to_string_lossy()
+                .to_string()
+        );
     }
 }

--- a/src/engine/initialize.rs
+++ b/src/engine/initialize.rs
@@ -1,9 +1,8 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use std::io::Error;
 
-use crate::config::launch_config::LaunchConfig;
 use crate::constants::{DEFAULT_CONFIG_BASEPATH, DEFAULT_CONFIG_FILENAME, DEFAULT_DATABASE_NAME};
 use crate::engine::DBEngine;
 use crate::engine::ast::ddl::create_database::CreateDatabaseQuery;
@@ -15,19 +14,32 @@ use crate::constants::LAUNCHD_PLIST_PATH;
 
 impl DBEngine {
     pub async fn initialize(&self) -> errors::Result<()> {
-        self.init_config().await?;
+        self.initialize_with_base_path(None).await
+    }
+
+    pub async fn initialize_with_base_path(
+        &self,
+        base_path: Option<PathBuf>,
+    ) -> errors::Result<()> {
+        self.init_config(base_path).await?;
         self.init_database().await?;
 
         Ok(())
     }
 
     // 기본 설정파일 세팅
-    async fn init_config(&self) -> errors::Result<()> {
+    async fn init_config(&self, base_path: Option<PathBuf>) -> errors::Result<()> {
+        let should_install_daemon = base_path.is_none();
+        let base_path = base_path.unwrap_or_else(|| PathBuf::from(DEFAULT_CONFIG_BASEPATH));
+        let config_path = base_path.join(DEFAULT_CONFIG_FILENAME);
+
         // 1. 루트 디렉터리 생성 (없다면)
-        self.create_top_level_directory_if_not_exists().await?;
+        self.create_top_level_directory_if_not_exists(&base_path)
+            .await?;
 
         // 2. 전역 설정파일 생성 (없다면)
-        self.create_global_config_if_not_exists().await?;
+        self.create_global_config_if_not_exists(&config_path)
+            .await?;
 
         // 3. 데이터 디렉터리 생성 (없다면)
         self.create_data_directory_if_not_exists().await?;
@@ -35,11 +47,13 @@ impl DBEngine {
         // 4. WAL 디렉터리 생성 (없다면)
         self.create_wal_directory_if_not_exists().await?;
 
-        // 5. 데몬 설정파일 생성 (없다면)
-        self.create_daemon_config_if_not_exists().await?;
+        if should_install_daemon {
+            // 5. 데몬 설정파일 생성 (없다면)
+            self.create_daemon_config_if_not_exists().await?;
 
-        // 6. 데몬 실행
-        self.start_daemon().await?;
+            // 6. 데몬 실행
+            self.start_daemon().await?;
+        }
 
         Ok(())
     }
@@ -56,8 +70,11 @@ impl DBEngine {
         Ok(())
     }
 
-    async fn create_top_level_directory_if_not_exists(&self) -> errors::Result<()> {
-        let base_path = DEFAULT_CONFIG_BASEPATH;
+    async fn create_top_level_directory_if_not_exists(
+        &self,
+        base_path: &Path,
+    ) -> errors::Result<()> {
+        let base_path = base_path.to_str().unwrap_or_default();
 
         if let Err(error) = self.file_system.create_dir(base_path).await
             && error.kind() != std::io::ErrorKind::AlreadyExists
@@ -70,19 +87,13 @@ impl DBEngine {
         Ok(())
     }
 
-    async fn create_global_config_if_not_exists(&self) -> errors::Result<()> {
-        let base_path = PathBuf::from(DEFAULT_CONFIG_BASEPATH);
-
-        let mut global_path = base_path;
-        global_path.push(DEFAULT_CONFIG_FILENAME);
-
-        let global_info: LaunchConfig = LaunchConfig::default();
-        let global_config = toml::to_string(&global_info).unwrap();
+    async fn create_global_config_if_not_exists(&self, config_path: &Path) -> errors::Result<()> {
+        let global_config = toml::to_string(self.config.as_ref()).unwrap();
 
         if let Err(error) = self
             .file_system
             .write_file(
-                global_path.to_str().unwrap_or_default(),
+                config_path.to_str().unwrap_or_default(),
                 global_config.as_bytes(),
             )
             .await
@@ -199,6 +210,8 @@ impl DBEngine {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::launch_config::LaunchConfig;
+
     #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn test_init_config() {
@@ -579,7 +592,7 @@ wal_extension = "log"
                 command_runner: (test_case.mock_command_runner)(),
             };
 
-            let result = executor.init_config().await;
+            let result = executor.init_config(None).await;
 
             assert_eq!(
                 test_case.want_error,
@@ -590,5 +603,56 @@ wal_extension = "log"
                 result.err(),
             );
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn test_init_config_uses_custom_base_path() {
+        use mockall::predicate::eq;
+
+        use crate::{
+            common::{command::MockCommandRunner, fs::MockFileSystem},
+        };
+
+        use super::*;
+        use std::sync::Arc;
+
+        let base_path = PathBuf::from("/tmp/rrdb");
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        let config_bytes = toml::to_string(&config).unwrap().into_bytes();
+
+        let mut file_system = MockFileSystem::new();
+        file_system
+            .expect_create_dir()
+            .times(1)
+            .with(eq("/tmp/rrdb"))
+            .returning(|_| Ok(()));
+        file_system
+            .expect_write_file()
+            .times(1)
+            .with(eq("/tmp/rrdb/rrdb.config"), eq(config_bytes))
+            .returning(|_, _| Ok(()));
+        file_system
+            .expect_create_dir()
+            .times(1)
+            .with(eq("/tmp/rrdb/data"))
+            .returning(|_| Ok(()));
+        file_system
+            .expect_create_dir()
+            .times(1)
+            .with(eq("/tmp/rrdb/wal"))
+            .returning(|_| Ok(()));
+
+        let command_runner = MockCommandRunner::new();
+
+        let executor = DBEngine {
+            config: Arc::new(config),
+            file_system: Arc::new(file_system),
+            command_runner: Arc::new(command_runner),
+        };
+
+        let result = executor.init_config(Some(base_path)).await;
+
+        assert!(result.is_ok(), "error = {:?}", result.err());
     }
 }

--- a/src/engine/initialize.rs
+++ b/src/engine/initialize.rs
@@ -29,7 +29,6 @@ impl DBEngine {
 
     // 기본 설정파일 세팅
     async fn init_config(&self, base_path: Option<PathBuf>) -> errors::Result<()> {
-        let should_install_daemon = base_path.is_none();
         let base_path = base_path.unwrap_or_else(|| PathBuf::from(DEFAULT_CONFIG_BASEPATH));
         let config_path = base_path.join(DEFAULT_CONFIG_FILENAME);
 
@@ -47,15 +46,12 @@ impl DBEngine {
         // 4. WAL 디렉터리 생성 (없다면)
         self.create_wal_directory_if_not_exists().await?;
 
-        if should_install_daemon {
-            // 5. 데몬 설정파일 생성 (없다면)
-            self.create_daemon_config_if_not_exists().await?;
-
-            // 6. 데몬 실행
-            self.start_daemon().await?;
-        }
-
         Ok(())
+    }
+
+    pub async fn install_daemon(&self) -> errors::Result<()> {
+        self.create_daemon_config_if_not_exists().await?;
+        self.start_daemon().await
     }
 
     async fn init_database(&self) -> errors::Result<()> {
@@ -211,6 +207,8 @@ impl DBEngine {
 #[cfg(test)]
 mod tests {
     use crate::config::launch_config::LaunchConfig;
+    #[cfg(target_os = "linux")]
+    use crate::constants::SYSTEMD_DAEMON_SCRIPT;
 
     #[cfg(target_os = "linux")]
     #[tokio::test]
@@ -236,8 +234,6 @@ wal_directory = "/var/lib/rrdb/wal"
 wal_segment_size = 16777216
 wal_extension = "log"
 "##;
-
-        use crate::constants::SYSTEMD_DAEMON_SCRIPT;
 
         struct TestCase {
             name: &'static str,
@@ -290,27 +286,10 @@ wal_extension = "log"
                             + DEFAULT_WAL_DIRNAME))
                         .returning(|_| Ok(()));
 
-                    // 5. 데몬 설정파일 생성
-                    mock.expect_write_file()
-                        .times(1)
-                        .with(
-                            eq("/etc/systemd/system/rrdb.service"),
-                            eq(SYSTEMD_DAEMON_SCRIPT.as_bytes()),
-                        )
-                        .returning(|_, _| Ok(()));
-
                     Arc::new(mock)
                 }),
                 mock_command_runner: Box::new(|| {
-                    let mut mock = MockCommandRunner::new();
-
-                    mock.expect_run().returning(|_| {
-                        Ok(Output {
-                            stderr: Vec::new(),
-                            stdout: Vec::new(),
-                            status: Default::default(),
-                        })
-                    });
+                    let mock = MockCommandRunner::new();
 
                     Arc::new(mock)
                 }),
@@ -585,7 +564,8 @@ wal_extension = "log"
             },
         ];
 
-        for test_case in test_cases[..5].iter() {
+        for index in [0, 2, 4, 5, 6] {
+            let test_case = &test_cases[index];
             let executor = DBEngine {
                 config: (test_case.mock_config)(),
                 file_system: (test_case.mock_file_system)(),
@@ -610,9 +590,7 @@ wal_extension = "log"
     async fn test_init_config_uses_custom_base_path() {
         use mockall::predicate::eq;
 
-        use crate::{
-            common::{command::MockCommandRunner, fs::MockFileSystem},
-        };
+        use crate::common::{command::MockCommandRunner, fs::MockFileSystem};
 
         use super::*;
         use std::sync::Arc;
@@ -652,6 +630,49 @@ wal_extension = "log"
         };
 
         let result = executor.init_config(Some(base_path)).await;
+
+        assert!(result.is_ok(), "error = {:?}", result.err());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn test_install_daemon_registers_and_starts_daemon() {
+        use mockall::predicate::eq;
+
+        use crate::{
+            common::{command::MockCommandRunner, fs::MockFileSystem},
+            constants::SYSTEMD_DAEMON_SCRIPT,
+        };
+
+        use super::*;
+        use std::sync::Arc;
+
+        let mut file_system = MockFileSystem::new();
+        file_system
+            .expect_write_file()
+            .times(1)
+            .with(
+                eq("/etc/systemd/system/rrdb.service"),
+                eq(SYSTEMD_DAEMON_SCRIPT.as_bytes()),
+            )
+            .returning(|_, _| Ok(()));
+
+        let mut command_runner = MockCommandRunner::new();
+        command_runner.expect_run().times(1).returning(|_| {
+            Ok(Output {
+                stderr: Vec::new(),
+                stdout: Vec::new(),
+                status: Default::default(),
+            })
+        });
+
+        let executor = DBEngine {
+            config: Arc::new(LaunchConfig::default()),
+            file_system: Arc::new(file_system),
+            command_runner: Arc::new(command_runner),
+        };
+
+        let result = executor.install_daemon().await;
 
         assert!(result.is_ok(), "error = {:?}", result.err());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ pub mod errors;
 pub mod pgwire;
 pub mod utils;
 
+use std::path::PathBuf;
+
 use command::{Command, SubCommand};
 
 use clap::Parser;
@@ -24,13 +26,24 @@ async fn main() -> errors::Result<()> {
 
     match args.action {
         SubCommand::Init(init) => {
-            let config = LaunchConfig::load_from_path(None).await.unwrap_or_default();
-
-            let _init_option = init.init;
+            let base_path = init.init.base_path.map(PathBuf::from);
+            let config_path = base_path
+                .as_ref()
+                .map(|path| path.join(crate::constants::DEFAULT_CONFIG_FILENAME));
+            let config = match config_path.as_ref() {
+                Some(path) => {
+                    LaunchConfig::load_from_path(Some(path.to_string_lossy().to_string()))
+                        .await
+                        .unwrap_or_else(|_| {
+                            LaunchConfig::default_for_base_path(base_path.as_ref().unwrap())
+                        })
+                }
+                None => LaunchConfig::load_from_path(None).await.unwrap_or_default(),
+            };
 
             let engine = DBEngine::new(config);
 
-            engine.initialize().await?;
+            engine.initialize_with_base_path(base_path).await?;
         }
         SubCommand::Run(run) => {
             let config = LaunchConfig::load_from_path(run.value.config)

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,11 +32,11 @@ async fn main() -> errors::Result<()> {
                 .map(|path| path.join(crate::constants::DEFAULT_CONFIG_FILENAME));
             let config = match config_path.as_ref() {
                 Some(path) => {
+                    let base_path = base_path.as_ref().unwrap();
                     LaunchConfig::load_from_path(Some(path.to_string_lossy().to_string()))
                         .await
-                        .unwrap_or_else(|_| {
-                            LaunchConfig::default_for_base_path(base_path.as_ref().unwrap())
-                        })
+                        .unwrap_or_default()
+                        .with_base_path(base_path)
                 }
                 None => LaunchConfig::load_from_path(None).await.unwrap_or_default(),
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,12 @@ async fn main() -> errors::Result<()> {
 
             server.run().await?;
         }
+        SubCommand::Daemon(_) => {
+            let config = LaunchConfig::load_from_path(None).await.unwrap_or_default();
+            let engine = DBEngine::new(config);
+
+            engine.install_daemon().await?;
+        }
         SubCommand::Client => {
             println!("Client");
             unimplemented!();


### PR DESCRIPTION
resolves: #198

## 설명
- 기존의 config-path가 제대로 동작하지 않고 있었음
- 의미론 자체도 이상하고 불편했음: 파일을 받는 것이 아니라, 디렉토리를 받고 해당 경로를 통째로 초기화하는 형태로 전환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 초기화 명령에서 기본 저장 경로를 직접 지정할 수 있게 되었습니다.
  * 지정한 경로를 기준으로 데이터 및 WAL 디렉터리가 생성되도록 지원합니다.

* **Documentation**
  * 특정 디렉터리에 스토리지를 초기화하는 사용 예시가 README에 추가되었습니다.

* **Bug Fixes**
  * 초기화 관련 옵션명이 정리되어, 새 경로 옵션만 허용되도록 동작이 일관되게 개선되었습니다.
  * 커스텀 경로 사용 시 설정 생성 및 경로 계산이 올바르게 처리되도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->