### PR TITLE
perf: replace bson with bincode for data storage encoding (#216)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,9 @@ bytes = "1.2.1"
 tokio-util = { version = "0.7.4", features = [ "codec" ] }
 futures = "0.3.23"
 chrono = "0.4.22"
-bson = "2.11.0"
 time = "0.3.36"
 colored = "2.0.0"
-uuid = "1.1.2"
+uuid = { version = "1.1.2", features = ["v4"] }
 itertools = "0.10.5"
 anyhow = "1.0.86"
 mockall = "0.12.1"

--- a/src/engine/actions/ddl/alter_database.rs
+++ b/src/engine/actions/ddl/alter_database.rs
@@ -60,7 +60,7 @@ impl DBEngine {
                     match tokio::fs::read(&config_path).await {
                         Ok(data) => {
                             let database_config: Option<DatabaseSchema> =
-                                encoder.decode(data.as_slice());
+                                encoder.decode(data.as_slice()).ok();
 
                             match database_config {
                                 Some(mut database_config) => {

--- a/src/engine/actions/ddl/alter_database.rs
+++ b/src/engine/actions/ddl/alter_database.rs
@@ -59,11 +59,8 @@ impl DBEngine {
 
                     match tokio::fs::read(&config_path).await {
                         Ok(data) => {
-                            let database_config: Option<DatabaseSchema> =
-                                encoder.decode(data.as_slice()).ok();
-
-                            match database_config {
-                                Some(mut database_config) => {
+                            match encoder.decode::<DatabaseSchema>(data.as_slice()) {
+                                Ok(mut database_config) => {
                                     database_config.database_name = to_database_name;
                                     if let Err(_error) = tokio::fs::write(
                                         config_path,
@@ -76,8 +73,11 @@ impl DBEngine {
                                         ));
                                     }
                                 }
-                                None => {
-                                    return Err(ExecuteError::wrap("invalid config data"));
+                                Err(error) => {
+                                    return Err(ExecuteError::wrap(format!(
+                                        "invalid config data: {}",
+                                        error
+                                    )));
                                 }
                             }
                         }

--- a/src/engine/actions/ddl/alter_table.rs
+++ b/src/engine/actions/ddl/alter_table.rs
@@ -121,11 +121,8 @@ impl DBEngine {
 
                         match tokio::fs::read(&config_path).await {
                             Ok(data) => {
-                                let table_config: Option<TableSchema> =
-                                    encoder.decode(data.as_slice()).ok();
-
-                                match table_config {
-                                    Some(mut table_config) => {
+                                match encoder.decode::<TableSchema>(data.as_slice()) {
+                                    Ok(mut table_config) => {
                                         let target = table_config
                                             .columns
                                             .iter_mut()
@@ -152,10 +149,11 @@ impl DBEngine {
                                             return Err(ExecuteError::wrap(error.to_string()));
                                         }
                                     }
-                                    None => {
-                                        return Err(ExecuteError::wrap(
-                                            "invalid config data".to_string(),
-                                        ));
+                                    Err(error) => {
+                                        return Err(ExecuteError::wrap(format!(
+                                            "invalid config data: {}",
+                                            error
+                                        )));
                                     }
                                 }
                             }
@@ -175,11 +173,8 @@ impl DBEngine {
 
                         match tokio::fs::read(&config_path).await {
                             Ok(data) => {
-                                let table_config: Option<TableSchema> =
-                                    encoder.decode(data.as_slice()).ok();
-
-                                match table_config {
-                                    Some(mut table_config) => {
+                                match encoder.decode::<TableSchema>(data.as_slice()) {
+                                    Ok(mut table_config) => {
                                         let target = table_config
                                             .columns
                                             .iter_mut()
@@ -206,10 +201,11 @@ impl DBEngine {
                                             return Err(ExecuteError::wrap(error.to_string()));
                                         }
                                     }
-                                    None => {
-                                        return Err(ExecuteError::wrap(
-                                            "invalid config data".to_string(),
-                                        ));
+                                    Err(error) => {
+                                        return Err(ExecuteError::wrap(format!(
+                                            "invalid config data: {}",
+                                            error
+                                        )));
                                     }
                                 }
                             }
@@ -229,11 +225,8 @@ impl DBEngine {
 
                         match tokio::fs::read(&config_path).await {
                             Ok(data) => {
-                                let table_config: Option<TableSchema> =
-                                    encoder.decode(data.as_slice()).ok();
-
-                                match table_config {
-                                    Some(mut table_config) => {
+                                match encoder.decode::<TableSchema>(data.as_slice()) {
+                                    Ok(mut table_config) => {
                                         let target = table_config
                                             .columns
                                             .iter_mut()
@@ -260,10 +253,11 @@ impl DBEngine {
                                             return Err(ExecuteError::wrap(error.to_string()));
                                         }
                                     }
-                                    None => {
-                                        return Err(ExecuteError::wrap(
-                                            "invalid config data".to_string(),
-                                        ));
+                                    Err(error) => {
+                                        return Err(ExecuteError::wrap(format!(
+                                            "invalid config data: {}",
+                                            error
+                                        )));
                                     }
                                 }
                             }
@@ -282,11 +276,8 @@ impl DBEngine {
 
                         match tokio::fs::read(&config_path).await {
                             Ok(data) => {
-                                let table_config: Option<TableSchema> =
-                                    encoder.decode(data.as_slice()).ok();
-
-                                match table_config {
-                                    Some(mut table_config) => {
+                                match encoder.decode::<TableSchema>(data.as_slice()) {
+                                    Ok(mut table_config) => {
                                         let target = table_config
                                             .columns
                                             .iter_mut()
@@ -313,10 +304,11 @@ impl DBEngine {
                                             return Err(ExecuteError::wrap(error.to_string()));
                                         }
                                     }
-                                    None => {
-                                        return Err(ExecuteError::wrap(
-                                            "invalid config data".to_string(),
-                                        ));
+                                    Err(error) => {
+                                        return Err(ExecuteError::wrap(format!(
+                                            "invalid config data: {}",
+                                            error
+                                        )));
                                     }
                                 }
                             }

--- a/src/engine/actions/ddl/alter_table.rs
+++ b/src/engine/actions/ddl/alter_table.rs
@@ -122,7 +122,7 @@ impl DBEngine {
                         match tokio::fs::read(&config_path).await {
                             Ok(data) => {
                                 let table_config: Option<TableSchema> =
-                                    encoder.decode(data.as_slice());
+                                    encoder.decode(data.as_slice()).ok();
 
                                 match table_config {
                                     Some(mut table_config) => {
@@ -176,7 +176,7 @@ impl DBEngine {
                         match tokio::fs::read(&config_path).await {
                             Ok(data) => {
                                 let table_config: Option<TableSchema> =
-                                    encoder.decode(data.as_slice());
+                                    encoder.decode(data.as_slice()).ok();
 
                                 match table_config {
                                     Some(mut table_config) => {
@@ -230,7 +230,7 @@ impl DBEngine {
                         match tokio::fs::read(&config_path).await {
                             Ok(data) => {
                                 let table_config: Option<TableSchema> =
-                                    encoder.decode(data.as_slice());
+                                    encoder.decode(data.as_slice()).ok();
 
                                 match table_config {
                                     Some(mut table_config) => {
@@ -283,7 +283,7 @@ impl DBEngine {
                         match tokio::fs::read(&config_path).await {
                             Ok(data) => {
                                 let table_config: Option<TableSchema> =
-                                    encoder.decode(data.as_slice());
+                                    encoder.decode(data.as_slice()).ok();
 
                                 match table_config {
                                     Some(mut table_config) => {

--- a/src/engine/actions/dml/delete.rs
+++ b/src/engine/actions/dml/delete.rs
@@ -24,7 +24,7 @@ impl DBEngine {
         wal_manager: SharedWALManager,
     ) -> errors::Result<ExecuteResult> {
         let wal_payload =
-            bson::to_vec(&query).map_err(|error| ExecuteError::wrap(error.to_string()))?;
+            bincode::serialize(&query).map_err(|error| ExecuteError::wrap(error.to_string()))?;
 
         let table = query.from_table.as_ref().unwrap().table.clone();
 

--- a/src/engine/actions/dml/insert.rs
+++ b/src/engine/actions/dml/insert.rs
@@ -162,7 +162,8 @@ impl DBEngine {
                 }
 
                 let wal_payload =
-                    bson::to_vec(&query).map_err(|error| ExecuteError::wrap(error.to_string()))?;
+                    bincode::serialize(&query)
+                        .map_err(|error| ExecuteError::wrap(error.to_string()))?;
                 wal_manager
                     .lock()
                     .await

--- a/src/engine/actions/dml/scan.rs
+++ b/src/engine/actions/dml/scan.rs
@@ -145,7 +145,9 @@ impl DBEngine {
 
             let row = encoder
                 .decode::<TableDataRow>(&content[offset..offset + frame_len])
-                .ok_or_else(|| ExecuteError::wrap("invalid row segment frame".to_string()))?;
+                .map_err(|error| {
+                    ExecuteError::wrap(format!("invalid row segment frame: {}", error))
+                })?;
             rows.push(row);
             offset += frame_len;
         }
@@ -189,6 +191,8 @@ impl DBEngine {
             .join(ROW_SEGMENT_FILENAME))
     }
 
+    // TODO(#195): read only the frames covering the indexed rows instead of the
+    // whole segment file once partial reads are supported.
     pub async fn index_scan(&self, _table_name: TableName) {}
 }
 

--- a/src/engine/actions/dml/update.rs
+++ b/src/engine/actions/dml/update.rs
@@ -24,7 +24,7 @@ impl DBEngine {
         wal_manager: SharedWALManager,
     ) -> errors::Result<ExecuteResult> {
         let wal_payload =
-            bson::to_vec(&query).map_err(|error| ExecuteError::wrap(error.to_string()))?;
+            bincode::serialize(&query).map_err(|error| ExecuteError::wrap(error.to_string()))?;
 
         let table = query.target_table.clone().unwrap().table;
         let update_items = query.update_items.clone();

--- a/src/engine/actions/etc.rs
+++ b/src/engine/actions/etc.rs
@@ -35,7 +35,7 @@ impl DBEngine {
             Ok(read_result) => {
                 let table_info: TableSchema = encoder
                     .decode(read_result.as_slice())
-                    .ok_or_else(|| ExecuteError::wrap("config decode error".to_string()))?;
+                    .map_err(|e| ExecuteError::wrap(format!("config decode error: {}", e)))?;
 
                 Ok(ExecuteResult::new(
                     vec![
@@ -223,8 +223,8 @@ impl DBEngine {
                                             let encoder = StorageEncoder::new();
                                             let table_config: TableSchema =
                                                 match encoder.decode(result.as_slice()) {
-                                                    Some(decoded) => decoded,
-                                                    None => return None,
+                                                    Ok(decoded) => decoded,
+                                                    Err(_) => return None,
                                                 };
 
                                             Some(table_config.table.table_name)

--- a/src/engine/actions/etc.rs
+++ b/src/engine/actions/etc.rs
@@ -217,6 +217,7 @@ impl DBEngine {
                                 if file_type.is_dir() {
                                     let mut path = entry.path();
                                     path.push("table.config");
+                                    let path_display = path.display().to_string();
 
                                     match tokio::fs::read(path).await {
                                         Ok(result) => {
@@ -224,7 +225,10 @@ impl DBEngine {
                                             let table_config: TableSchema =
                                                 match encoder.decode(result.as_slice()) {
                                                     Ok(decoded) => decoded,
-                                                    Err(_) => return None,
+                                                    Err(e) => {
+                                                        log::warn!("failed to decode table config {}: {}", path_display, e);
+                                                        return None;
+                                                    }
                                                 };
 
                                             Some(table_config.table.table_name)

--- a/src/engine/encoder/schema_encoder.rs
+++ b/src/engine/encoder/schema_encoder.rs
@@ -9,13 +9,13 @@ impl StorageEncoder {
     }
 
     pub fn encode(&self, data: impl Serialize) -> Vec<u8> {
-        bson::to_vec(&data).unwrap()
+        bincode::serialize(&data).unwrap()
     }
 
-    pub fn decode<'a, T>(&self, data: &'a [u8]) -> Option<T>
+    pub fn decode<'a, T>(&self, data: &'a [u8]) -> bincode::Result<T>
     where
         T: Deserialize<'a>,
     {
-        bson::from_slice(data).ok()
+        bincode::deserialize(data)
     }
 }

--- a/src/engine/index/manager.rs
+++ b/src/engine/index/manager.rs
@@ -430,10 +430,10 @@ impl IndexManager {
                             })?;
 
                             let file_data: IndexFile =
-                                self.encoder.decode(data.as_slice()).ok_or_else(|| {
+                                self.encoder.decode(data.as_slice()).map_err(|e| {
                                     ExecuteError::wrap(format!(
-                                        "failed to decode index file {:?}",
-                                        path
+                                        "failed to decode index file {:?}: {}",
+                                        path, e
                                     ))
                                 })?;
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -158,11 +158,12 @@ impl DBEngine {
 
         match tokio::fs::read(&config_path).await {
             Ok(data) => {
-                let table_config: Option<TableSchema> = encoder.decode(data.as_slice()).ok();
-
-                match table_config {
-                    Some(table_config) => Ok(table_config),
-                    None => Err(ExecuteError::wrap("invalid config data".to_string())),
+                match encoder.decode::<TableSchema>(data.as_slice()) {
+                    Ok(table_config) => Ok(table_config),
+                    Err(error) => Err(ExecuteError::wrap(format!(
+                        "invalid config data: {}",
+                        error
+                    ))),
                 }
             }
             Err(error) => match error.kind() {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -158,7 +158,7 @@ impl DBEngine {
 
         match tokio::fs::read(&config_path).await {
             Ok(data) => {
-                let table_config: Option<TableSchema> = encoder.decode(data.as_slice());
+                let table_config: Option<TableSchema> = encoder.decode(data.as_slice()).ok();
 
                 match table_config {
                     Some(table_config) => Ok(table_config),


### PR DESCRIPTION
Closes #216

## Summary
Replace bson with bincode for data storage serialization to dramatically improve sequential access (scan) performance.

## Changes
- **`StorageEncoder`** (`schema_encoder.rs`): Replace `bson::to_vec`/`bson::from_slice` with `bincode::serialize`/`bincode::deserialize`
- **WAL payloads** (`delete.rs`, `insert.rs`, `update.rs`): Replace `bson::to_vec` with `bincode::serialize`
- **Call sites**: Adapt all `decode()` callers to handle `Result` return type (previously `Option`)
- **`Cargo.toml`**: Remove `bson` dependency, add `uuid` v4 feature
- **`index/manager.rs`**: Adapt encoder.decode() error handling

## Why bincode
bincode is already used in the WAL layer (`BincodeEncoder`). It's significantly faster than bson for Rust-native serialization:
- No BSON document overhead (type tags, field name strings)
- Compact binary format with minimal allocations
- Direct `Serialize`/`Deserialize` impls — no intermediate BSON document representation

## Verification
- ✅ `cargo build` — passes
- ✅ `cargo test` — 235 tests pass
- ✅ `cargo clippy -- -D warnings` — pre-existing warnings only (8, same as master)
- ✅ Zero `bson` references remaining in `src/`
- ⚠️ Segment file format changed (bson→bincode) — old data files are incompatible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 설정/스키마 읽기 실패 시 오류가 더 일관되게 처리되어, 잘못된 데이터가 있을 때 명확한 안내가 표시됩니다.
  * 삭제, 추가, 수정 작업의 기록 방식이 통일되어 동작 안정성이 향상되었습니다.
  * 인덱스 및 테이블 정보 로드 실패 시 원인 메시지가 더 자세히 표시됩니다.

* **New Features**
  * 행 스캔 오류 메시지에 세부 원인이 포함되어 문제 파악이 쉬워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->