### PR TITLE
[#201] run 명령의 설정 경로 옵션을 base path로 통일

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ cargo run --bin rrdb init --base-path local-test
 cargo run --bin rrdb daemon
 # 서버 실행
 cargo run --bin rrdb run
+# 특정 디렉터리 설정으로 서버 실행
+cargo run --bin rrdb run --base-path local-test
 ```
 
 #### Client

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -2,11 +2,12 @@ use serde::Deserialize;
 
 use clap::Args;
 
-/// Config options for the build system.
+/// Config options for running the server.
 #[derive(Clone, Debug, Default, Deserialize, Args)]
 pub struct ConfigOptions {
-    #[clap(name = "config", long, help = "config file path")]
-    pub config: Option<String>,
+    /// RRDB 파일이 세팅된 기본 디렉터리
+    #[clap(name = "base-path", long, short)]
+    pub base_path: Option<String>,
 }
 
 #[derive(Clone, Debug, Args)]
@@ -14,4 +15,30 @@ pub struct ConfigOptions {
 pub struct Command {
     #[clap(flatten)]
     pub value: ConfigOptions,
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use crate::command::{Command, SubCommand};
+
+    #[test]
+    fn run_accepts_base_path() {
+        let command = Command::parse_from(["rrdb", "run", "--base-path", "local-test"]);
+
+        match command.action {
+            SubCommand::Run(run) => {
+                assert_eq!(run.value.base_path, Some("local-test".to_string()));
+            }
+            _ => panic!("expected run command"),
+        }
+    }
+
+    #[test]
+    fn run_rejects_config() {
+        let result = Command::try_parse_from(["rrdb", "run", "--config", "local-test/rrdb.config"]);
+
+        assert!(result.is_err());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,28 @@ use clap::Parser;
 
 use crate::{
     config::launch_config::LaunchConfig,
+    constants::DEFAULT_CONFIG_FILENAME,
     engine::{DBEngine, server::Server},
+    errors::execute_error::ExecuteError,
 };
+
+async fn load_launch_config(base_path: Option<&PathBuf>) -> errors::Result<LaunchConfig> {
+    match base_path {
+        Some(base_path) => {
+            let config_path = base_path.join(DEFAULT_CONFIG_FILENAME);
+
+            let config =
+                LaunchConfig::load_from_path(Some(config_path.to_string_lossy().to_string()))
+                    .await
+                    .map_err(|error| ExecuteError::wrap(format!("config load error: {}", error)))?;
+
+            Ok(config.with_base_path(base_path))
+        }
+        None => LaunchConfig::load_from_path(None)
+            .await
+            .map_err(|error| ExecuteError::wrap(format!("config load error: {}", error))),
+    }
+}
 
 #[tokio::main]
 async fn main() -> errors::Result<()> {
@@ -27,18 +47,11 @@ async fn main() -> errors::Result<()> {
     match args.action {
         SubCommand::Init(init) => {
             let base_path = init.init.base_path.map(PathBuf::from);
-            let config_path = base_path
-                .as_ref()
-                .map(|path| path.join(crate::constants::DEFAULT_CONFIG_FILENAME));
-            let config = match config_path.as_ref() {
-                Some(path) => {
-                    let base_path = base_path.as_ref().unwrap();
-                    LaunchConfig::load_from_path(Some(path.to_string_lossy().to_string()))
-                        .await
-                        .unwrap_or_default()
-                        .with_base_path(base_path)
-                }
-                None => LaunchConfig::load_from_path(None).await.unwrap_or_default(),
+            let config = match base_path.as_ref() {
+                Some(base_path) => load_launch_config(Some(base_path))
+                    .await
+                    .unwrap_or_else(|_| LaunchConfig::default_for_base_path(base_path)),
+                None => load_launch_config(None).await.unwrap_or_default(),
             };
 
             let engine = DBEngine::new(config);
@@ -46,9 +59,8 @@ async fn main() -> errors::Result<()> {
             engine.initialize_with_base_path(base_path).await?;
         }
         SubCommand::Run(run) => {
-            let config = LaunchConfig::load_from_path(run.value.config)
-                .await
-                .expect("config load error");
+            let base_path = run.value.base_path.map(PathBuf::from);
+            let config = load_launch_config(base_path.as_ref()).await?;
 
             let server = Server::new(config);
 
@@ -67,4 +79,64 @@ async fn main() -> errors::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn load_launch_config_applies_base_path_to_loaded_config() {
+        let base_path = PathBuf::from("target/test_config_loader/run_base_path");
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+        tokio::fs::create_dir_all(&base_path).await.unwrap();
+
+        let config_path = base_path.join(DEFAULT_CONFIG_FILENAME);
+        tokio::fs::write(
+            &config_path,
+            br#"port = 34567
+host = "127.0.0.2"
+data_directory = "/var/lib/rrdb/data"
+wal_enabled = true
+wal_directory = "/var/lib/rrdb/wal"
+wal_segment_size = 16777216
+wal_extension = "log"
+"#,
+        )
+        .await
+        .unwrap();
+
+        let config = load_launch_config(Some(&base_path)).await.unwrap();
+
+        assert_eq!(config.port, 34567);
+        assert_eq!(config.host, "127.0.0.2");
+        assert_eq!(
+            config.data_directory,
+            base_path
+                .join(constants::DEFAULT_DATA_DIRNAME)
+                .to_string_lossy()
+                .to_string()
+        );
+        assert_eq!(
+            config.wal_directory,
+            base_path
+                .join(constants::DEFAULT_WAL_DIRNAME)
+                .to_string_lossy()
+                .to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn load_launch_config_returns_error_when_base_path_config_is_missing() {
+        let base_path = PathBuf::from("target/test_config_loader/missing_base_path");
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+
+        let result = load_launch_config(Some(&base_path)).await;
+
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
resolves: #201

## 설명
init 명령은 --base-path로 rrdb.config, data, wal 위치를 함께 결정하지만 run 명령은 --config로 설정 파일 경로만 직접 받는 불일치가 있었다.

이 때문에 init --base-path local-test로 초기화한 뒤 같은 기준 경로로 서버를 실행하려면 run에서는 별도의 config 파일 경로를 기억해서 넘겨야 했고, 로드된 설정의 storage 경로 재계산 규칙도 init과 달라질 수 있었다.

run --config 옵션을 제거하고 run --base-path를 추가해 <base>/rrdb.config를 읽도록 변경했다. init과 run이 같은 load_launch_config 흐름을 사용하게 하여 --base-path가 주어지면 로드된 설정의 data_directory와 wal_directory도 base path 기준으로 재설정한다.

run --base-path 파싱, 기존 run --config 거부, 기존 설정 로드 후 base path 적용 동작을 검증하는 테스트를 추가했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `run` 명령에서 `--base-path`/`-b` 옵션으로 특정 디렉터리 기준 실행을 지원합니다.
  * 실행 예시 문서에 `cargo run --bin rrdb run --base-path local-test` 사용법이 추가되었습니다.
* **Bug Fixes**
  * 설정 입력 방식이 정리되어, `--config` 대신 `--base-path` 기반으로 올바르게 동작하며 파싱 오류가 더 명확히 처리됩니다.
  * 설정 로딩 실패 시 `run`은 오류를 전파하고, `init`은 `base-path` 기준 기본 설정으로 폴백합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->