### PR TITLE
 [#205] fix: SQLx 커넥션 풀과 PostgreSQL Close 메시지 호환 외

### DIFF
--- a/src/engine/actions/ddl/drop_database.rs
+++ b/src/engine/actions/ddl/drop_database.rs
@@ -24,9 +24,11 @@ impl DBEngine {
         if let Err(error) = tokio::fs::remove_dir_all(database_path.clone()).await {
             match error.kind() {
                 IOErrorKind::NotFound => {
-                    return Err(ExecuteError::wrap(
-                        "database not found".to_string(),
-                    ));
+                    if !query.if_exists {
+                        return Err(ExecuteError::wrap(
+                            "database not found".to_string(),
+                        ));
+                    }
                 }
                 _ => {
                     return Err(ExecuteError::wrap(
@@ -48,5 +50,37 @@ impl DBEngine {
                 ))],
             }]),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::config::launch_config::LaunchConfig;
+    use crate::engine::DBEngine;
+    use crate::engine::ast::ddl::drop_database::DropDatabaseQuery;
+
+    #[tokio::test]
+    async fn drop_database_if_exists_succeeds_when_database_is_missing() {
+        let base_path = PathBuf::from("target/test_drop_database/if_exists_missing");
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        tokio::fs::create_dir_all(&config.data_directory)
+            .await
+            .unwrap();
+
+        let engine = DBEngine::new(config);
+        engine
+            .drop_database(
+                DropDatabaseQuery::builder()
+                    .set_name("missing".to_string())
+                    .set_if_exists(true),
+            )
+            .await
+            .unwrap();
     }
 }

--- a/src/engine/actions/ddl/drop_table.rs
+++ b/src/engine/actions/ddl/drop_table.rs
@@ -27,9 +27,11 @@ impl DBEngine {
         if let Err(error) = tokio::fs::remove_dir_all(table_path).await {
             match error.kind() {
                 IOErrorKind::NotFound => {
-                    return Err(ExecuteError::wrap(
-                        "table not found".to_string(),
-                    ));
+                    if !query.if_exists {
+                        return Err(ExecuteError::wrap(
+                            "table not found".to_string(),
+                        ));
+                    }
                 }
                 _ => {
                     return Err(ExecuteError::wrap(
@@ -51,5 +53,42 @@ impl DBEngine {
                 ))],
             }]),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::config::launch_config::LaunchConfig;
+    use crate::engine::DBEngine;
+    use crate::engine::ast::ddl::drop_table::DropTableQuery;
+    use crate::engine::ast::types::TableName;
+
+    #[tokio::test]
+    async fn drop_table_if_exists_succeeds_when_table_is_missing() {
+        let base_path = PathBuf::from("target/test_drop_table/if_exists_missing");
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        tokio::fs::create_dir_all(
+            PathBuf::from(&config.data_directory)
+                .join("rrdb")
+                .join("tables"),
+        )
+        .await
+        .unwrap();
+
+        let engine = DBEngine::new(config);
+        engine
+            .drop_table(
+                DropTableQuery::builder()
+                    .set_table(TableName::new(Some("rrdb".to_string()), "missing".to_string()))
+                    .set_if_exists(true),
+            )
+            .await
+            .unwrap();
     }
 }

--- a/src/engine/actions/etc.rs
+++ b/src/engine/actions/etc.rs
@@ -14,8 +14,8 @@ use crate::engine::schema::table::TableSchema;
 use crate::engine::types::{
     ExecuteColumn, ExecuteColumnType, ExecuteField, ExecuteResult, ExecuteRow,
 };
-use crate::errors::execute_error::ExecuteError;
 use crate::errors;
+use crate::errors::execute_error::ExecuteError;
 
 impl DBEngine {
     pub async fn desc_table(&self, query: DescTableQuery) -> errors::Result<ExecuteResult> {
@@ -33,10 +33,9 @@ impl DBEngine {
 
         match tokio::fs::read(config_path).await {
             Ok(read_result) => {
-                let table_info: TableSchema =
-                    encoder.decode(read_result.as_slice()).ok_or_else(|| {
-                        ExecuteError::wrap("config decode error".to_string())
-                    })?;
+                let table_info: TableSchema = encoder
+                    .decode(read_result.as_slice())
+                    .ok_or_else(|| ExecuteError::wrap("config decode error".to_string()))?;
 
                 Ok(ExecuteResult {
                     columns: (vec![
@@ -81,9 +80,7 @@ impl DBEngine {
                     "table '{}' not exists",
                     table_name
                 ))),
-                _ => Err(ExecuteError::wrap(
-                    "database listup failed".to_string(),
-                )),
+                _ => Err(ExecuteError::wrap("database listup failed".to_string())),
             },
         }
     }
@@ -94,8 +91,6 @@ impl DBEngine {
         &self,
         _query: ShowDatabasesQuery,
     ) -> errors::Result<ExecuteResult> {
-
-
         let base_path = self.get_data_directory();
 
         match tokio::fs::read_dir(&base_path).await {
@@ -144,33 +139,69 @@ impl DBEngine {
                 })
             }
             Err(error) => match error.kind() {
-                IOErrorKind::NotFound => Err(ExecuteError::wrap(
-                    "base path not exists".to_string(),
-                )),
-                _ => Err(ExecuteError::wrap(
-                    "database listup failed".to_string(),
-                )),
+                IOErrorKind::NotFound => {
+                    Err(ExecuteError::wrap("base path not exists".to_string()))
+                }
+                _ => Err(ExecuteError::wrap("database listup failed".to_string())),
             },
         }
     }
 
     pub async fn find_database(&self, database_name: String) -> errors::Result<bool> {
-        let result = self.show_databases(ShowDatabasesQuery {}).await?;
+        let database_path = self.get_data_directory().join(database_name);
 
-        Ok(result.rows.iter().any(|e| {
-            if let ExecuteField::String(name) = &e.fields[0] {
-                name == &database_name
-            } else {
-                false
-            }
-        }))
+        match tokio::fs::metadata(database_path).await {
+            Ok(metadata) => Ok(metadata.is_dir()),
+            Err(error) => match error.kind() {
+                IOErrorKind::NotFound => Ok(false),
+                _ => Err(ExecuteError::wrap(error.to_string())),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::config::launch_config::LaunchConfig;
+    use crate::engine::DBEngine;
+    use crate::engine::ast::ddl::create_database::CreateDatabaseQuery;
+
+    #[tokio::test]
+    async fn find_database_checks_database_directory_directly() {
+        let base_path = PathBuf::from("target/test_find_database/direct_directory_lookup");
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        tokio::fs::create_dir_all(&config.data_directory)
+            .await
+            .unwrap();
+
+        let engine = DBEngine::new(config);
+        engine
+            .create_database(
+                CreateDatabaseQuery::builder()
+                    .set_name("lookup_db".to_string())
+                    .set_if_not_exists(false),
+            )
+            .await
+            .unwrap();
+
+        assert!(engine.find_database("lookup_db".to_string()).await.unwrap());
+        assert!(
+            !engine
+                .find_database("missing_db".to_string())
+                .await
+                .unwrap()
+        );
     }
 }
 
 impl DBEngine {
     pub async fn show_tables(&self, query: ShowTablesQuery) -> errors::Result<ExecuteResult> {
-
-
         let base_path = self.get_data_directory();
         let database_path = base_path.clone().join(query.database);
         let tables_path = database_path.join("tables");
@@ -224,12 +255,10 @@ impl DBEngine {
                 })
             }
             Err(error) => match error.kind() {
-                IOErrorKind::NotFound => Err(ExecuteError::wrap(
-                    "base path not exists".to_string(),
-                )),
-                _ => Err(ExecuteError::wrap(
-                    "table listup failed".to_string(),
-                )),
+                IOErrorKind::NotFound => {
+                    Err(ExecuteError::wrap("base path not exists".to_string()))
+                }
+                _ => Err(ExecuteError::wrap("table listup failed".to_string())),
             },
         }
     }

--- a/src/engine/lexer/tokenizer.rs
+++ b/src/engine/lexer/tokenizer.rs
@@ -11,7 +11,7 @@ pub struct Tokenizer {
 
 impl Tokenizer {
     pub fn new(text: String) -> Self {
-        log::info!("SQL echo: {:?}", text);
+        log::debug!("SQL echo: {:?}", text);
         Self {
             last_char: ' ',
             buffer: text.chars().collect(),

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -51,7 +51,7 @@ impl DBEngine {
         _wal_manager: Arc<WALManager<BitcodeEncoder>>,
         _connection_id: String,
     ) -> errors::Result<ExecuteResult> {
-        log::info!("AST echo: {:?}", statement);
+        log::debug!("AST echo: {:?}", statement);
 
         // 쿼리 실행
         let result = match statement {

--- a/src/engine/parser/implements/common.rs
+++ b/src/engine/parser/implements/common.rs
@@ -17,13 +17,19 @@ impl Parser {
 
         let current_token = self.get_next_token();
 
-        if let Token::Identifier(name) = current_token {
-            builder = builder.set_name(name);
-        } else {
-            return Err(ParsingError::wrap(format!(
-                "expected identifier. but your input word is '{:?}'",
-                current_token
-            )));
+        match current_token {
+            Token::Identifier(name) => {
+                builder = builder.set_name(name);
+            }
+            Token::Key => {
+                builder = builder.set_name("key".to_string());
+            }
+            _ => {
+                return Err(ParsingError::wrap(format!(
+                    "expected identifier. but your input word is '{:?}'",
+                    current_token
+                )));
+            }
         }
 
         let data_type = self.parse_data_type()?;

--- a/src/engine/parser/test/common.rs
+++ b/src/engine/parser/test/common.rs
@@ -37,6 +37,25 @@ fn test_parse_table_column() {
             want_error: false,
         },
         TestCase {
+            name: "key VARCHAR(255)".into(),
+            input: vec![
+                Token::Key,
+                Token::Identifier("VARCHAR".into()),
+                Token::LeftParentheses,
+                Token::Integer(255),
+                Token::RightParentheses,
+            ],
+            expected: Column {
+                name: "key".into(),
+                data_type: DataType::Varchar(255),
+                primary_key: false,
+                comment: "".into(),
+                not_null: false,
+                default: None,
+            },
+            want_error: false,
+        },
+        TestCase {
             name: "오류: id INT PRIMARY".into(),
             input: vec![
                 Token::Identifier("id".into()),

--- a/src/engine/server/mod.rs
+++ b/src/engine/server/mod.rs
@@ -13,6 +13,7 @@ use crate::engine::wal::endec::implements::bitcode::{BitcodeDecoder, BitcodeEnco
 use crate::engine::wal::manager::builder::WALBuilder;
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
+use crate::pgwire::connection::ConnectionError;
 use crate::pgwire::predule::Connection;
 
 use futures::future::join_all;
@@ -21,6 +22,10 @@ use tokio::sync::mpsc;
 
 pub struct Server {
     pub config: Arc<LaunchConfig>,
+}
+
+fn is_expected_disconnect(error: &ConnectionError) -> bool {
+    matches!(error, ConnectionError::ConnectionClosed)
 }
 
 impl Server {
@@ -123,7 +128,11 @@ impl Server {
                 tokio::spawn(async move {
                     let mut conn = Connection::new(shared_state, config);
                     if let Err(error) = conn.run(stream).await {
-                        log::error!("connection error {:?}", error);
+                        if is_expected_disconnect(&error) {
+                            log::debug!("connection closed");
+                        } else {
+                            log::error!("connection error {:?}", error);
+                        }
                     }
                 });
             }
@@ -138,5 +147,17 @@ impl Server {
         join_all(vec![connection_task, background_task]).await;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::pgwire::connection::ConnectionError;
+
+    use super::is_expected_disconnect;
+
+    #[test]
+    fn connection_closed_is_expected_disconnect() {
+        assert!(is_expected_disconnect(&ConnectionError::ConnectionClosed));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,12 +57,6 @@ fn print_banner() {
     println!("{}", banner());
 }
 
-fn display_base_path(base_path: Option<&PathBuf>) -> String {
-    base_path
-        .map(|base_path| absolute_path(base_path.clone()).to_string_lossy().to_string())
-        .unwrap_or_else(|| DEFAULT_CONFIG_BASEPATH.to_string())
-}
-
 fn display_config_path(base_path: Option<&PathBuf>) -> String {
     base_path
         .map(|base_path| absolute_path(base_path.clone()).join(DEFAULT_CONFIG_FILENAME))
@@ -139,18 +133,6 @@ mod tests {
 
         assert!(banner.contains("RRDB"));
         assert!(banner.contains(env!("CARGO_PKG_VERSION")));
-    }
-
-    #[test]
-    fn display_base_path_uses_absolute_custom_or_default_path() {
-        let base_path = PathBuf::from("local-test");
-        let current_dir = std::env::current_dir().unwrap();
-
-        assert_eq!(
-            display_base_path(Some(&base_path)),
-            current_dir.join("local-test").to_string_lossy().to_string()
-        );
-        assert_eq!(display_base_path(None), DEFAULT_CONFIG_BASEPATH);
     }
 
     #[test]

--- a/src/pgwire/connection/connection.rs
+++ b/src/pgwire/connection/connection.rs
@@ -15,10 +15,11 @@ use crate::engine::server::shared_state::SharedState;
 use crate::pgwire::connection::{BoundPortal, ConnectionError, ConnectionState, PreparedStatement};
 use crate::pgwire::engine::{Engine, Portal, RRDBEngine};
 use crate::pgwire::protocol::backend::{
-    AuthenticationOk, BindComplete, CommandComplete, EmptyQueryResponse, ErrorResponse, NoData,
-    ParameterDescription, ParameterStatus, ParseComplete, ReadyForQuery, RowDescription,
+    AuthenticationOk, BindComplete, CloseComplete, CommandComplete, EmptyQueryResponse,
+    ErrorResponse, NoData, ParameterDescription, ParameterStatus, ParseComplete, ReadyForQuery,
+    RowDescription,
 };
-use crate::pgwire::protocol::client::{BindFormat, ClientMessage, Describe};
+use crate::pgwire::protocol::client::{BindFormat, ClientMessage, Close, Describe};
 use crate::pgwire::protocol::{ConnectionCodec, DataRowBatch, FormatCode, Severity, SqlState};
 
 /// Describes a connection using a specific engine.
@@ -158,7 +159,7 @@ impl Connection {
                     }
                 }
 
-                framed.send(AuthenticationOk).await?;
+                framed.feed(AuthenticationOk).await?;
 
                 let param_statuses = &[
                     ("server_version", "13"),
@@ -170,7 +171,7 @@ impl Connection {
                 ];
 
                 for &(param, status) in param_statuses {
-                    framed.send(ParameterStatus::new(param, status)).await?;
+                    framed.feed(ParameterStatus::new(param, status)).await?;
                 }
 
                 framed.send(ReadyForQuery).await?;
@@ -245,6 +246,14 @@ impl Connection {
                             Some(portal) => framed.send(portal.row_desc.clone()).await?,
                             None => framed.send(NoData).await?,
                         }
+                    }
+                    ClientMessage::Close(Close::PreparedStatement(statement_name)) => {
+                        self.statements.remove(&statement_name);
+                        framed.send(CloseComplete).await?;
+                    }
+                    ClientMessage::Close(Close::Portal(portal_name)) => {
+                        self.portals.remove(&portal_name);
+                        framed.send(CloseComplete).await?;
                     }
                     ClientMessage::Sync => {
                         framed.send(ReadyForQuery).await?;

--- a/src/pgwire/connection/connection.rs
+++ b/src/pgwire/connection/connection.rs
@@ -120,7 +120,7 @@ impl Connection {
                                         self.engine.shared_state.client_info.database =
                                             database_name.to_owned();
 
-                                        log::info!(
+                                        log::debug!(
                                             "New Connection=> UUID:{} IP:{} DATABASE:{}",
                                             self.engine.shared_state.client_info.connection_id,
                                             self.engine.shared_state.client_info.ip,

--- a/src/pgwire/protocol/connection_codec.rs
+++ b/src/pgwire/protocol/connection_codec.rs
@@ -5,9 +5,9 @@ use tokio_util::codec::{Decoder, Encoder};
 use crate::pgwire::protocol::ProtocolError;
 
 use super::{
-    backend::BackendMessage,
-    client::{Bind, BindFormat, ClientMessage, Describe, Execute, Parse, Startup},
     FormatCode, MESSAGE_HEADER_SIZE, STARTUP_HEADER_SIZE,
+    backend::BackendMessage,
+    client::{Bind, BindFormat, ClientMessage, Close, Describe, Execute, Parse, Startup},
 };
 
 #[derive(Default, Debug)]
@@ -132,6 +132,16 @@ impl Decoder for ConnectionCodec {
                     _ => return Err(ProtocolError::ParserError),
                 })
             }
+            b'C' => {
+                let target_type = src.get_u8();
+                let name = read_cstr(src)?;
+
+                ClientMessage::Close(match target_type {
+                    b'P' => Close::Portal(name),
+                    b'S' => Close::PreparedStatement(name),
+                    _ => return Err(ProtocolError::ParserError),
+                })
+            }
             b'S' => ClientMessage::Sync,
             b'B' => {
                 let portal = read_cstr(src)?;
@@ -210,5 +220,59 @@ impl Encoder<char> for ConnectionCodec {
     fn encode(&mut self, item: char, dst: &mut BytesMut) -> Result<(), Self::Error> {
         dst.put_u8(item as u8);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::{BufMut, BytesMut};
+    use tokio_util::codec::Decoder;
+
+    use crate::pgwire::protocol::client::{ClientMessage, Close};
+
+    use super::ConnectionCodec;
+
+    fn close_message(target_type: u8, name: &str) -> BytesMut {
+        let mut message = BytesMut::new();
+        message.put_u8(b'C');
+        message.put_i32((4 + 1 + name.len() + 1) as i32);
+        message.put_u8(target_type);
+        message.put_slice(name.as_bytes());
+        message.put_u8(0);
+        message
+    }
+
+    #[test]
+    fn decodes_close_prepared_statement_message() {
+        let mut codec = ConnectionCodec {
+            startup_received: true,
+        };
+        let mut message = close_message(b'S', "sqlx_s_1");
+
+        let decoded = codec.decode(&mut message).unwrap().unwrap();
+
+        match decoded {
+            ClientMessage::Close(Close::PreparedStatement(name)) => {
+                assert_eq!(name, "sqlx_s_1");
+            }
+            other => panic!("expected prepared statement close, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decodes_close_portal_message() {
+        let mut codec = ConnectionCodec {
+            startup_received: true,
+        };
+        let mut message = close_message(b'P', "sqlx_p_1");
+
+        let decoded = codec.decode(&mut message).unwrap().unwrap();
+
+        match decoded {
+            ClientMessage::Close(Close::Portal(name)) => {
+                assert_eq!(name, "sqlx_p_1");
+            }
+            other => panic!("expected portal close, got {other:?}"),
+        }
     }
 }

--- a/src/pgwire/protocol/message/backend/types/close_complete.rs
+++ b/src/pgwire/protocol/message/backend/types/close_complete.rs
@@ -1,0 +1,12 @@
+use bytes::BytesMut;
+
+use crate::pgwire::protocol::backend::BackendMessage;
+
+#[derive(Debug)]
+pub struct CloseComplete;
+
+impl BackendMessage for CloseComplete {
+    const TAG: u8 = b'3';
+
+    fn encode(&self, _dst: &mut BytesMut) {}
+}

--- a/src/pgwire/protocol/message/backend/types/mod.rs
+++ b/src/pgwire/protocol/message/backend/types/mod.rs
@@ -19,6 +19,9 @@ pub use parse_complete::*;
 pub mod bind_complete;
 pub use bind_complete::*;
 
+pub mod close_complete;
+pub use close_complete::*;
+
 pub mod no_data;
 pub use no_data::*;
 

--- a/src/pgwire/protocol/message/client/client_message.rs
+++ b/src/pgwire/protocol/message/client/client_message.rs
@@ -1,4 +1,4 @@
-use super::{Bind, Describe, Execute, Parse, Startup};
+use super::{Bind, Close, Describe, Execute, Parse, Startup};
 
 #[derive(Debug)]
 pub enum ClientMessage {
@@ -6,6 +6,7 @@ pub enum ClientMessage {
     Startup(Startup),
     Parse(Parse),
     Describe(Describe),
+    Close(Close),
     Bind(Bind),
     Sync,
     Execute(Execute),

--- a/src/pgwire/protocol/message/client/types/close.rs
+++ b/src/pgwire/protocol/message/client/types/close.rs
@@ -1,0 +1,5 @@
+#[derive(Debug)]
+pub enum Close {
+    Portal(String),
+    PreparedStatement(String),
+}

--- a/src/pgwire/protocol/message/client/types/mod.rs
+++ b/src/pgwire/protocol/message/client/types/mod.rs
@@ -4,6 +4,9 @@ pub use startup::*;
 pub mod describe;
 pub use describe::*;
 
+pub mod close;
+pub use close::*;
+
 pub mod parse;
 pub use parse::*;
 


### PR DESCRIPTION
resolves: #205

## 설명
- 커넥션 대량 생성시 타임아웃 등으로 실패하는 문제 수정
- 그 외 로그 레벨 정돈 등 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `DROP DATABASE`와 `DROP TABLE`이 대상이 없어도 `IF EXISTS`가 설정된 경우 성공으로 처리됩니다.
  * 준비된 문장과 포털을 닫는 요청을 처리하고, 닫기 완료 응답을 반환합니다.
  * 컬럼 이름으로 `key`를 인식할 수 있게 되어 테이블 정의 파싱이 더 유연해졌습니다.

* **Bug Fixes**
  * 데이터베이스 존재 여부 확인과 연결 종료 처리가 더 안정적으로 개선되었습니다.
  * 일부 로그가 더 낮은 수준으로 조정되어 불필요한 출력이 줄었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->