### PR TITLE
feat: add GROUP BY ALL support (PG19 feature)

### DIFF
--- a/src/engine/ast/dml/parts/group_by.rs
+++ b/src/engine/ast/dml/parts/group_by.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct GroupByClause {
     pub group_by_items: Vec<GroupByItem>,
+    pub group_by_all: bool,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash, Default)]

--- a/src/engine/ast/dml/plan/select/select_plan.rs
+++ b/src/engine/ast/dml/plan/select/select_plan.rs
@@ -128,6 +128,7 @@ mod tests {
     fn From_GroupByClause_for_SelectPlanItem() {
         let group_by = GroupByClause {
             group_by_items: vec![],
+            group_by_all: false,
         };
         let select_plan_item: SelectPlanItem = group_by.clone().into();
         assert_eq!(select_plan_item, SelectPlanItem::Group(group_by));

--- a/src/engine/ast/dml/select.rs
+++ b/src/engine/ast/dml/select.rs
@@ -128,10 +128,11 @@ impl SelectQuery {
     }
 
     pub fn set_group_by_all(mut self) -> Self {
-        self.group_by_clause = Some(GroupByClause {
+        let group_by_clause = self.group_by_clause.get_or_insert_with(|| GroupByClause {
             group_by_items: vec![],
-            group_by_all: true,
+            group_by_all: false,
         });
+        group_by_clause.group_by_all = true;
         self
     }
 

--- a/src/engine/ast/dml/select.rs
+++ b/src/engine/ast/dml/select.rs
@@ -119,10 +119,19 @@ impl SelectQuery {
             None => {
                 self.group_by_clause = Some(GroupByClause {
                     group_by_items: vec![item],
+                    group_by_all: false,
                 })
             }
         }
 
+        self
+    }
+
+    pub fn set_group_by_all(mut self) -> Self {
+        self.group_by_clause = Some(GroupByClause {
+            group_by_items: vec![],
+            group_by_all: true,
+        });
         self
     }
 

--- a/src/engine/lexer/tokenizer.rs
+++ b/src/engine/lexer/tokenizer.rs
@@ -171,6 +171,7 @@ impl Tokenizer {
                 "BEGIN" => Token::Begin,
                 "TRANSACTION" => Token::Transaction,
                 "COMMIT" => Token::Commit,
+                "ALL" => Token::All,
                 "ROLLBACK" => Token::Rollback,
                 _ => Token::Identifier(identifier),
             };

--- a/src/engine/lexer/tokens.rs
+++ b/src/engine/lexer/tokens.rs
@@ -15,6 +15,7 @@ pub enum Token {
     As,
     Order,
     By,
+    All,
     Asc,
     Desc,
     Group,

--- a/src/engine/parser/implements/dml/select.rs
+++ b/src/engine/parser/implements/dml/select.rs
@@ -5,7 +5,7 @@ use crate::engine::ast::dml::parts::group_by::GroupByItem;
 use crate::engine::ast::dml::parts::having::HavingClause;
 use crate::engine::ast::dml::parts::join::{JoinClause, JoinType};
 use crate::engine::ast::dml::parts::order_by::{OrderByItem, OrderByNulls, OrderByType};
-use crate::engine::ast::dml::parts::select_item::{SelectItem, SelectWildCard};
+use crate::engine::ast::dml::parts::select_item::{SelectItem, SelectKind, SelectWildCard};
 use crate::engine::ast::dml::select::SelectQuery;
 use crate::engine::lexer::predule::{OperatorToken, Token};
 use crate::engine::parser::predule::{Parser, ParserContext};
@@ -115,12 +115,15 @@ impl Parser {
             self.get_next_token();
             self.get_next_token();
 
-            // GROUP BY ALL 체크
-            let next_token = self.get_next_token();
-            if next_token == Token::All {
+            if !self.has_next_token() {
+                return Err(ParsingError::wrap("need more tokens"));
+            }
+
+            let current_token = self.get_next_token();
+            if current_token == Token::All {
                 query_builder = query_builder.set_group_by_all();
             } else {
-                self.unget_next_token(next_token);
+                self.unget_next_token(current_token);
 
                 loop {
                     if !self.has_next_token() {
@@ -159,9 +162,21 @@ impl Parser {
             }
         }
 
-        // GROUP BY ALL: expand to all non-aggregate columns
-        let needs_expand = query_builder.group_by_clause.as_ref().map_or(false, |c| c.group_by_all);
+        let needs_expand = query_builder
+            .group_by_clause
+            .as_ref()
+            .is_some_and(|clause| clause.group_by_all);
         if needs_expand {
+            let has_wildcard = query_builder
+                .select_items
+                .iter()
+                .any(|item| matches!(item, SelectKind::WildCard(_)));
+            if has_wildcard {
+                return Err(ParsingError::wrap(
+                    "GROUP BY ALL cannot be used with a wildcard select list",
+                ));
+            }
+
             let non_aggregate = query_builder.get_non_aggregate_column();
             if let Some(ref mut clause) = query_builder.group_by_clause {
                 clause.group_by_items = non_aggregate

--- a/src/engine/parser/implements/dml/select.rs
+++ b/src/engine/parser/implements/dml/select.rs
@@ -115,39 +115,60 @@ impl Parser {
             self.get_next_token();
             self.get_next_token();
 
-            loop {
-                if !self.has_next_token() {
-                    break;
-                }
+            // GROUP BY ALL 체크
+            let next_token = self.get_next_token();
+            if next_token == Token::All {
+                query_builder = query_builder.set_group_by_all();
+            } else {
+                self.unget_next_token(next_token);
 
-                let current_token = self.get_next_token();
-
-                match current_token {
-                    Token::SemiColon => {
-                        return Ok(query_builder.build());
-                    }
-                    Token::RightParentheses => {
-                        self.unget_next_token(current_token);
-                        return Ok(query_builder.build());
-                    }
-                    Token::Comma => continue,
-                    Token::Having | Token::Limit | Token::Offset | Token::Order => {
-                        self.unget_next_token(current_token);
+                loop {
+                    if !self.has_next_token() {
                         break;
                     }
-                    _ => {
-                        if current_token.is_expression() {
+
+                    let current_token = self.get_next_token();
+
+                    match current_token {
+                        Token::SemiColon => {
+                            return Ok(query_builder.build());
+                        }
+                        Token::RightParentheses => {
                             self.unget_next_token(current_token);
-                            let group_by_item = self.parse_group_by_item(context.clone())?;
-                            query_builder = query_builder.add_group_by(group_by_item);
-                        } else {
-                            return Err(ParsingError::wrap(format!(
-                                "unexpected token '{:?}'",
-                                current_token
-                            )));
+                            return Ok(query_builder.build());
+                        }
+                        Token::Comma => continue,
+                        Token::Having | Token::Limit | Token::Offset | Token::Order => {
+                            self.unget_next_token(current_token);
+                            break;
+                        }
+                        _ => {
+                            if current_token.is_expression() {
+                                self.unget_next_token(current_token);
+                                let group_by_item = self.parse_group_by_item(context.clone())?;
+                                query_builder = query_builder.add_group_by(group_by_item);
+                            } else {
+                                return Err(ParsingError::wrap(format!(
+                                    "unexpected token '{:?}'",
+                                    current_token
+                                )));
+                            }
                         }
                     }
                 }
+            }
+        }
+
+        // GROUP BY ALL: expand to all non-aggregate columns
+        let needs_expand = query_builder.group_by_clause.as_ref().map_or(false, |c| c.group_by_all);
+        if needs_expand {
+            let non_aggregate = query_builder.get_non_aggregate_column();
+            if let Some(ref mut clause) = query_builder.group_by_clause {
+                clause.group_by_items = non_aggregate
+                    .into_iter()
+                    .map(|item| GroupByItem { item })
+                    .collect();
+                clause.group_by_all = false;
             }
         }
 

--- a/src/engine/parser/test/select.rs
+++ b/src/engine/parser/test/select.rs
@@ -2473,3 +2473,38 @@ fn test_parse_limit() {
         }
     }
 }
+
+#[test]
+fn test_parse_group_by_all() {
+    // SELECT a, b, SUM(c) FROM t GROUP BY ALL
+    // Should auto-expand GROUP BY to a, b (all non-aggregate columns)
+    let tokens = vec![
+        Token::Select,
+        Token::Identifier("a".into()),
+        Token::Comma,
+        Token::Identifier("b".into()),
+        Token::Comma,
+        Token::Identifier("sum".into()),
+        Token::LeftParentheses,
+        Token::Identifier("c".into()),
+        Token::RightParentheses,
+        Token::From,
+        Token::Identifier("t".into()),
+        Token::Group,
+        Token::By,
+        Token::All,
+    ];
+
+    let mut parser = Parser::new(tokens);
+    let select: SelectQuery = parser.handle_select_query(Default::default()).unwrap();
+
+    assert!(select.has_group_by());
+
+    let group_by = select.group_by_clause.unwrap();
+    assert_eq!(group_by.group_by_items.len(), 2, "GROUP BY ALL should expand to 2 non-aggregate columns");
+
+    let columns: Vec<&str> = group_by.group_by_items.iter().map(|item| item.item.column_name.as_str()).collect();
+    assert!(columns.contains(&"a"), "GROUP BY ALL should include column 'a'");
+    assert!(columns.contains(&"b"), "GROUP BY ALL should include column 'b'");
+    assert!(!columns.contains(&"c"), "GROUP BY ALL should NOT include aggregate column 'c'");
+}

--- a/src/engine/parser/test/select.rs
+++ b/src/engine/parser/test/select.rs
@@ -2476,8 +2476,6 @@ fn test_parse_limit() {
 
 #[test]
 fn test_parse_group_by_all() {
-    // SELECT a, b, SUM(c) FROM t GROUP BY ALL
-    // Should auto-expand GROUP BY to a, b (all non-aggregate columns)
     let tokens = vec![
         Token::Select,
         Token::Identifier("a".into()),
@@ -2496,15 +2494,67 @@ fn test_parse_group_by_all() {
     ];
 
     let mut parser = Parser::new(tokens);
-    let select: SelectQuery = parser.handle_select_query(Default::default()).unwrap();
+    let select = parser.handle_select_query(Default::default()).unwrap();
 
     assert!(select.has_group_by());
 
     let group_by = select.group_by_clause.unwrap();
-    assert_eq!(group_by.group_by_items.len(), 2, "GROUP BY ALL should expand to 2 non-aggregate columns");
+    assert_eq!(group_by.group_by_items.len(), 2);
+    assert!(!group_by.group_by_all);
 
-    let columns: Vec<&str> = group_by.group_by_items.iter().map(|item| item.item.column_name.as_str()).collect();
-    assert!(columns.contains(&"a"), "GROUP BY ALL should include column 'a'");
-    assert!(columns.contains(&"b"), "GROUP BY ALL should include column 'b'");
-    assert!(!columns.contains(&"c"), "GROUP BY ALL should NOT include aggregate column 'c'");
+    let columns: Vec<&str> = group_by
+        .group_by_items
+        .iter()
+        .map(|item| item.item.column_name.as_str())
+        .collect();
+    assert!(columns.contains(&"a"));
+    assert!(columns.contains(&"b"));
+    assert!(!columns.contains(&"c"));
+}
+
+#[test]
+fn test_parse_group_by_all_with_wildcard_fails() {
+    let tokens = vec![
+        Token::Select,
+        Token::Operator(OperatorToken::Asterisk),
+        Token::From,
+        Token::Identifier("t".into()),
+        Token::Group,
+        Token::By,
+        Token::All,
+    ];
+
+    let mut parser = Parser::new(tokens);
+    let got = parser.handle_select_query(Default::default());
+
+    assert!(got.is_err());
+    assert_eq!(
+        got.err().unwrap().to_string(),
+        "parsing error: GROUP BY ALL cannot be used with a wildcard select list"
+    );
+}
+
+#[test]
+fn test_parse_group_by_all_with_only_aggregates() {
+    let tokens = vec![
+        Token::Select,
+        Token::Identifier("sum".into()),
+        Token::LeftParentheses,
+        Token::Identifier("c".into()),
+        Token::RightParentheses,
+        Token::From,
+        Token::Identifier("t".into()),
+        Token::Group,
+        Token::By,
+        Token::All,
+    ];
+
+    let mut parser = Parser::new(tokens);
+    let select = parser.handle_select_query(Default::default()).unwrap();
+
+    assert!(!select.has_group_by());
+
+    let group_by = select.group_by_clause.unwrap();
+    assert!(group_by.group_by_items.is_empty());
+    assert!(!group_by.group_by_all);
 }


### PR DESCRIPTION
## Summary

Implement `GROUP BY ALL` support — a PostgreSQL 19 feature that automatically groups by all non-aggregate columns in the SELECT list.

```sql
-- Before (explicit):
SELECT a, b, SUM(c) FROM t GROUP BY a, b

-- After (shorthand):
SELECT a, b, SUM(c) FROM t GROUP BY ALL
```

## Changes

- **`tokens.rs`** — Added `All` variant to `Token` enum
- **`tokenizer.rs`** — Added `"ALL" => Token::All` keyword mapping
- **`group_by.rs`** — Added `group_by_all: bool` field to `GroupByClause`
- **`select.rs` (AST)** — Added `set_group_by_all()` builder method; fixed `add_group_by()` to initialize `group_by_all: false`
- **`select_plan.rs`** — Fixed test constructor to include `group_by_all: false`
- **`select.rs` (parser)** — Parse `GROUP BY ALL` → set flag → after GROUP BY parsing, auto-expand to all non-aggregate SELECT columns

## How it works

When the parser encounters `GROUP BY ALL`:
1. Sets `group_by_all: true` on the `GroupByClause`
2. After the GROUP BY parsing block, calls `get_non_aggregate_column()` to find all non-aggregate columns in SELECT
3. Expands those columns as explicit `GroupByItem`s
4. Clears the `group_by_all` flag

The existing validation logic (non-aggregate columns must be in GROUP BY, aggregate columns must not be) then works naturally with the expanded items.

## Test Plan

- Added `test_parse_group_by_all` — verifies that `GROUP BY ALL` correctly expands to non-aggregate columns `a` and `b` while excluding aggregate column `c`
- All 196 existing tests pass

Closes #211


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `GROUP BY ALL`을 지원하여 집계되지 않은 컬럼을 자동으로 그룹 기준에 포함할 수 있게 되었습니다.
  * `GROUP BY` 설정을 제어하는 API가 확장되었습니다.
* **Bug Fixes**
  * `GROUP BY ALL` 처리 시 그룹 기준 산정과 상태 전파가 일관되도록 개선되었습니다.
* **Tests**
  * `GROUP BY ALL` 파싱 및 `SELECT *` 조합 시 오류를 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->