### PR TITLE
[#226] 쓰기 처리량 정상화

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ RRDB는 **Rust**로 작성된 **PostgreSQL 호환 관계형 데이터베이스**
 | 비동기 런타임 | **Tokio** (features = `["full"]`) — async I/O, 타이머, 채널, 파일시스템 전반 |
 | CLI 프레임워크 | **clap** 3.x (derive 매크로) |
 | 설정 파일 | **serde** + **toml** — `LaunchConfig`를 TOML에서 역직렬화 |
-| WAL 인코딩 | **bitcode** 0.6 — 바이너리 직렬화로 WAL 세그먼트 저장 |
+| WAL 인코딩 | **bincode** — 바이너리 직렬화로 WAL 세그먼트 저장 |
 | Wire Protocol | **tokio-util** codec — PostgreSQL pgwire Decoder/Encoder |
 | 오류 처리 | **thiserror** (라이브러리 에러) + **anyhow** (바이너리 레벨) |
 | 로깅 | **env_logger** + **log** — `RUST_LOG` 환경변수로 레벨 제어 |
@@ -47,7 +47,7 @@ RRDB는 **Rust**로 작성된 **PostgreSQL 호환 관계형 데이터베이스**
 │         → actions (DDL/DML/Other)                  │
 │                                                   │
 │  ├─ server/  (TCP listener, channel dispatch)     │
-│  ├─ wal/     (WAL manager + bitcode encoder)      │
+│  ├─ wal/     (WAL manager + bincode encoder)      │
 │  └─ schema/  (table/config storage)               │
 └──────────────────┬──────────────────────────────┘
                    │
@@ -214,7 +214,7 @@ cargo run -- init
 ### WAL 세그먼트 관리
 - 기본 세그먼트 크기: 16MB (`1024 * 1024 * 16`)
 - WAL 확장자: `log` (기본값)
-- 인코더: `BitcodeEncoder` (`bitcode` 크레이트)
+- 인코더: `BincodeEncoder` (`bincode` 크레이트)
 - WAL 설정 필드: `wal_enabled`, `wal_directory`, `wal_segment_size`, `wal_extension`
 
 ### OS별 경로

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ mockall = "0.12.1"
 bincode = "1.3.3"
 env_logger = "0.11.8"
 log = "0.4.28"
+memmap2 = "0.9.5"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.10.1"

--- a/src/engine/AGENTS.md
+++ b/src/engine/AGENTS.md
@@ -86,12 +86,12 @@ SQL Text (String)
 - `shared_state`: `SharedState` (클라이언트 정보 + 채널 sender)
 
 ### `wal/` — Write-Ahead Logging
-- `WALManager` + `BitcodeEncoder`
+- `WALManager` + `BincodeEncoder`
 - WAL 세그먼트: 크기 제한 (`wal_segment_size`), 확장자 (`wal_extension`)
 - 복구 시 WAL replay
 
 ### `encoder/` — 인코딩 유틸리티
-- `schema_encoder`: StorageEncoder — 스키마 데이터 bitcode 직렬화
+- `schema_encoder`: StorageEncoder — 스키마 데이터 bincode 직렬화
 
 ### `initialize/` — 초기화
 - `DBEngine::initialize_with_base_path()` — 데이터 저장소 초기 설정
@@ -102,7 +102,7 @@ SQL Text (String)
 pub async fn process_query(
     &self,
     statement: SQLStatement,
-    _wal_manager: Arc<WALManager<BitcodeEncoder>>,
+    _wal_manager: Arc<WALManager<BincodeEncoder>>,
     _connection_id: String,
 ) -> errors::Result<ExecuteResult> {
     let result = match statement {
@@ -140,7 +140,7 @@ pub async fn process_query(
 
 ```rust
 // 1. WALManager는 Arc로 공유
-wal_manager: Arc<WALManager<BitcodeEncoder>>
+wal_manager: Arc<WALManager<BincodeEncoder>>
 
 // 2. mutation 작업(INSERT/UPDATE/DELETE/CREATE/DROP) 시 WAL 기록
 //    engine actions 내부에서 wal_manager.append() 호출
@@ -148,15 +148,26 @@ wal_manager: Arc<WALManager<BitcodeEncoder>>
 // 3. WAL 세그먼트 속성
 //    - segment_size: config.wal_segment_size (기본 16MB)
 //    - extension: config.wal_extension (기본 "log")
-//    - encoder: BitcodeEncoder (bitcode crate)
+//    - encoder: BincodeEncoder (bincode crate)
 
 // 4. WAL 복구는 Server startup 시 수행
 ```
+
+## WAL 내구성/복구 정책
+
+- mutation은 데이터 파일을 수정하기 전에 반드시 WAL에 먼저 기록한다.
+- 일반 write path에서는 WAL frame을 mmap segment에 append하고, 매 요청마다 `flush`/`fsync`/`sync_data`를 호출하지 않는다.
+- WAL mmap segment는 background flush loop, checkpoint, segment rotation에서만 flush + `sync_data`로 디스크 내구성 경계를 만든다.
+- table segment/data 파일은 mutation마다 fsync하지 않는다. INSERT append는 메모리 row buffer에 먼저 쌓고 background row flush loop, buffer size pressure, 또는 읽기/수정/삭제 직전 flush에서 디스크에 append한다.
+- row buffer에만 있고 아직 data segment에 내려가지 않은 내용은 중단 시 유실될 수 있다. 중단 복구 기준은 WAL이다.
+- INSERT/UPDATE/DELETE/DDL처럼 디스크 상태를 바꾸는 기능을 추가하거나 저장 형식을 변경할 때는 같은 PR에서 WAL entry와 replay 경로, 복구 테스트를 함께 추가해야 한다.
+- replay가 지원되지 않는 새 mutation은 WAL 기반 복구 계약을 깨므로 병합하지 않는다.
 
 ## 주의사항
 
 - **AST 패턴 매칭은 exhaustive**: `SQLStatement`에 새 변형 추가 시 반드시 `process_query`의 match에 추가
 - **에러 변환**: actions에서 발생한 에러는 `ExecuteError::wrap()`으로 감싸서 반환
-- **스키마 인코딩**: `StorageEncoder` (`bitcode`)로 테이블 config 저장/로드
+- **스키마 인코딩**: `StorageEncoder` (`bincode`)로 테이블 config 저장/로드
+- **WAL 우선 기록**: 데이터 파일 변경 전에 WAL을 먼저 기록하고, replay 테스트를 같이 유지
 - **파일시스템 접근**: 직접 `tokio::fs` 호출 대신 `self.file_system` 트레이트 메서드 사용하여 테스트 가능하게 유지
 - **채널 통신**: Server는 `SharedState`의 `oneshot` 채널로 per-connection 요청을 dispatch

--- a/src/engine/actions/dml/insert.rs
+++ b/src/engine/actions/dml/insert.rs
@@ -161,9 +161,8 @@ impl DBEngine {
                     rows.push(row);
                 }
 
-                let wal_payload =
-                    bincode::serialize(&query)
-                        .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+                let wal_payload = bincode::serialize(&(into_table, &rows))
+                    .map_err(|error| ExecuteError::wrap(error.to_string()))?;
                 wal_manager
                     .lock()
                     .await

--- a/src/engine/actions/dml/scan.rs
+++ b/src/engine/actions/dml/scan.rs
@@ -206,24 +206,40 @@ impl DBEngine {
 
     pub(crate) async fn flush_row_buffers(&self) -> errors::Result<()> {
         let _guard = self.row_storage_lock.lock().await;
-        self.flush_row_buffers_locked().await
+        self.flush_row_buffers_locked(false).await
     }
 
-    async fn flush_row_buffers_locked(&self) -> errors::Result<()> {
+    pub(crate) async fn flush_row_buffers_durable(&self) -> errors::Result<()> {
+        let _guard = self.row_storage_lock.lock().await;
+        self.flush_row_buffers_locked(true).await
+    }
+
+    async fn flush_row_buffers_locked(&self, durable: bool) -> errors::Result<()> {
         let pending = self.row_buffer_pool.lock().await.drain_writes()?;
 
         for write in pending {
-            if let Err(error) = self.apply_row_buffer_write(&write).await {
+            if let Err(error) = self.apply_row_buffer_write(&write, durable).await {
                 self.row_buffer_pool.lock().await.restore_write(write);
                 return Err(error);
             }
-            self.row_buffer_pool.lock().await.complete_write(write);
+            self.row_buffer_pool
+                .lock()
+                .await
+                .complete_write(write, durable);
+        }
+
+        if durable {
+            self.sync_unsynced_row_segments().await?;
         }
 
         Ok(())
     }
 
-    async fn apply_row_buffer_write(&self, write: &RowBufferWrite) -> errors::Result<()> {
+    async fn apply_row_buffer_write(
+        &self,
+        write: &RowBufferWrite,
+        durable: bool,
+    ) -> errors::Result<()> {
         let existing_len = if write.replace_existing {
             0
         } else {
@@ -237,6 +253,7 @@ impl DBEngine {
         let mut file = match tokio::fs::OpenOptions::new()
             .create(true)
             .write(true)
+            .truncate(false)
             .open(&write.segment_path)
             .await
         {
@@ -251,6 +268,44 @@ impl DBEngine {
             .await
             .map_err(|error| ExecuteError::wrap(error.to_string()))?;
         file.write_all(&write.content)
+            .await
+            .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+
+        if durable {
+            file.sync_data()
+                .await
+                .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+        }
+
+        Ok(())
+    }
+
+    async fn sync_unsynced_row_segments(&self) -> errors::Result<()> {
+        let mut unsynced_segments = self.row_buffer_pool.lock().await.drain_unsynced_segments();
+
+        while let Some(segment_path) = unsynced_segments.pop() {
+            if let Err(error) = self.sync_row_segment(&segment_path).await {
+                let mut row_buffer_pool = self.row_buffer_pool.lock().await;
+                row_buffer_pool.mark_unsynced_segment(segment_path);
+                for remaining_segment_path in unsynced_segments {
+                    row_buffer_pool.mark_unsynced_segment(remaining_segment_path);
+                }
+                return Err(error);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn sync_row_segment(&self, segment_path: &Path) -> errors::Result<()> {
+        let file = tokio::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(segment_path)
+            .await
+            .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+
+        file.sync_data()
             .await
             .map_err(|error| ExecuteError::wrap(error.to_string()))
     }
@@ -549,5 +604,10 @@ mod tests {
         let segment_path = rows_path.join("00000001.rows");
         assert!(segment_path.exists());
         assert!(engine.row_buffer_pool.lock().await.is_dirty_empty());
+        assert!(!engine.row_buffer_pool.lock().await.is_unsynced_empty());
+
+        engine.flush_row_buffers_durable().await.unwrap();
+
+        assert!(engine.row_buffer_pool.lock().await.is_unsynced_empty());
     }
 }

--- a/src/engine/actions/dml/scan.rs
+++ b/src/engine/actions/dml/scan.rs
@@ -69,6 +69,7 @@ impl DBEngine {
             return Ok(());
         }
 
+        let _guard = self.row_storage_lock.lock().await;
         let segment_path = self.row_segment_path(table_name)?;
         let frame = encode_row_frames(rows)?;
 
@@ -80,7 +81,7 @@ impl DBEngine {
         };
 
         if buffered_bytes >= buffer_limit_bytes {
-            self.flush_row_buffers().await?;
+            self.flush_row_buffers_locked(false).await?;
         }
 
         Ok(())
@@ -204,6 +205,7 @@ impl DBEngine {
         Ok(rows)
     }
 
+    #[cfg(test)]
     pub(crate) async fn flush_row_buffers(&self) -> errors::Result<()> {
         let _guard = self.row_storage_lock.lock().await;
         self.flush_row_buffers_locked(false).await
@@ -333,6 +335,7 @@ impl DBEngine {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     use crate::config::launch_config::LaunchConfig;
     use crate::engine::DBEngine;
@@ -609,5 +612,43 @@ mod tests {
         engine.flush_row_buffers_durable().await.unwrap();
 
         assert!(engine.row_buffer_pool.lock().await.is_unsynced_empty());
+    }
+
+    #[tokio::test]
+    async fn append_table_rows_waits_for_row_storage_lock() {
+        let base_path = PathBuf::from(format!(
+            "target/test_row_segments/append_waits_for_storage_lock_{}",
+            std::process::id()
+        ));
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        let table_name = TableName::new(Some("rrdb".to_string()), "users".to_string());
+        let rows_path = PathBuf::from(&config.data_directory)
+            .join("rrdb")
+            .join("tables")
+            .join("users")
+            .join("rows");
+        tokio::fs::create_dir_all(&rows_path).await.unwrap();
+
+        let engine = Arc::new(DBEngine::new(config));
+        let row = TableDataRow {
+            fields: vec![TableDataField {
+                table_name: table_name.clone(),
+                column_name: "id".to_string(),
+                data: TableDataFieldType::Integer(1),
+            }],
+        };
+        let _guard = engine.row_storage_lock.lock().await;
+        let append_task = {
+            let engine = engine.clone();
+            tokio::spawn(async move { engine.append_table_rows(&table_name, &[row]).await })
+        };
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        assert!(!append_task.is_finished());
     }
 }

--- a/src/engine/actions/dml/scan.rs
+++ b/src/engine/actions/dml/scan.rs
@@ -12,6 +12,7 @@ use crate::errors;
 use crate::errors::execute_error::ExecuteError;
 
 const ROW_SEGMENT_FILENAME: &str = "00000001.rows";
+const DEFAULT_ROW_WRITE_BUFFER_LIMIT_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct RowLocation {
@@ -23,6 +24,8 @@ impl DBEngine {
         &self,
         table_name: TableName,
     ) -> errors::Result<Vec<(RowLocation, TableDataRow)>> {
+        self.flush_row_buffers().await?;
+
         let segment_path = self.row_segment_path(&table_name)?;
         let rows = self.read_segment_rows(&segment_path).await?;
 
@@ -38,37 +41,41 @@ impl DBEngine {
         table_name: &TableName,
         rows: &[TableDataRow],
     ) -> errors::Result<()> {
+        self.append_table_rows_with_buffer_limit(
+            table_name,
+            rows,
+            DEFAULT_ROW_WRITE_BUFFER_LIMIT_BYTES,
+        )
+        .await
+    }
+
+    async fn append_table_rows_with_buffer_limit(
+        &self,
+        table_name: &TableName,
+        rows: &[TableDataRow],
+        buffer_limit_bytes: usize,
+    ) -> errors::Result<()> {
         if rows.is_empty() {
             return Ok(());
         }
 
-        let _guard = self.row_storage_lock.lock().await;
         let segment_path = self.row_segment_path(table_name)?;
-        let encoder = StorageEncoder::new();
-        let mut frame = Vec::new();
+        let frame = encode_row_frames(rows)?;
 
-        for row in rows {
-            let len_offset = frame.len();
-            frame.extend_from_slice(&0u32.to_le_bytes());
-            encoder
-                .encode_into(&mut frame, row)
-                .map_err(|error| ExecuteError::wrap(error.to_string()))?;
-            let frame_len = u32::try_from(frame.len() - len_offset - size_of::<u32>())
-                .map_err(|_| ExecuteError::wrap("row frame is too large".to_string()))?;
-            frame[len_offset..len_offset + size_of::<u32>()]
-                .copy_from_slice(&frame_len.to_le_bytes());
+        let buffered_bytes = {
+            let mut buffer = self.row_write_buffer.lock().await;
+            buffer
+                .entry(segment_path)
+                .or_default()
+                .extend_from_slice(&frame);
+            buffer.values().map(Vec::len).sum::<usize>()
+        };
+
+        if buffered_bytes >= buffer_limit_bytes {
+            self.flush_row_buffers().await?;
         }
 
-        let mut file = tokio::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&segment_path)
-            .await
-            .map_err(|error| ExecuteError::wrap(error.to_string()))?;
-
-        file.write_all(&frame)
-            .await
-            .map_err(|error| ExecuteError::wrap(error.to_string()))
+        Ok(())
     }
 
     pub(crate) async fn update_table_rows(
@@ -82,6 +89,7 @@ impl DBEngine {
 
         let _guard = self.row_storage_lock.lock().await;
         let segment_path = self.row_segment_path(table_name)?;
+        self.flush_row_buffers_locked().await?;
         let mut rows = self.read_segment_rows(&segment_path).await?;
 
         for (row_index, row) in replacements {
@@ -105,6 +113,7 @@ impl DBEngine {
 
         let _guard = self.row_storage_lock.lock().await;
         let segment_path = self.row_segment_path(table_name)?;
+        self.flush_row_buffers_locked().await?;
         let rows = self.read_segment_rows(&segment_path).await?;
         let rows = rows
             .into_iter()
@@ -164,24 +173,57 @@ impl DBEngine {
         segment_path: &Path,
         rows: &[TableDataRow],
     ) -> errors::Result<()> {
-        let encoder = StorageEncoder::new();
-        let mut content = Vec::new();
-
-        for row in rows {
-            let len_offset = content.len();
-            content.extend_from_slice(&0u32.to_le_bytes());
-            encoder
-                .encode_into(&mut content, row)
-                .map_err(|error| ExecuteError::wrap(error.to_string()))?;
-            let frame_len = u32::try_from(content.len() - len_offset - size_of::<u32>())
-                .map_err(|_| ExecuteError::wrap("row frame is too large".to_string()))?;
-            content[len_offset..len_offset + size_of::<u32>()]
-                .copy_from_slice(&frame_len.to_le_bytes());
-        }
+        let content = encode_row_frames(rows)?;
 
         tokio::fs::write(segment_path, content)
             .await
             .map_err(|error| ExecuteError::wrap(error.to_string()))
+    }
+
+    pub(crate) async fn flush_row_buffers(&self) -> errors::Result<()> {
+        let _guard = self.row_storage_lock.lock().await;
+        self.flush_row_buffers_locked().await
+    }
+
+    async fn flush_row_buffers_locked(&self) -> errors::Result<()> {
+        let pending = {
+            let mut buffer = self.row_write_buffer.lock().await;
+            if buffer.is_empty() {
+                return Ok(());
+            }
+
+            std::mem::take(&mut *buffer)
+        };
+
+        for (segment_path, content) in pending {
+            let mut file = match tokio::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&segment_path)
+                .await
+            {
+                Ok(file) => file,
+                Err(error) => {
+                    self.restore_row_buffer(segment_path, content).await;
+                    return Err(ExecuteError::wrap(error.to_string()));
+                }
+            };
+
+            if let Err(error) = file.write_all(&content).await {
+                self.restore_row_buffer(segment_path, content).await;
+                return Err(ExecuteError::wrap(error.to_string()));
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn restore_row_buffer(&self, segment_path: PathBuf, content: Vec<u8>) {
+        let mut buffer = self.row_write_buffer.lock().await;
+        let existing = buffer.entry(segment_path).or_default();
+        let mut restored = content;
+        restored.extend_from_slice(existing);
+        *existing = restored;
     }
 
     fn row_segment_path(&self, table_name: &TableName) -> errors::Result<PathBuf> {
@@ -202,6 +244,25 @@ impl DBEngine {
     // TODO(#195): read only the frames covering the indexed rows instead of the
     // whole segment file once partial reads are supported.
     pub async fn index_scan(&self, _table_name: TableName) {}
+}
+
+fn encode_row_frames(rows: &[TableDataRow]) -> errors::Result<Vec<u8>> {
+    let encoder = StorageEncoder::new();
+    let mut content = Vec::new();
+
+    for row in rows {
+        let len_offset = content.len();
+        content.extend_from_slice(&0u32.to_le_bytes());
+        encoder
+            .encode_into(&mut content, row)
+            .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+        let frame_len = u32::try_from(content.len() - len_offset - size_of::<u32>())
+            .map_err(|_| ExecuteError::wrap("row frame is too large".to_string()))?;
+        content[len_offset..len_offset + size_of::<u32>()]
+            .copy_from_slice(&frame_len.to_le_bytes());
+    }
+
+    Ok(content)
 }
 
 #[cfg(test)]
@@ -259,5 +320,88 @@ mod tests {
         assert_eq!(scanned[0].1.fields[0].data, TableDataFieldType::Integer(1));
         assert_eq!(scanned[1].1.fields[0].data, TableDataFieldType::Integer(2));
         assert_eq!(file_count, 1);
+    }
+
+    #[tokio::test]
+    async fn append_table_rows_buffers_rows_until_flush() {
+        let base_path = PathBuf::from(format!(
+            "target/test_row_segments/buffered_segment_file_{}",
+            std::process::id()
+        ));
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        let table_name = TableName::new(Some("rrdb".to_string()), "users".to_string());
+        let rows_path = PathBuf::from(&config.data_directory)
+            .join("rrdb")
+            .join("tables")
+            .join("users")
+            .join("rows");
+        tokio::fs::create_dir_all(&rows_path).await.unwrap();
+
+        let engine = DBEngine::new(config);
+        let row = |id| TableDataRow {
+            fields: vec![TableDataField {
+                table_name: table_name.clone(),
+                column_name: "id".to_string(),
+                data: TableDataFieldType::Integer(id),
+            }],
+        };
+
+        engine
+            .append_table_rows(&table_name, &[row(1), row(2)])
+            .await
+            .unwrap();
+
+        let segment_path = rows_path.join("00000001.rows");
+        assert!(!segment_path.exists());
+
+        engine.flush_row_buffers().await.unwrap();
+
+        let scanned = engine.full_scan(table_name).await.unwrap();
+        assert_eq!(scanned.len(), 2);
+        assert_eq!(scanned[0].1.fields[0].data, TableDataFieldType::Integer(1));
+        assert_eq!(scanned[1].1.fields[0].data, TableDataFieldType::Integer(2));
+        assert!(segment_path.exists());
+    }
+
+    #[tokio::test]
+    async fn append_table_rows_flushes_when_buffer_limit_is_reached() {
+        let base_path = PathBuf::from(format!(
+            "target/test_row_segments/buffer_pressure_flush_{}",
+            std::process::id()
+        ));
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        let table_name = TableName::new(Some("rrdb".to_string()), "users".to_string());
+        let rows_path = PathBuf::from(&config.data_directory)
+            .join("rrdb")
+            .join("tables")
+            .join("users")
+            .join("rows");
+        tokio::fs::create_dir_all(&rows_path).await.unwrap();
+
+        let engine = DBEngine::new(config);
+        let row = TableDataRow {
+            fields: vec![TableDataField {
+                table_name: table_name.clone(),
+                column_name: "id".to_string(),
+                data: TableDataFieldType::Integer(1),
+            }],
+        };
+
+        engine
+            .append_table_rows_with_buffer_limit(&table_name, &[row], 1)
+            .await
+            .unwrap();
+
+        let segment_path = rows_path.join("00000001.rows");
+        assert!(segment_path.exists());
+        assert!(engine.row_write_buffer.lock().await.is_empty());
     }
 }

--- a/src/engine/actions/dml/scan.rs
+++ b/src/engine/actions/dml/scan.rs
@@ -2,11 +2,12 @@ use std::collections::{HashMap, HashSet};
 use std::io::ErrorKind as IOErrorKind;
 use std::path::{Path, PathBuf};
 
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 
 use crate::engine::DBEngine;
 use crate::engine::ast::types::TableName;
 use crate::engine::encoder::schema_encoder::StorageEncoder;
+use crate::engine::row_buffer::{RowBufferWrite, encode_row_frames};
 use crate::engine::schema::row::TableDataRow;
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
@@ -24,10 +25,19 @@ impl DBEngine {
         &self,
         table_name: TableName,
     ) -> errors::Result<Vec<(RowLocation, TableDataRow)>> {
-        self.flush_row_buffers().await?;
-
+        let _guard = self.row_storage_lock.lock().await;
         let segment_path = self.row_segment_path(&table_name)?;
-        let rows = self.read_segment_rows(&segment_path).await?;
+        let cached_rows = { self.row_buffer_pool.lock().await.cached_rows(&segment_path) };
+        let rows = match cached_rows {
+            Some(rows) => rows,
+            None => {
+                let disk_rows = self.read_segment_rows(&segment_path).await?;
+                self.row_buffer_pool
+                    .lock()
+                    .await
+                    .read_rows(segment_path, disk_rows)
+            }
+        };
 
         Ok(rows
             .into_iter()
@@ -63,12 +73,10 @@ impl DBEngine {
         let frame = encode_row_frames(rows)?;
 
         let buffered_bytes = {
-            let mut buffer = self.row_write_buffer.lock().await;
-            buffer
-                .entry(segment_path)
-                .or_default()
-                .extend_from_slice(&frame);
-            buffer.values().map(Vec::len).sum::<usize>()
+            self.row_buffer_pool
+                .lock()
+                .await
+                .append_rows(segment_path, rows, frame)
         };
 
         if buffered_bytes >= buffer_limit_bytes {
@@ -89,8 +97,17 @@ impl DBEngine {
 
         let _guard = self.row_storage_lock.lock().await;
         let segment_path = self.row_segment_path(table_name)?;
-        self.flush_row_buffers_locked().await?;
-        let mut rows = self.read_segment_rows(&segment_path).await?;
+        let cached_rows = { self.row_buffer_pool.lock().await.cached_rows(&segment_path) };
+        let mut rows = match cached_rows {
+            Some(rows) => rows,
+            None => {
+                let disk_rows = self.read_segment_rows(&segment_path).await?;
+                self.row_buffer_pool
+                    .lock()
+                    .await
+                    .read_rows(segment_path.clone(), disk_rows)
+            }
+        };
 
         for (row_index, row) in replacements {
             let target = rows.get_mut(row_index).ok_or_else(|| {
@@ -99,7 +116,12 @@ impl DBEngine {
             *target = row;
         }
 
-        self.write_segment_rows(&segment_path, &rows).await
+        self.row_buffer_pool
+            .lock()
+            .await
+            .replace_rows(segment_path, rows);
+
+        Ok(())
     }
 
     pub(crate) async fn delete_table_rows(
@@ -113,8 +135,17 @@ impl DBEngine {
 
         let _guard = self.row_storage_lock.lock().await;
         let segment_path = self.row_segment_path(table_name)?;
-        self.flush_row_buffers_locked().await?;
-        let rows = self.read_segment_rows(&segment_path).await?;
+        let cached_rows = { self.row_buffer_pool.lock().await.cached_rows(&segment_path) };
+        let rows = match cached_rows {
+            Some(rows) => rows,
+            None => {
+                let disk_rows = self.read_segment_rows(&segment_path).await?;
+                self.row_buffer_pool
+                    .lock()
+                    .await
+                    .read_rows(segment_path.clone(), disk_rows)
+            }
+        };
         let rows = rows
             .into_iter()
             .enumerate()
@@ -122,7 +153,12 @@ impl DBEngine {
             .map(|(_, row)| row)
             .collect::<Vec<_>>();
 
-        self.write_segment_rows(&segment_path, &rows).await
+        self.row_buffer_pool
+            .lock()
+            .await
+            .replace_rows(segment_path, rows);
+
+        Ok(())
     }
 
     async fn read_segment_rows(&self, segment_path: &Path) -> errors::Result<Vec<TableDataRow>> {
@@ -168,62 +204,55 @@ impl DBEngine {
         Ok(rows)
     }
 
-    async fn write_segment_rows(
-        &self,
-        segment_path: &Path,
-        rows: &[TableDataRow],
-    ) -> errors::Result<()> {
-        let content = encode_row_frames(rows)?;
-
-        tokio::fs::write(segment_path, content)
-            .await
-            .map_err(|error| ExecuteError::wrap(error.to_string()))
-    }
-
     pub(crate) async fn flush_row_buffers(&self) -> errors::Result<()> {
         let _guard = self.row_storage_lock.lock().await;
         self.flush_row_buffers_locked().await
     }
 
     async fn flush_row_buffers_locked(&self) -> errors::Result<()> {
-        let pending = {
-            let mut buffer = self.row_write_buffer.lock().await;
-            if buffer.is_empty() {
-                return Ok(());
+        let pending = self.row_buffer_pool.lock().await.drain_writes()?;
+
+        for write in pending {
+            if let Err(error) = self.apply_row_buffer_write(&write).await {
+                self.row_buffer_pool.lock().await.restore_write(write);
+                return Err(error);
             }
-
-            std::mem::take(&mut *buffer)
-        };
-
-        for (segment_path, content) in pending {
-            let mut file = match tokio::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&segment_path)
-                .await
-            {
-                Ok(file) => file,
-                Err(error) => {
-                    self.restore_row_buffer(segment_path, content).await;
-                    return Err(ExecuteError::wrap(error.to_string()));
-                }
-            };
-
-            if let Err(error) = file.write_all(&content).await {
-                self.restore_row_buffer(segment_path, content).await;
-                return Err(ExecuteError::wrap(error.to_string()));
-            }
+            self.row_buffer_pool.lock().await.complete_write(write);
         }
 
         Ok(())
     }
 
-    async fn restore_row_buffer(&self, segment_path: PathBuf, content: Vec<u8>) {
-        let mut buffer = self.row_write_buffer.lock().await;
-        let existing = buffer.entry(segment_path).or_default();
-        let mut restored = content;
-        restored.extend_from_slice(existing);
-        *existing = restored;
+    async fn apply_row_buffer_write(&self, write: &RowBufferWrite) -> errors::Result<()> {
+        let existing_len = if write.replace_existing {
+            0
+        } else {
+            match tokio::fs::metadata(&write.segment_path).await {
+                Ok(metadata) => metadata.len(),
+                Err(error) if error.kind() == IOErrorKind::NotFound => 0,
+                Err(error) => return Err(ExecuteError::wrap(error.to_string())),
+            }
+        };
+
+        let mut file = match tokio::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(&write.segment_path)
+            .await
+        {
+            Ok(file) => file,
+            Err(error) => return Err(ExecuteError::wrap(error.to_string())),
+        };
+
+        file.set_len(existing_len)
+            .await
+            .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+        file.seek(std::io::SeekFrom::End(0))
+            .await
+            .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+        file.write_all(&write.content)
+            .await
+            .map_err(|error| ExecuteError::wrap(error.to_string()))
     }
 
     fn row_segment_path(&self, table_name: &TableName) -> errors::Result<PathBuf> {
@@ -246,25 +275,6 @@ impl DBEngine {
     pub async fn index_scan(&self, _table_name: TableName) {}
 }
 
-fn encode_row_frames(rows: &[TableDataRow]) -> errors::Result<Vec<u8>> {
-    let encoder = StorageEncoder::new();
-    let mut content = Vec::new();
-
-    for row in rows {
-        let len_offset = content.len();
-        content.extend_from_slice(&0u32.to_le_bytes());
-        encoder
-            .encode_into(&mut content, row)
-            .map_err(|error| ExecuteError::wrap(error.to_string()))?;
-        let frame_len = u32::try_from(content.len() - len_offset - size_of::<u32>())
-            .map_err(|_| ExecuteError::wrap("row frame is too large".to_string()))?;
-        content[len_offset..len_offset + size_of::<u32>()]
-            .copy_from_slice(&frame_len.to_le_bytes());
-    }
-
-    Ok(content)
-}
-
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -275,7 +285,7 @@ mod tests {
     use crate::engine::schema::row::{TableDataField, TableDataFieldType, TableDataRow};
 
     #[tokio::test]
-    async fn append_table_rows_stores_rows_in_single_segment_file() {
+    async fn full_scan_reads_buffered_rows_without_flushing_segment_file() {
         let base_path = PathBuf::from(format!(
             "target/test_row_segments/single_segment_file_{}",
             std::process::id()
@@ -308,18 +318,154 @@ mod tests {
             .unwrap();
 
         let scanned = engine.full_scan(table_name).await.unwrap();
-        let mut dir_entries = tokio::fs::read_dir(&rows_path).await.unwrap();
-        let mut file_count = 0;
-        while let Some(entry) = dir_entries.next_entry().await.unwrap() {
-            if entry.file_type().await.unwrap().is_file() {
-                file_count += 1;
-            }
-        }
+        let segment_path = rows_path.join("00000001.rows");
 
         assert_eq!(scanned.len(), 2);
         assert_eq!(scanned[0].1.fields[0].data, TableDataFieldType::Integer(1));
         assert_eq!(scanned[1].1.fields[0].data, TableDataFieldType::Integer(2));
-        assert_eq!(file_count, 1);
+        assert!(!segment_path.exists());
+    }
+
+    #[tokio::test]
+    async fn update_table_rows_updates_buffered_rows_without_flushing_segment_file() {
+        let base_path = PathBuf::from(format!(
+            "target/test_row_segments/update_buffered_rows_{}",
+            std::process::id()
+        ));
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        let table_name = TableName::new(Some("rrdb".to_string()), "users".to_string());
+        let rows_path = PathBuf::from(&config.data_directory)
+            .join("rrdb")
+            .join("tables")
+            .join("users")
+            .join("rows");
+        tokio::fs::create_dir_all(&rows_path).await.unwrap();
+
+        let engine = DBEngine::new(config);
+        let row = |id| TableDataRow {
+            fields: vec![TableDataField {
+                table_name: table_name.clone(),
+                column_name: "id".to_string(),
+                data: TableDataFieldType::Integer(id),
+            }],
+        };
+
+        engine
+            .append_table_rows(&table_name, &[row(1), row(2)])
+            .await
+            .unwrap();
+        engine
+            .update_table_rows(&table_name, [(1, row(20))].into())
+            .await
+            .unwrap();
+
+        let scanned = engine.full_scan(table_name).await.unwrap();
+        let segment_path = rows_path.join("00000001.rows");
+
+        assert_eq!(scanned.len(), 2);
+        assert_eq!(scanned[0].1.fields[0].data, TableDataFieldType::Integer(1));
+        assert_eq!(scanned[1].1.fields[0].data, TableDataFieldType::Integer(20));
+        assert!(!segment_path.exists());
+    }
+
+    #[tokio::test]
+    async fn delete_table_rows_deletes_buffered_rows_without_flushing_segment_file() {
+        let base_path = PathBuf::from(format!(
+            "target/test_row_segments/delete_buffered_rows_{}",
+            std::process::id()
+        ));
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        let table_name = TableName::new(Some("rrdb".to_string()), "users".to_string());
+        let rows_path = PathBuf::from(&config.data_directory)
+            .join("rrdb")
+            .join("tables")
+            .join("users")
+            .join("rows");
+        tokio::fs::create_dir_all(&rows_path).await.unwrap();
+
+        let engine = DBEngine::new(config);
+        let row = |id| TableDataRow {
+            fields: vec![TableDataField {
+                table_name: table_name.clone(),
+                column_name: "id".to_string(),
+                data: TableDataFieldType::Integer(id),
+            }],
+        };
+
+        engine
+            .append_table_rows(&table_name, &[row(1), row(2), row(3)])
+            .await
+            .unwrap();
+        engine
+            .delete_table_rows(&table_name, [1].into())
+            .await
+            .unwrap();
+
+        let scanned = engine.full_scan(table_name).await.unwrap();
+        let segment_path = rows_path.join("00000001.rows");
+
+        assert_eq!(scanned.len(), 2);
+        assert_eq!(scanned[0].1.fields[0].data, TableDataFieldType::Integer(1));
+        assert_eq!(scanned[1].1.fields[0].data, TableDataFieldType::Integer(3));
+        assert!(!segment_path.exists());
+    }
+
+    #[tokio::test]
+    async fn flush_rewrite_preserves_rows_appended_after_update() {
+        let base_path = PathBuf::from(format!(
+            "target/test_row_segments/rewrite_then_append_{}",
+            std::process::id()
+        ));
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        let table_name = TableName::new(Some("rrdb".to_string()), "users".to_string());
+        let rows_path = PathBuf::from(&config.data_directory)
+            .join("rrdb")
+            .join("tables")
+            .join("users")
+            .join("rows");
+        tokio::fs::create_dir_all(&rows_path).await.unwrap();
+
+        let engine = DBEngine::new(config);
+        let row = |id| TableDataRow {
+            fields: vec![TableDataField {
+                table_name: table_name.clone(),
+                column_name: "id".to_string(),
+                data: TableDataFieldType::Integer(id),
+            }],
+        };
+
+        engine
+            .append_table_rows(&table_name, &[row(1), row(2)])
+            .await
+            .unwrap();
+        engine
+            .update_table_rows(&table_name, [(1, row(20))].into())
+            .await
+            .unwrap();
+        engine
+            .append_table_rows(&table_name, &[row(3)])
+            .await
+            .unwrap();
+        engine.flush_row_buffers().await.unwrap();
+
+        let scanned = engine.full_scan(table_name).await.unwrap();
+
+        assert_eq!(scanned.len(), 3);
+        assert_eq!(scanned[0].1.fields[0].data, TableDataFieldType::Integer(1));
+        assert_eq!(scanned[1].1.fields[0].data, TableDataFieldType::Integer(20));
+        assert_eq!(scanned[2].1.fields[0].data, TableDataFieldType::Integer(3));
     }
 
     #[tokio::test]
@@ -402,6 +548,6 @@ mod tests {
 
         let segment_path = rows_path.join("00000001.rows");
         assert!(segment_path.exists());
-        assert!(engine.row_write_buffer.lock().await.is_empty());
+        assert!(engine.row_buffer_pool.lock().await.is_dirty_empty());
     }
 }

--- a/src/engine/initialize.rs
+++ b/src/engine/initialize.rs
@@ -574,8 +574,8 @@ wal_extension = "log"
                     std::collections::HashMap::new(),
                 )),
                 row_storage_lock: Arc::new(tokio::sync::Mutex::new(())),
-                row_write_buffer: Arc::new(tokio::sync::Mutex::new(
-                    std::collections::HashMap::new(),
+                row_buffer_pool: Arc::new(tokio::sync::Mutex::new(
+                    crate::engine::row_buffer::RowBufferPool::default(),
                 )),
             };
 
@@ -638,7 +638,9 @@ wal_extension = "log"
                 tokio::sync::RwLock::new(std::collections::HashMap::new()),
             ),
             row_storage_lock: Arc::new(tokio::sync::Mutex::new(())),
-            row_write_buffer: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+            row_buffer_pool: Arc::new(tokio::sync::Mutex::new(
+                crate::engine::row_buffer::RowBufferPool::default(),
+            )),
         };
 
         let result = executor.init_config(Some(base_path)).await;
@@ -686,7 +688,9 @@ wal_extension = "log"
                 tokio::sync::RwLock::new(std::collections::HashMap::new()),
             ),
             row_storage_lock: Arc::new(tokio::sync::Mutex::new(())),
-            row_write_buffer: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+            row_buffer_pool: Arc::new(tokio::sync::Mutex::new(
+                crate::engine::row_buffer::RowBufferPool::default(),
+            )),
         };
 
         let result = executor.install_daemon().await;

--- a/src/engine/initialize.rs
+++ b/src/engine/initialize.rs
@@ -574,6 +574,9 @@ wal_extension = "log"
                     std::collections::HashMap::new(),
                 )),
                 row_storage_lock: Arc::new(tokio::sync::Mutex::new(())),
+                row_write_buffer: Arc::new(tokio::sync::Mutex::new(
+                    std::collections::HashMap::new(),
+                )),
             };
 
             let result = executor.init_config(None).await;
@@ -635,6 +638,7 @@ wal_extension = "log"
                 tokio::sync::RwLock::new(std::collections::HashMap::new()),
             ),
             row_storage_lock: Arc::new(tokio::sync::Mutex::new(())),
+            row_write_buffer: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
         };
 
         let result = executor.init_config(Some(base_path)).await;
@@ -682,6 +686,7 @@ wal_extension = "log"
                 tokio::sync::RwLock::new(std::collections::HashMap::new()),
             ),
             row_storage_lock: Arc::new(tokio::sync::Mutex::new(())),
+            row_write_buffer: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
         };
 
         let result = executor.install_daemon().await;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -40,6 +40,7 @@ pub struct DBEngine {
     pub(crate) command_runner: Arc<dyn CommandRunner + Send + Sync>,
     pub(crate) table_config_cache: Arc<RwLock<HashMap<TableName, TableSchema>>>,
     pub(crate) row_storage_lock: Arc<Mutex<()>>,
+    pub(crate) row_write_buffer: Arc<Mutex<HashMap<PathBuf, Vec<u8>>>>,
 }
 
 impl DBEngine {
@@ -50,6 +51,7 @@ impl DBEngine {
             command_runner: Arc::new(RealCommandRunner {}),
             table_config_cache: Arc::new(RwLock::new(HashMap::new())),
             row_storage_lock: Arc::new(Mutex::new(())),
+            row_write_buffer: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -157,15 +159,13 @@ impl DBEngine {
         let config_path = table_path.clone().join("table.config");
 
         match tokio::fs::read(&config_path).await {
-            Ok(data) => {
-                match encoder.decode::<TableSchema>(data.as_slice()) {
-                    Ok(table_config) => Ok(table_config),
-                    Err(error) => Err(ExecuteError::wrap(format!(
-                        "invalid config data: {}",
-                        error
-                    ))),
-                }
-            }
+            Ok(data) => match encoder.decode::<TableSchema>(data.as_slice()) {
+                Ok(table_config) => Ok(table_config),
+                Err(error) => Err(ExecuteError::wrap(format!(
+                    "invalid config data: {}",
+                    error
+                ))),
+            },
             Err(error) => match error.kind() {
                 std::io::ErrorKind::NotFound => {
                     Err(ExecuteError::wrap("table not found".to_string()))

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -4,6 +4,7 @@ pub mod index;
 pub mod lexer;
 pub mod optimizer;
 pub mod parser;
+pub mod row_buffer;
 pub mod schema;
 pub mod server;
 pub mod wal;
@@ -24,6 +25,7 @@ use crate::config::launch_config::LaunchConfig;
 use crate::engine::ast::types::TableName;
 use crate::engine::ast::{DDLStatement, DMLStatement, OtherStatement, SQLStatement};
 use crate::engine::encoder::schema_encoder::StorageEncoder;
+use crate::engine::row_buffer::RowBufferPool;
 use crate::engine::schema::table::TableSchema;
 use crate::engine::types::ExecuteResult;
 use crate::engine::wal::endec::implements::bincode::BincodeEncoder;
@@ -40,7 +42,7 @@ pub struct DBEngine {
     pub(crate) command_runner: Arc<dyn CommandRunner + Send + Sync>,
     pub(crate) table_config_cache: Arc<RwLock<HashMap<TableName, TableSchema>>>,
     pub(crate) row_storage_lock: Arc<Mutex<()>>,
-    pub(crate) row_write_buffer: Arc<Mutex<HashMap<PathBuf, Vec<u8>>>>,
+    pub(crate) row_buffer_pool: Arc<Mutex<RowBufferPool>>,
 }
 
 impl DBEngine {
@@ -51,7 +53,7 @@ impl DBEngine {
             command_runner: Arc::new(RealCommandRunner {}),
             table_config_cache: Arc::new(RwLock::new(HashMap::new())),
             row_storage_lock: Arc::new(Mutex::new(())),
-            row_write_buffer: Arc::new(Mutex::new(HashMap::new())),
+            row_buffer_pool: Arc::new(Mutex::new(RowBufferPool::default())),
         }
     }
 

--- a/src/engine/row_buffer.rs
+++ b/src/engine/row_buffer.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use crate::engine::encoder::schema_encoder::StorageEncoder;
@@ -9,6 +9,7 @@ use crate::errors::execute_error::ExecuteError;
 #[derive(Default)]
 pub(crate) struct RowBufferPool {
     segments: HashMap<PathBuf, RowSegmentBuffer>,
+    unsynced_segments: HashSet<PathBuf>,
 }
 
 #[derive(Default)]
@@ -109,8 +110,9 @@ impl RowBufferPool {
         Ok(writes)
     }
 
-    pub(crate) fn complete_write(&mut self, write: RowBufferWrite) {
-        let segment = self.segments.entry(write.segment_path).or_default();
+    pub(crate) fn complete_write(&mut self, write: RowBufferWrite, durable: bool) {
+        let segment_path = write.segment_path;
+        let segment = self.segments.entry(segment_path.clone()).or_default();
         match write.kind {
             RowBufferWriteKind::Append { rows } => {
                 if let Some(persisted_rows) = &mut segment.persisted_rows {
@@ -120,6 +122,12 @@ impl RowBufferPool {
             RowBufferWriteKind::Rewrite { rows } => {
                 segment.persisted_rows = Some(rows);
             }
+        }
+
+        if durable {
+            self.unsynced_segments.remove(&segment_path);
+        } else {
+            self.unsynced_segments.insert(segment_path);
         }
     }
 
@@ -151,6 +159,19 @@ impl RowBufferPool {
                 && segment.pending_append_rows.is_empty()
                 && segment.pending_append_bytes.is_empty()
         })
+    }
+
+    pub(crate) fn drain_unsynced_segments(&mut self) -> Vec<PathBuf> {
+        self.unsynced_segments.drain().collect()
+    }
+
+    pub(crate) fn mark_unsynced_segment(&mut self, segment_path: PathBuf) {
+        self.unsynced_segments.insert(segment_path);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_unsynced_empty(&self) -> bool {
+        self.unsynced_segments.is_empty()
     }
 
     fn dirty_bytes(&self) -> usize {

--- a/src/engine/row_buffer.rs
+++ b/src/engine/row_buffer.rs
@@ -1,0 +1,192 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use crate::engine::encoder::schema_encoder::StorageEncoder;
+use crate::engine::schema::row::TableDataRow;
+use crate::errors;
+use crate::errors::execute_error::ExecuteError;
+
+#[derive(Default)]
+pub(crate) struct RowBufferPool {
+    segments: HashMap<PathBuf, RowSegmentBuffer>,
+}
+
+#[derive(Default)]
+struct RowSegmentBuffer {
+    persisted_rows: Option<Vec<TableDataRow>>,
+    pending_append_rows: Vec<TableDataRow>,
+    pending_append_bytes: Vec<u8>,
+    rewrite_required: bool,
+}
+
+pub(crate) struct RowBufferWrite {
+    pub(crate) segment_path: PathBuf,
+    pub(crate) content: Vec<u8>,
+    pub(crate) replace_existing: bool,
+    kind: RowBufferWriteKind,
+}
+
+enum RowBufferWriteKind {
+    Append { rows: Vec<TableDataRow> },
+    Rewrite { rows: Vec<TableDataRow> },
+}
+
+impl RowBufferPool {
+    pub(crate) fn append_rows(
+        &mut self,
+        segment_path: PathBuf,
+        rows: &[TableDataRow],
+        encoded_rows: Vec<u8>,
+    ) -> usize {
+        let segment = self.segments.entry(segment_path).or_default();
+        segment.pending_append_rows.extend_from_slice(rows);
+        segment
+            .pending_append_bytes
+            .extend_from_slice(&encoded_rows);
+        self.dirty_bytes()
+    }
+
+    pub(crate) fn read_rows(
+        &mut self,
+        segment_path: PathBuf,
+        disk_rows: Vec<TableDataRow>,
+    ) -> Vec<TableDataRow> {
+        let segment = self.segments.entry(segment_path).or_default();
+        let persisted_rows = segment.persisted_rows.get_or_insert(disk_rows);
+        let mut rows = persisted_rows.clone();
+        rows.extend_from_slice(&segment.pending_append_rows);
+        rows
+    }
+
+    pub(crate) fn cached_rows(&self, segment_path: &PathBuf) -> Option<Vec<TableDataRow>> {
+        let segment = self.segments.get(segment_path)?;
+        let persisted_rows = segment.persisted_rows.as_ref()?;
+        let mut rows = persisted_rows.clone();
+        rows.extend_from_slice(&segment.pending_append_rows);
+        Some(rows)
+    }
+
+    pub(crate) fn replace_rows(&mut self, segment_path: PathBuf, rows: Vec<TableDataRow>) {
+        let segment = self.segments.entry(segment_path).or_default();
+        segment.persisted_rows = Some(rows);
+        segment.pending_append_rows.clear();
+        segment.pending_append_bytes.clear();
+        segment.rewrite_required = true;
+    }
+
+    pub(crate) fn drain_writes(&mut self) -> errors::Result<Vec<RowBufferWrite>> {
+        let mut writes = Vec::new();
+
+        for (segment_path, segment) in self.segments.iter_mut() {
+            if segment.rewrite_required {
+                let mut rows = segment.persisted_rows.clone().unwrap_or_default();
+                rows.extend_from_slice(&segment.pending_append_rows);
+                let content = encode_row_frames(&rows)?;
+                segment.rewrite_required = false;
+                segment.pending_append_rows.clear();
+                segment.pending_append_bytes.clear();
+                writes.push(RowBufferWrite {
+                    segment_path: segment_path.clone(),
+                    content,
+                    replace_existing: true,
+                    kind: RowBufferWriteKind::Rewrite { rows },
+                });
+                continue;
+            }
+
+            if !segment.pending_append_bytes.is_empty() {
+                let rows = std::mem::take(&mut segment.pending_append_rows);
+                let content = std::mem::take(&mut segment.pending_append_bytes);
+                writes.push(RowBufferWrite {
+                    segment_path: segment_path.clone(),
+                    content,
+                    replace_existing: false,
+                    kind: RowBufferWriteKind::Append { rows },
+                });
+            }
+        }
+
+        Ok(writes)
+    }
+
+    pub(crate) fn complete_write(&mut self, write: RowBufferWrite) {
+        let segment = self.segments.entry(write.segment_path).or_default();
+        match write.kind {
+            RowBufferWriteKind::Append { rows } => {
+                if let Some(persisted_rows) = &mut segment.persisted_rows {
+                    persisted_rows.extend(rows);
+                }
+            }
+            RowBufferWriteKind::Rewrite { rows } => {
+                segment.persisted_rows = Some(rows);
+            }
+        }
+    }
+
+    pub(crate) fn restore_write(&mut self, write: RowBufferWrite) {
+        let segment = self.segments.entry(write.segment_path).or_default();
+        match write.kind {
+            RowBufferWriteKind::Append { rows } => {
+                let mut restored_bytes = write.content;
+                restored_bytes.extend_from_slice(&segment.pending_append_bytes);
+                segment.pending_append_bytes = restored_bytes;
+
+                let mut restored_rows = rows;
+                restored_rows.extend_from_slice(&segment.pending_append_rows);
+                segment.pending_append_rows = restored_rows;
+            }
+            RowBufferWriteKind::Rewrite { rows } => {
+                segment.persisted_rows = Some(rows);
+                segment.pending_append_rows.clear();
+                segment.pending_append_bytes.clear();
+                segment.rewrite_required = true;
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_dirty_empty(&self) -> bool {
+        self.segments.values().all(|segment| {
+            !segment.rewrite_required
+                && segment.pending_append_rows.is_empty()
+                && segment.pending_append_bytes.is_empty()
+        })
+    }
+
+    fn dirty_bytes(&self) -> usize {
+        self.segments
+            .values()
+            .map(|segment| {
+                segment.pending_append_bytes.len()
+                    + if segment.rewrite_required {
+                        segment
+                            .persisted_rows
+                            .as_ref()
+                            .map(|rows| rows.len() * size_of::<TableDataRow>())
+                            .unwrap_or_default()
+                    } else {
+                        0
+                    }
+            })
+            .sum()
+    }
+}
+
+pub(crate) fn encode_row_frames(rows: &[TableDataRow]) -> errors::Result<Vec<u8>> {
+    let encoder = StorageEncoder::new();
+    let mut content = Vec::new();
+
+    for row in rows {
+        let len_offset = content.len();
+        content.extend_from_slice(&0u32.to_le_bytes());
+        encoder
+            .encode_into(&mut content, row)
+            .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+        let frame_len = u32::try_from(content.len() - len_offset - size_of::<u32>())
+            .map_err(|_| ExecuteError::wrap("row frame is too large".to_string()))?;
+        content[len_offset..len_offset + size_of::<u32>()]
+            .copy_from_slice(&frame_len.to_le_bytes());
+    }
+
+    Ok(content)
+}

--- a/src/engine/server/mod.rs
+++ b/src/engine/server/mod.rs
@@ -2,13 +2,14 @@ pub mod client;
 pub mod shared_state;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::config::launch_config::LaunchConfig;
-use crate::engine::DBEngine;
 use crate::engine::server::client::ClientInfo;
 use crate::engine::server::shared_state::SharedState;
 use crate::engine::wal::endec::implements::bincode::{BincodeDecoder, BincodeEncoder};
 use crate::engine::wal::manager::builder::WALBuilder;
+use crate::engine::{DBEngine, SharedWALManager};
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
 use crate::pgwire::connection::ConnectionError;
@@ -16,6 +17,10 @@ use crate::pgwire::predule::Connection;
 
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+const DEFAULT_WAL_FLUSH_INTERVAL: Duration = Duration::from_secs(10);
+const DEFAULT_ROW_FLUSH_INTERVAL: Duration = Duration::from_secs(10);
 
 pub struct Server {
     pub config: Arc<LaunchConfig>,
@@ -23,6 +28,37 @@ pub struct Server {
 
 fn is_expected_disconnect(error: &ConnectionError) -> bool {
     matches!(error, ConnectionError::ConnectionClosed)
+}
+
+fn spawn_wal_flush_loop(
+    wal_manager: SharedWALManager,
+    interval_duration: Duration,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(interval_duration);
+
+        loop {
+            interval.tick().await;
+
+            if let Err(error) = wal_manager.lock().await.flush().await {
+                log::error!("failed to flush WAL: {}", error);
+            }
+        }
+    })
+}
+
+fn spawn_row_flush_loop(engine: Arc<DBEngine>, interval_duration: Duration) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(interval_duration);
+
+        loop {
+            interval.tick().await;
+
+            if let Err(error) = engine.flush_row_buffers().await {
+                log::error!("failed to flush row buffers: {}", error);
+            }
+        }
+    })
 }
 
 impl Server {
@@ -49,6 +85,8 @@ impl Server {
                 .await
                 .map_err(|error| ExecuteError::wrap(error.to_string()))?,
         ));
+        let _wal_flush_task = spawn_wal_flush_loop(wal_manager.clone(), DEFAULT_WAL_FLUSH_INTERVAL);
+        let _row_flush_task = spawn_row_flush_loop(engine.clone(), DEFAULT_ROW_FLUSH_INTERVAL);
 
         // connection task
         // client와의 커넥션 처리 루프
@@ -109,12 +147,140 @@ impl Server {
 
 #[cfg(test)]
 mod tests {
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use tokio::sync::Mutex;
+
+    use crate::config::launch_config::LaunchConfig;
+    use crate::engine::DBEngine;
+    use crate::engine::ast::types::TableName;
+    use crate::engine::schema::row::{TableDataField, TableDataFieldType, TableDataRow};
+    use crate::engine::wal::endec::WALDecoder;
+    use crate::engine::wal::endec::implements::bincode::{BincodeDecoder, BincodeEncoder};
+    use crate::engine::wal::manager::builder::WALBuilder;
+    use crate::engine::wal::types::EntryType;
     use crate::pgwire::connection::ConnectionError;
 
     use super::is_expected_disconnect;
+    use super::spawn_row_flush_loop;
+    use super::spawn_wal_flush_loop;
 
     #[test]
     fn connection_closed_is_expected_disconnect() {
         assert!(is_expected_disconnect(&ConnectionError::ConnectionClosed));
+    }
+
+    fn get_test_config(wal_dir_path: &Path) -> LaunchConfig {
+        LaunchConfig {
+            port: 22208,
+            host: "127.0.0.1".to_string(),
+            data_directory: "./test_db_data".to_string(),
+            wal_enabled: true,
+            wal_directory: wal_dir_path.to_str().unwrap().to_string(),
+            wal_segment_size: 1024,
+            wal_extension: "waltest".to_string(),
+        }
+    }
+
+    async fn setup_test_wal_dir(test_name: &str) -> PathBuf {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let wal_dir = PathBuf::from("target")
+            .join("test_server_wal_data")
+            .join(format!("{test_name}_{now}"));
+        tokio::fs::create_dir_all(&wal_dir).await.unwrap();
+        wal_dir
+    }
+
+    #[tokio::test]
+    async fn wal_flush_loop_periodically_checkpoints_current_wal() {
+        let wal_dir = setup_test_wal_dir("wal_flush_loop_checkpoints").await;
+        let config = get_test_config(&wal_dir);
+        let decoder = BincodeDecoder::new();
+        let encoder = BincodeEncoder::new();
+        let wal_manager = Arc::new(Mutex::new(
+            WALBuilder::new(&config)
+                .build(decoder.clone(), encoder)
+                .await
+                .unwrap(),
+        ));
+
+        wal_manager
+            .lock()
+            .await
+            .append_record(EntryType::Insert, Some(b"row-1".to_vec()), None)
+            .await
+            .unwrap();
+
+        let flush_task = spawn_wal_flush_loop(wal_manager, Duration::from_millis(10));
+        let wal_path = wal_dir.join(format!("00000001.{}", config.wal_extension));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let content = tokio::fs::read(&wal_path).await.unwrap();
+                let entries = decoder.decode(&content).unwrap();
+
+                if entries
+                    .iter()
+                    .any(|entry| matches!(entry.entry_type, EntryType::Checkpoint))
+                {
+                    break;
+                }
+
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .unwrap();
+
+        flush_task.abort();
+    }
+
+    #[tokio::test]
+    async fn row_flush_loop_periodically_writes_buffered_rows() {
+        let wal_dir = setup_test_wal_dir("row_flush_loop_writes_rows").await;
+        let base_path = wal_dir.join("base");
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        let table_name = TableName::new(Some("rrdb".to_string()), "users".to_string());
+        let rows_path = PathBuf::from(&config.data_directory)
+            .join("rrdb")
+            .join("tables")
+            .join("users")
+            .join("rows");
+        tokio::fs::create_dir_all(&rows_path).await.unwrap();
+
+        let engine = Arc::new(DBEngine::new(config));
+        let row = TableDataRow {
+            fields: vec![TableDataField {
+                table_name: table_name.clone(),
+                column_name: "id".to_string(),
+                data: TableDataFieldType::Integer(1),
+            }],
+        };
+
+        engine.append_table_rows(&table_name, &[row]).await.unwrap();
+
+        let segment_path = rows_path.join("00000001.rows");
+        assert!(!segment_path.exists());
+
+        let flush_task = spawn_row_flush_loop(engine, Duration::from_millis(10));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if segment_path.exists() {
+                    break;
+                }
+
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .unwrap();
+
+        flush_task.abort();
     }
 }

--- a/src/engine/server/mod.rs
+++ b/src/engine/server/mod.rs
@@ -19,8 +19,7 @@ use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
-const DEFAULT_WAL_FLUSH_INTERVAL: Duration = Duration::from_secs(10);
-const DEFAULT_ROW_FLUSH_INTERVAL: Duration = Duration::from_secs(10);
+const DEFAULT_DURABILITY_FLUSH_INTERVAL: Duration = Duration::from_secs(10);
 
 pub struct Server {
     pub config: Arc<LaunchConfig>,
@@ -30,7 +29,8 @@ fn is_expected_disconnect(error: &ConnectionError) -> bool {
     matches!(error, ConnectionError::ConnectionClosed)
 }
 
-fn spawn_wal_flush_loop(
+fn spawn_durability_flush_loop(
+    engine: Arc<DBEngine>,
     wal_manager: SharedWALManager,
     interval_duration: Duration,
 ) -> JoinHandle<()> {
@@ -40,22 +40,13 @@ fn spawn_wal_flush_loop(
         loop {
             interval.tick().await;
 
+            if let Err(error) = engine.flush_row_buffers_durable().await {
+                log::error!("failed to flush row buffers durably: {}", error);
+                continue;
+            }
+
             if let Err(error) = wal_manager.lock().await.flush().await {
                 log::error!("failed to flush WAL: {}", error);
-            }
-        }
-    })
-}
-
-fn spawn_row_flush_loop(engine: Arc<DBEngine>, interval_duration: Duration) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(interval_duration);
-
-        loop {
-            interval.tick().await;
-
-            if let Err(error) = engine.flush_row_buffers().await {
-                log::error!("failed to flush row buffers: {}", error);
             }
         }
     })
@@ -85,8 +76,18 @@ impl Server {
                 .await
                 .map_err(|error| ExecuteError::wrap(error.to_string()))?,
         ));
-        let _wal_flush_task = spawn_wal_flush_loop(wal_manager.clone(), DEFAULT_WAL_FLUSH_INTERVAL);
-        let _row_flush_task = spawn_row_flush_loop(engine.clone(), DEFAULT_ROW_FLUSH_INTERVAL);
+        {
+            let mut wal_manager_guard = wal_manager.lock().await;
+            engine
+                .recover_from_wal(&mut wal_manager_guard)
+                .await
+                .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+        }
+        let _durability_flush_task = spawn_durability_flush_loop(
+            engine.clone(),
+            wal_manager.clone(),
+            DEFAULT_DURABILITY_FLUSH_INTERVAL,
+        );
 
         // connection task
         // client와의 커넥션 처리 루프
@@ -147,7 +148,7 @@ impl Server {
 
 #[cfg(test)]
 mod tests {
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
     use std::sync::Arc;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -164,24 +165,11 @@ mod tests {
     use crate::pgwire::connection::ConnectionError;
 
     use super::is_expected_disconnect;
-    use super::spawn_row_flush_loop;
-    use super::spawn_wal_flush_loop;
+    use super::spawn_durability_flush_loop;
 
     #[test]
     fn connection_closed_is_expected_disconnect() {
         assert!(is_expected_disconnect(&ConnectionError::ConnectionClosed));
-    }
-
-    fn get_test_config(wal_dir_path: &Path) -> LaunchConfig {
-        LaunchConfig {
-            port: 22208,
-            host: "127.0.0.1".to_string(),
-            data_directory: "./test_db_data".to_string(),
-            wal_enabled: true,
-            wal_directory: wal_dir_path.to_str().unwrap().to_string(),
-            wal_segment_size: 1024,
-            wal_extension: "waltest".to_string(),
-        }
     }
 
     async fn setup_test_wal_dir(test_name: &str) -> PathBuf {
@@ -197,9 +185,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn wal_flush_loop_periodically_checkpoints_current_wal() {
-        let wal_dir = setup_test_wal_dir("wal_flush_loop_checkpoints").await;
-        let config = get_test_config(&wal_dir);
+    async fn durability_flush_loop_syncs_rows_before_checkpointing_wal() {
+        let wal_dir = setup_test_wal_dir("durability_flush_loop").await;
+        let base_path = wal_dir.join("base");
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        let table_name = TableName::new(Some("rrdb".to_string()), "users".to_string());
+        let rows_path = PathBuf::from(&config.data_directory)
+            .join("rrdb")
+            .join("tables")
+            .join("users")
+            .join("rows");
+        tokio::fs::create_dir_all(&rows_path).await.unwrap();
+        tokio::fs::create_dir_all(&config.wal_directory)
+            .await
+            .unwrap();
+
         let decoder = BincodeDecoder::new();
         let encoder = BincodeEncoder::new();
         let wal_manager = Arc::new(Mutex::new(
@@ -208,6 +208,14 @@ mod tests {
                 .await
                 .unwrap(),
         ));
+        let engine = Arc::new(DBEngine::new(config.clone()));
+        let row = TableDataRow {
+            fields: vec![TableDataField {
+                table_name: table_name.clone(),
+                column_name: "id".to_string(),
+                data: TableDataFieldType::Integer(1),
+            }],
+        };
 
         wal_manager
             .lock()
@@ -215,9 +223,15 @@ mod tests {
             .append_record(EntryType::Insert, Some(b"row-1".to_vec()), None)
             .await
             .unwrap();
+        engine.append_table_rows(&table_name, &[row]).await.unwrap();
+        engine.flush_row_buffers().await.unwrap();
+        assert!(!engine.row_buffer_pool.lock().await.is_unsynced_empty());
 
-        let flush_task = spawn_wal_flush_loop(wal_manager, Duration::from_millis(10));
-        let wal_path = wal_dir.join(format!("00000001.{}", config.wal_extension));
+        let flush_task =
+            spawn_durability_flush_loop(engine.clone(), wal_manager, Duration::from_millis(10));
+        let wal_path =
+            PathBuf::from(&config.wal_directory).join(format!("00000001.{}", config.wal_extension));
+        let segment_path = rows_path.join("00000001.rows");
 
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {
@@ -228,50 +242,8 @@ mod tests {
                     .iter()
                     .any(|entry| matches!(entry.entry_type, EntryType::Checkpoint))
                 {
-                    break;
-                }
-
-                tokio::time::sleep(Duration::from_millis(5)).await;
-            }
-        })
-        .await
-        .unwrap();
-
-        flush_task.abort();
-    }
-
-    #[tokio::test]
-    async fn row_flush_loop_periodically_writes_buffered_rows() {
-        let wal_dir = setup_test_wal_dir("row_flush_loop_writes_rows").await;
-        let base_path = wal_dir.join("base");
-        let config = LaunchConfig::default_for_base_path(&base_path);
-        let table_name = TableName::new(Some("rrdb".to_string()), "users".to_string());
-        let rows_path = PathBuf::from(&config.data_directory)
-            .join("rrdb")
-            .join("tables")
-            .join("users")
-            .join("rows");
-        tokio::fs::create_dir_all(&rows_path).await.unwrap();
-
-        let engine = Arc::new(DBEngine::new(config));
-        let row = TableDataRow {
-            fields: vec![TableDataField {
-                table_name: table_name.clone(),
-                column_name: "id".to_string(),
-                data: TableDataFieldType::Integer(1),
-            }],
-        };
-
-        engine.append_table_rows(&table_name, &[row]).await.unwrap();
-
-        let segment_path = rows_path.join("00000001.rows");
-        assert!(!segment_path.exists());
-
-        let flush_task = spawn_row_flush_loop(engine, Duration::from_millis(10));
-
-        tokio::time::timeout(Duration::from_secs(1), async {
-            loop {
-                if segment_path.exists() {
+                    assert!(segment_path.exists());
+                    assert!(engine.row_buffer_pool.lock().await.is_unsynced_empty());
                     break;
                 }
 

--- a/src/engine/wal/endec/implements/bincode.rs
+++ b/src/engine/wal/endec/implements/bincode.rs
@@ -50,6 +50,10 @@ impl WALDecoder<Vec<WALEntry>> for BincodeDecoder {
 
         while offset < data.len() {
             if data.len() - offset < size_of::<u32>() {
+                if data[offset..].iter().all(|byte| *byte == 0) {
+                    break;
+                }
+
                 return Err(WALError::wrap("truncated wal frame header".to_string()));
             }
 
@@ -59,6 +63,10 @@ impl WALDecoder<Vec<WALEntry>> for BincodeDecoder {
                     .map_err(|e| WALError::wrap(format!("{:?}", e)))?,
             ) as usize;
             offset += size_of::<u32>();
+
+            if frame_len == 0 {
+                break;
+            }
 
             if data.len() - offset < frame_len {
                 return Err(WALError::wrap("truncated wal frame body".to_string()));

--- a/src/engine/wal/manager/builder.rs
+++ b/src/engine/wal/manager/builder.rs
@@ -22,11 +22,12 @@ impl<'a> WALBuilder<'a> {
         T: WALDecoder<Vec<WALEntry>>,
         D: WALEncoder<WALEntry>,
     {
-        let (sequence, entries) = self.load_data(decoder).await?;
+        let (sequence, entries, current_offset) = self.load_data(decoder).await?;
 
         Ok(WALManager::new(
             sequence,
             entries,
+            current_offset,
             self.config.wal_segment_size as usize,
             PathBuf::from(self.config.wal_directory.clone()),
             self.config.wal_extension.to_string(),
@@ -34,7 +35,7 @@ impl<'a> WALBuilder<'a> {
         ))
     }
 
-    async fn load_data<T>(&self, decoder: T) -> errors::Result<(usize, Vec<WALEntry>)>
+    async fn load_data<T>(&self, decoder: T) -> errors::Result<(usize, Vec<WALEntry>, usize)>
     where
         T: WALDecoder<Vec<WALEntry>>,
     {
@@ -68,11 +69,11 @@ impl<'a> WALBuilder<'a> {
             }
         }
 
-        let (current_sequence, entries) = match last_log_path {
+        let (current_sequence, entries, current_offset) = match last_log_path {
             // Case 1: WAL 파일이 하나도 없는 초기 상태
             None => {
                 // 첫 번째 WAL 파일이므로 시퀀스는 1로 시작하고, 복구할 엔트리는 없음
-                Ok::<(usize, Vec<WALEntry>), errors::Errors>((1, Vec::new()))
+                Ok::<(usize, Vec<WALEntry>, usize), errors::Errors>((1, Vec::new(), 0))
             }
             // Case 2: 최신 WAL 파일이 존재하는 상태
             Some(log_path) => {
@@ -83,9 +84,10 @@ impl<'a> WALBuilder<'a> {
 
                 // 파일 내용이 비어있는 경우 복구할 엔트리는 없음
                 if content.is_empty() {
-                    return Ok((max_sequence + 1, Vec::new()));
+                    return Ok((max_sequence + 1, Vec::new(), 0));
                 }
 
+                let used_bytes = used_wal_bytes(&content)?;
                 let saved_entries: Vec<WALEntry> = decoder.decode(&content).map_err(|e| {
                     WALError::wrap(format!(
                         "failed to decode log file {:?}: {}",
@@ -96,18 +98,52 @@ impl<'a> WALBuilder<'a> {
 
                 let last_entry = match saved_entries.last() {
                     Some(entry) => entry,
-                    None => return Ok((max_sequence + 1, Vec::new())),
+                    None => return Ok((max_sequence + 1, Vec::new(), 0)),
                 };
 
                 if matches!(last_entry.entry_type, EntryType::Checkpoint) {
-                    Ok((max_sequence + 1, Vec::new()))
+                    Ok((max_sequence + 1, Vec::new(), 0))
                 } else {
                     // 마지막 엔트리가 체크포인트가 아니면 비정상 종료로 간주
-                    Ok((max_sequence, saved_entries))
+                    Ok((max_sequence, saved_entries, used_bytes))
                 }
             }
         }?;
 
-        Ok((current_sequence, entries))
+        Ok((current_sequence, entries, current_offset))
     }
+}
+
+fn used_wal_bytes(content: &[u8]) -> errors::Result<usize> {
+    let mut offset = 0;
+
+    while offset < content.len() {
+        if content.len() - offset < size_of::<u32>() {
+            if content[offset..].iter().all(|byte| *byte == 0) {
+                return Ok(offset);
+            }
+
+            return Err(WALError::wrap("truncated wal frame header".to_string()));
+        }
+
+        let frame_len = u32::from_le_bytes(
+            content[offset..offset + size_of::<u32>()]
+                .try_into()
+                .map_err(|e| WALError::wrap(format!("{:?}", e)))?,
+        ) as usize;
+
+        if frame_len == 0 {
+            return Ok(offset);
+        }
+
+        offset += size_of::<u32>();
+
+        if content.len() - offset < frame_len {
+            return Err(WALError::wrap("truncated wal frame body".to_string()));
+        }
+
+        offset += frame_len;
+    }
+
+    Ok(offset)
 }

--- a/src/engine/wal/manager/mod.rs
+++ b/src/engine/wal/manager/mod.rs
@@ -7,6 +7,7 @@ use std::time::SystemTime;
 use crate::errors;
 use crate::errors::wal_errors::WALError;
 use memmap2::{MmapMut, MmapOptions};
+use tokio::task;
 
 use super::{
     endec::WALEncoder,
@@ -87,6 +88,10 @@ where
         .await
     }
 
+    pub(crate) fn pending_entries(&self) -> &[WALEntry] {
+        &self.buffers
+    }
+
     async fn write_entry(&mut self, entry: WALEntry) -> errors::Result<()> {
         let mut frame = Vec::new();
         frame.extend_from_slice(&0u32.to_le_bytes());
@@ -96,7 +101,7 @@ where
         frame[..size_of::<u32>()].copy_from_slice(&frame_len.to_le_bytes());
 
         self.rotate_if_needed(frame.len()).await?;
-        self.append_frame_to_mmap(&frame)?;
+        self.append_frame_to_mmap(&frame).await?;
 
         self.buffers.push(entry);
 
@@ -127,8 +132,8 @@ where
             .join(format!("{:08X}.{}", self.sequence, self.extension))
     }
 
-    fn append_frame_to_mmap(&mut self, frame: &[u8]) -> errors::Result<()> {
-        self.open_current_segment_if_needed()?;
+    async fn append_frame_to_mmap(&mut self, frame: &[u8]) -> errors::Result<()> {
+        self.open_current_segment_if_needed().await?;
 
         let segment = self
             .current_segment
@@ -147,52 +152,66 @@ where
         Ok(())
     }
 
-    fn open_current_segment_if_needed(&mut self) -> errors::Result<()> {
+    async fn open_current_segment_if_needed(&mut self) -> errors::Result<()> {
         if self.current_segment.is_some() {
             return Ok(());
         }
 
         let path = self.current_path();
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| WALError::wrap(e.to_string()))?;
-        }
+        let page_size = self.page_size;
+        let offset = self.current_offset;
+        let segment = task::spawn_blocking(move || -> errors::Result<WALSegmentWriter> {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| WALError::wrap(e.to_string()))?;
+            }
 
-        let file = OpenOptions::new()
-            .create(true)
-            .read(true)
-            .write(true)
-            .open(&path)
-            .map_err(|e| WALError::wrap(e.to_string()))?;
-        file.set_len(self.page_size as u64)
-            .map_err(|e| WALError::wrap(e.to_string()))?;
-        let mmap = unsafe {
-            MmapOptions::new()
-                .len(self.page_size)
-                .map_mut(&file)
-                .map_err(|e| WALError::wrap(e.to_string()))?
-        };
+            let file = OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .open(&path)
+                .map_err(|e| WALError::wrap(e.to_string()))?;
+            file.set_len(page_size as u64)
+                .map_err(|e| WALError::wrap(e.to_string()))?;
+            let mmap = unsafe {
+                MmapOptions::new()
+                    .len(page_size)
+                    .map_mut(&file)
+                    .map_err(|e| WALError::wrap(e.to_string()))?
+            };
 
-        self.current_segment = Some(WALSegmentWriter {
-            file,
-            mmap,
-            offset: self.current_offset,
-        });
+            Ok(WALSegmentWriter { file, mmap, offset })
+        })
+        .await
+        .map_err(|e| WALError::wrap(e.to_string()))??;
+
+        self.current_segment = Some(segment);
         Ok(())
     }
 
     pub(crate) async fn sync_current_file(&mut self) -> errors::Result<()> {
-        let Some(segment) = self.current_segment.as_mut() else {
+        let Some(segment) = self.current_segment.take() else {
             return Ok(());
         };
 
-        segment
-            .mmap
-            .flush()
-            .map_err(|e| WALError::wrap(e.to_string()))?;
-        segment
-            .file
-            .sync_data()
-            .map_err(|e| WALError::wrap(e.to_string()))?;
+        let (segment, sync_error) = task::spawn_blocking(move || {
+            let sync_error = segment
+                .mmap
+                .flush()
+                .err()
+                .or_else(|| segment.file.sync_data().err())
+                .map(|error| error.to_string());
+
+            (segment, sync_error)
+        })
+        .await
+        .map_err(|e| WALError::wrap(e.to_string()))?;
+
+        self.current_segment = Some(segment);
+        if let Some(error) = sync_error {
+            return Err(WALError::wrap(error));
+        }
 
         Ok(())
     }

--- a/src/engine/wal/manager/mod.rs
+++ b/src/engine/wal/manager/mod.rs
@@ -1,19 +1,19 @@
 pub mod builder;
 
-use std::io::ErrorKind;
+use std::fs::OpenOptions;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
 use crate::errors;
 use crate::errors::wal_errors::WALError;
-use tokio::io::AsyncWriteExt;
+use memmap2::{MmapMut, MmapOptions};
 
 use super::{
     endec::WALEncoder,
     types::{EntryType, WALEntry},
 };
 
-#[derive(Default, Debug, Clone)]
+#[derive(Debug)]
 pub struct WALManager<T>
 where
     T: WALEncoder<WALEntry>,
@@ -29,6 +29,15 @@ where
     /// The extension of the WAL file
     extension: String,
     encoder: T,
+    current_segment: Option<WALSegmentWriter>,
+    current_offset: usize,
+}
+
+#[derive(Debug)]
+struct WALSegmentWriter {
+    file: std::fs::File,
+    mmap: MmapMut,
+    offset: usize,
 }
 
 // TODO: gz 압축 구현
@@ -40,6 +49,7 @@ where
     fn new(
         sequence: usize,
         entries: Vec<WALEntry>,
+        current_offset: usize,
         page_size: usize,
         directory: PathBuf,
         extension: String,
@@ -52,6 +62,8 @@ where
             directory,
             extension,
             encoder,
+            current_segment: None,
+            current_offset,
         }
     }
 
@@ -76,8 +88,6 @@ where
     }
 
     async fn write_entry(&mut self, entry: WALEntry) -> errors::Result<()> {
-        self.rotate_if_needed(entry.size()).await?;
-
         let mut frame = Vec::new();
         frame.extend_from_slice(&0u32.to_le_bytes());
         self.encoder.encode_into(&mut frame, &entry)?;
@@ -85,21 +95,8 @@ where
             .map_err(|_| WALError::wrap("wal entry is too large".to_string()))?;
         frame[..size_of::<u32>()].copy_from_slice(&frame_len.to_le_bytes());
 
-        let path = self.current_path();
-
-        let mut file = tokio::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-            .await
-            .map_err(|e| WALError::wrap(e.to_string()))?;
-
-        file.write_all(&frame)
-            .await
-            .map_err(|e| WALError::wrap(e.to_string()))?;
-        file.flush()
-            .await
-            .map_err(|e| WALError::wrap(e.to_string()))?;
+        self.rotate_if_needed(frame.len()).await?;
+        self.append_frame_to_mmap(&frame)?;
 
         self.buffers.push(entry);
 
@@ -107,12 +104,19 @@ where
     }
 
     async fn rotate_if_needed(&mut self, incoming_size: usize) -> errors::Result<()> {
-        let current_size = self.buffers.iter().map(|entry| entry.size()).sum::<usize>();
+        if incoming_size > self.page_size {
+            return Err(WALError::wrap(format!(
+                "wal frame is larger than segment size: {} > {}",
+                incoming_size, self.page_size
+            )));
+        }
 
-        if !self.buffers.is_empty() && current_size + incoming_size > self.page_size {
+        if self.current_offset > 0 && self.current_offset + incoming_size > self.page_size {
             self.sync_current_file().await?;
+            self.current_segment = None;
             self.sequence += 1;
             self.buffers.clear();
+            self.current_offset = 0;
         }
 
         Ok(())
@@ -123,22 +127,72 @@ where
             .join(format!("{:08X}.{}", self.sequence, self.extension))
     }
 
-    async fn sync_current_file(&self) -> errors::Result<()> {
-        let path = self.current_path();
+    fn append_frame_to_mmap(&mut self, frame: &[u8]) -> errors::Result<()> {
+        self.open_current_segment_if_needed()?;
 
-        match tokio::fs::OpenOptions::new()
+        let segment = self
+            .current_segment
+            .as_mut()
+            .ok_or_else(|| WALError::wrap("wal segment is not open".to_string()))?;
+        let end_offset = segment.offset + frame.len();
+
+        if end_offset > self.page_size {
+            return Err(WALError::wrap("wal segment overflow".to_string()));
+        }
+
+        segment.mmap[segment.offset..end_offset].copy_from_slice(frame);
+        segment.offset = end_offset;
+        self.current_offset = end_offset;
+
+        Ok(())
+    }
+
+    fn open_current_segment_if_needed(&mut self) -> errors::Result<()> {
+        if self.current_segment.is_some() {
+            return Ok(());
+        }
+
+        let path = self.current_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| WALError::wrap(e.to_string()))?;
+        }
+
+        let file = OpenOptions::new()
+            .create(true)
             .read(true)
             .write(true)
-            .open(path)
-            .await
-        {
-            Ok(file) => file
-                .sync_data()
-                .await
-                .map_err(|e| WALError::wrap(e.to_string()))?,
-            Err(error) if error.kind() == ErrorKind::NotFound => {}
-            Err(error) => return Err(WALError::wrap(error.to_string())),
-        }
+            .open(&path)
+            .map_err(|e| WALError::wrap(e.to_string()))?;
+        file.set_len(self.page_size as u64)
+            .map_err(|e| WALError::wrap(e.to_string()))?;
+        let mmap = unsafe {
+            MmapOptions::new()
+                .len(self.page_size)
+                .map_mut(&file)
+                .map_err(|e| WALError::wrap(e.to_string()))?
+        };
+
+        self.current_segment = Some(WALSegmentWriter {
+            file,
+            mmap,
+            offset: self.current_offset,
+        });
+        Ok(())
+    }
+
+    pub(crate) async fn sync_current_file(&mut self) -> errors::Result<()> {
+        let Some(segment) = self.current_segment.as_mut() else {
+            return Ok(());
+        };
+
+        segment
+            .mmap
+            .flush()
+            .map_err(|e| WALError::wrap(e.to_string()))?;
+        segment
+            .file
+            .sync_data()
+            .map_err(|e| WALError::wrap(e.to_string()))?;
 
         Ok(())
     }
@@ -147,13 +201,19 @@ where
         self.append_record(EntryType::Checkpoint, None, None)
             .await?;
         self.sync_current_file().await?;
+        self.current_segment = None;
         self.sequence += 1;
         self.buffers.clear();
+        self.current_offset = 0;
 
         Ok(())
     }
 
     pub async fn flush(&mut self) -> errors::Result<()> {
+        if self.buffers.is_empty() && self.current_segment.is_none() {
+            return Ok(());
+        }
+
         self.checkpoint().await?;
         Ok(())
     }
@@ -320,6 +380,7 @@ mod tests {
             .append_record(EntryType::Delete, Some(b"row-2".to_vec()), Some(2))
             .await
             .unwrap();
+        wal_manager.sync_current_file().await.unwrap();
 
         let wal_path = wal_dir.join(format!("00000001.{}", config.wal_extension));
         let content = tokio::fs::read(wal_path).await.unwrap();
@@ -347,6 +408,7 @@ mod tests {
             .append_record(EntryType::Insert, Some(b"row-1".to_vec()), Some(1))
             .await
             .unwrap();
+        wal_manager.sync_current_file().await.unwrap();
 
         let wal_path = wal_dir.join(format!("00000001.{}", config.wal_extension));
         let content = tokio::fs::read(wal_path).await.unwrap();
@@ -358,6 +420,72 @@ mod tests {
         assert!(matches!(entry.entry_type, EntryType::Insert));
         assert_eq!(entry.transaction_id, Some(1));
         assert_eq!(entry.data, Some(b"row-1".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_append_record_appends_to_mmap_segment_without_pending_write_buffer() {
+        let wal_dir = setup_test_wal_dir("append_record_mmap_segment").await;
+        let config = get_test_config(&wal_dir);
+
+        let builder = WALBuilder::new(&config);
+        let encoder = BincodeEncoder::new();
+        let decoder = BincodeDecoder::new();
+        let mut wal_manager = builder.build(decoder, encoder).await.unwrap();
+
+        wal_manager
+            .append_record(EntryType::Insert, Some(b"row-1".to_vec()), Some(1))
+            .await
+            .unwrap();
+
+        assert!(wal_manager.current_segment.is_some());
+        assert!(wal_manager.current_offset > 0);
+
+        let wal_path = wal_dir.join(format!("00000001.{}", config.wal_extension));
+        let metadata = tokio::fs::metadata(wal_path).await.unwrap();
+        assert_eq!(metadata.len(), config.wal_segment_size as u64);
+    }
+
+    #[tokio::test]
+    async fn test_build_restores_append_offset_from_mmap_segment() {
+        let wal_dir = setup_test_wal_dir("build_restores_mmap_offset").await;
+        let config = get_test_config(&wal_dir);
+
+        let decoder = BincodeDecoder::new();
+        let encoder = BincodeEncoder::new();
+        let mut wal_manager = WALBuilder::new(&config)
+            .build(decoder.clone(), encoder)
+            .await
+            .unwrap();
+
+        wal_manager
+            .append_record(EntryType::Insert, Some(b"row-1".to_vec()), Some(1))
+            .await
+            .unwrap();
+        wal_manager.sync_current_file().await.unwrap();
+        let first_offset = wal_manager.current_offset;
+        drop(wal_manager);
+
+        let mut rebuilt = WALBuilder::new(&config)
+            .build(decoder.clone(), BincodeEncoder::new())
+            .await
+            .unwrap();
+
+        assert_eq!(rebuilt.sequence, 1);
+        assert_eq!(rebuilt.current_offset, first_offset);
+
+        rebuilt
+            .append_record(EntryType::Delete, Some(b"row-2".to_vec()), Some(2))
+            .await
+            .unwrap();
+        rebuilt.sync_current_file().await.unwrap();
+
+        let wal_path = wal_dir.join(format!("00000001.{}", config.wal_extension));
+        let content = tokio::fs::read(wal_path).await.unwrap();
+        let entries = decoder.decode(&content).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert!(matches!(entries[0].entry_type, EntryType::Insert));
+        assert!(matches!(entries[1].entry_type, EntryType::Delete));
     }
 
     #[tokio::test]

--- a/src/engine/wal/mod.rs
+++ b/src/engine/wal/mod.rs
@@ -1,3 +1,4 @@
 pub mod endec;
 pub mod manager;
+pub mod recovery;
 pub mod types;

--- a/src/engine/wal/recovery.rs
+++ b/src/engine/wal/recovery.rs
@@ -1,0 +1,162 @@
+use crate::engine::DBEngine;
+use crate::engine::ast::types::TableName;
+use crate::engine::schema::row::TableDataRow;
+use crate::engine::wal::endec::WALEncoder;
+use crate::engine::wal::manager::WALManager;
+use crate::engine::wal::types::{EntryType, WALEntry};
+use crate::errors;
+use crate::errors::execute_error::ExecuteError;
+
+impl DBEngine {
+    pub(crate) async fn recover_from_wal<T>(
+        &self,
+        wal_manager: &mut WALManager<T>,
+    ) -> errors::Result<()>
+    where
+        T: WALEncoder<WALEntry>,
+    {
+        self.replay_wal_entries(wal_manager.pending_entries())
+            .await?;
+        self.flush_row_buffers_durable().await?;
+        wal_manager.flush().await
+    }
+
+    async fn replay_wal_entries(&self, entries: &[WALEntry]) -> errors::Result<()> {
+        for entry in entries {
+            if matches!(entry.entry_type, EntryType::Insert) {
+                let Some(data) = entry.data.as_deref() else {
+                    continue;
+                };
+                let (table_name, rows): (TableName, Vec<TableDataRow>) = bincode::deserialize(data)
+                    .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+                self.append_table_rows(&table_name, &rows).await?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use tokio::io::AsyncWriteExt;
+
+    use crate::config::launch_config::LaunchConfig;
+    use crate::engine::DBEngine;
+    use crate::engine::ast::types::TableName;
+    use crate::engine::encoder::schema_encoder::StorageEncoder;
+    use crate::engine::schema::row::{TableDataField, TableDataFieldType, TableDataRow};
+    use crate::engine::wal::endec::WALEncoder;
+    use crate::engine::wal::endec::implements::bincode::{BincodeDecoder, BincodeEncoder};
+    use crate::engine::wal::manager::builder::WALBuilder;
+    use crate::engine::wal::types::{EntryType, WALEntry};
+
+    async fn setup_base_path(test_name: &str) -> PathBuf {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let base_path = PathBuf::from("target")
+            .join("test_wal_recovery")
+            .join(format!("{test_name}_{now}"));
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+        tokio::fs::create_dir_all(&base_path).await.unwrap();
+        base_path
+    }
+
+    async fn write_wal_entries(config: &LaunchConfig, entries: &[WALEntry]) {
+        tokio::fs::create_dir_all(&config.wal_directory)
+            .await
+            .unwrap();
+        let wal_path =
+            Path::new(&config.wal_directory).join(format!("00000001.{}", config.wal_extension));
+        let encoder = BincodeEncoder::new();
+        let mut file = tokio::fs::File::create(&wal_path).await.unwrap();
+
+        for entry in entries {
+            let encoded_entry = encoder.encode(entry).unwrap();
+            file.write_all(&u32::try_from(encoded_entry.len()).unwrap().to_le_bytes())
+                .await
+                .unwrap();
+            file.write_all(&encoded_entry).await.unwrap();
+        }
+
+        file.sync_all().await.unwrap();
+    }
+
+    fn row(table_name: &TableName, value: i64) -> TableDataRow {
+        TableDataRow {
+            fields: vec![TableDataField {
+                table_name: table_name.clone(),
+                column_name: "id".to_string(),
+                data: TableDataFieldType::Integer(value),
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn recover_from_wal_replays_insert_entries() {
+        let base_path = setup_base_path("insert_entries").await;
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        let table_name = TableName::new(Some("rrdb".to_string()), "users".to_string());
+        let rows_path = PathBuf::from(&config.data_directory)
+            .join("rrdb")
+            .join("tables")
+            .join("users")
+            .join("rows");
+        tokio::fs::create_dir_all(&rows_path).await.unwrap();
+
+        let rows = vec![row(&table_name, 1), row(&table_name, 2)];
+        let wal_payload = bincode::serialize(&(table_name.clone(), rows)).unwrap();
+        let entry = WALEntry {
+            entry_type: EntryType::Insert,
+            data: Some(wal_payload),
+            timestamp: 1,
+            transaction_id: None,
+            is_continuation: false,
+        };
+        write_wal_entries(&config, &[entry]).await;
+
+        let mut wal_manager = WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .unwrap();
+        let engine = DBEngine::new(config);
+
+        engine.recover_from_wal(&mut wal_manager).await.unwrap();
+
+        let segment_path = rows_path.join("00000001.rows");
+        let content = tokio::fs::read(segment_path).await.unwrap();
+        let decoder = StorageEncoder::new();
+        let mut values = Vec::new();
+        let mut offset = 0;
+
+        while offset < content.len() {
+            let frame_len = u32::from_le_bytes(
+                content[offset..offset + size_of::<u32>()]
+                    .try_into()
+                    .unwrap(),
+            ) as usize;
+            offset += size_of::<u32>();
+            let row: TableDataRow = decoder
+                .decode(&content[offset..offset + frame_len])
+                .unwrap();
+            values.push(row.fields[0].data.clone());
+            offset += frame_len;
+        }
+
+        assert_eq!(
+            values,
+            vec![
+                TableDataFieldType::Integer(1),
+                TableDataFieldType::Integer(2)
+            ]
+        );
+        assert!(wal_manager.pending_entries().is_empty());
+    }
+}

--- a/src/pgwire/connection/connection.rs
+++ b/src/pgwire/connection/connection.rs
@@ -5,6 +5,9 @@ use std::collections::HashMap;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::Framed;
 
+use crate::engine::ast::dml::insert::InsertQuery;
+use crate::engine::ast::dml::parts::insert_values::InsertValue;
+use crate::engine::ast::types::{SQLExpression, TableName};
 use crate::engine::ast::{DDLStatement, DMLStatement, OtherStatement, SQLStatement};
 use crate::engine::lexer::predule::Tokenizer;
 use crate::engine::parser::context::ParserContext;
@@ -89,6 +92,158 @@ impl Connection {
                 "expected zero or one statements",
             )),
         }
+    }
+
+    fn query_has_parameters(text: &str) -> bool {
+        let bytes = text.as_bytes();
+        let mut index = 0;
+
+        while index + 1 < bytes.len() {
+            if bytes[index] == b'$' && bytes[index + 1].is_ascii_digit() {
+                return true;
+            }
+            index += 1;
+        }
+
+        false
+    }
+
+    fn quote_parameter(parameter: &Option<String>) -> String {
+        match parameter {
+            Some(value) => format!("'{}'", value.replace('\'', "''")),
+            None => "NULL".to_string(),
+        }
+    }
+
+    fn bind_query_parameters(
+        query: &str,
+        parameters: &[Option<String>],
+    ) -> Result<String, ErrorResponse> {
+        let bytes = query.as_bytes();
+        let mut bound = String::with_capacity(query.len());
+        let mut index = 0;
+        let mut in_string = false;
+
+        while index < bytes.len() {
+            match bytes[index] {
+                b'\'' => {
+                    bound.push('\'');
+                    index += 1;
+
+                    if in_string && index < bytes.len() && bytes[index] == b'\'' {
+                        bound.push('\'');
+                        index += 1;
+                    } else {
+                        in_string = !in_string;
+                    }
+                }
+                b'$' if !in_string
+                    && index + 1 < bytes.len()
+                    && bytes[index + 1].is_ascii_digit() =>
+                {
+                    index += 1;
+                    let number_start = index;
+
+                    while index < bytes.len() && bytes[index].is_ascii_digit() {
+                        index += 1;
+                    }
+
+                    let parameter_index: usize = query[number_start..index]
+                        .parse::<usize>()
+                        .map_err(|error| {
+                            ErrorResponse::error(SqlState::SYNTAX_ERROR, error.to_string())
+                        })?;
+
+                    if parameter_index == 0 || parameter_index > parameters.len() {
+                        return Err(ErrorResponse::error(
+                            SqlState::SYNTAX_ERROR,
+                            format!("missing bind parameter ${parameter_index}"),
+                        ));
+                    }
+
+                    bound.push_str(&Self::quote_parameter(&parameters[parameter_index - 1]));
+                }
+                byte => {
+                    bound.push(byte as char);
+                    index += 1;
+                }
+            }
+        }
+
+        Ok(bound)
+    }
+
+    fn parse_parameterized_insert(
+        &self,
+        query: &str,
+        parameters: &[Option<String>],
+    ) -> Option<SQLStatement> {
+        let lower = query.to_ascii_lowercase();
+        let after_insert = lower.strip_prefix("insert into ")?;
+        let table_start = query.len() - after_insert.len();
+        let columns_start = query[table_start..].find('(')? + table_start;
+        let table = query[table_start..columns_start].trim();
+        let columns_end = query[columns_start + 1..].find(')')? + columns_start + 1;
+        let columns = query[columns_start + 1..columns_end]
+            .split(',')
+            .map(str::trim)
+            .filter(|column| !column.is_empty())
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+
+        if columns.is_empty() {
+            return None;
+        }
+
+        let rest = query[columns_end + 1..].trim_start();
+        let rest_lower = rest.to_ascii_lowercase();
+        let values_rest = rest_lower.strip_prefix("values")?;
+        let values_start = rest.len() - values_rest.len();
+        let values = rest[values_start..].trim_start();
+        let value_start = values.find('(')?;
+        let value_end = values[value_start + 1..].find(')')? + value_start + 1;
+        let placeholders = values[value_start + 1..value_end]
+            .split(',')
+            .map(str::trim)
+            .collect::<Vec<_>>();
+
+        if placeholders.len() != columns.len() {
+            return None;
+        }
+
+        let mut expressions = Vec::with_capacity(placeholders.len());
+        for placeholder in placeholders {
+            let parameter_index = placeholder.strip_prefix('$')?.parse::<usize>().ok()?;
+            if parameter_index == 0 || parameter_index > parameters.len() {
+                return None;
+            }
+
+            let expression = match &parameters[parameter_index - 1] {
+                Some(value) => SQLExpression::String(value.clone()),
+                None => SQLExpression::Null,
+            };
+            expressions.push(Some(expression));
+        }
+
+        let table_name = match table.split_once('.') {
+            Some((database_name, table_name)) => TableName::new(
+                Some(database_name.trim().to_string()),
+                table_name.trim().to_string(),
+            ),
+            None => TableName::new(
+                Some(self.engine.shared_state.client_info.database.clone()),
+                table.to_string(),
+            ),
+        };
+
+        Some(
+            InsertQuery::builder()
+                .set_into_table(table_name)
+                .set_columns(columns)
+                .set_values(vec![InsertValue { list: expressions }])
+                .build()
+                .into(),
+        )
     }
 
     fn returns_rows(statement: &SQLStatement) -> bool {
@@ -240,7 +395,13 @@ impl Connection {
                     .ok_or(ConnectionError::ConnectionClosed)??
                 {
                     ClientMessage::Parse(parse) => {
-                        let parsed_statement = self.parse_statement(&parse.query)?;
+                        let has_parameters = !parse.parameter_types.is_empty()
+                            || Self::query_has_parameters(&parse.query);
+                        let parsed_statement = if has_parameters {
+                            None
+                        } else {
+                            self.parse_statement(&parse.query)?
+                        };
 
                         self.statements.insert(
                             parse.prepared_statement_name,
@@ -250,6 +411,11 @@ impl Connection {
                                     None => vec![],
                                 },
                                 statement: parsed_statement,
+                                raw_query: if has_parameters {
+                                    Some(parse.query)
+                                } else {
+                                    None
+                                },
                             },
                         );
                         framed.send(ParseComplete).await?;
@@ -270,7 +436,27 @@ impl Connection {
                             .prepared_statement(&bind.prepared_statement_name)?
                             .clone();
 
-                        let portal = match prepared.statement {
+                        let prepared_statement = match prepared.statement {
+                            Some(statement) => Some(statement),
+                            None => match prepared.raw_query {
+                                Some(query) => {
+                                    match self.parse_parameterized_insert(&query, &bind.parameters)
+                                    {
+                                        Some(statement) => Some(statement),
+                                        None => {
+                                            let bound_query = Self::bind_query_parameters(
+                                                &query,
+                                                &bind.parameters,
+                                            )?;
+                                            self.parse_statement(&bound_query)?
+                                        }
+                                    }
+                                }
+                                None => None,
+                            },
+                        };
+
+                        let portal = match prepared_statement {
                             Some(statement) => {
                                 let portal = self.engine.create_portal(&statement).await?;
                                 let fields = if Self::returns_rows(&statement) {
@@ -443,5 +629,91 @@ impl Connection {
 
             self.state = new_state;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use tokio::sync::Mutex;
+
+    use crate::config::launch_config::LaunchConfig;
+    use crate::engine::DBEngine;
+    use crate::engine::ast::DMLStatement;
+    use crate::engine::server::client::ClientInfo;
+    use crate::engine::server::shared_state::SharedState;
+    use crate::engine::wal::endec::implements::bincode::{BincodeDecoder, BincodeEncoder};
+    use crate::engine::wal::manager::builder::WALBuilder;
+
+    use super::Connection;
+
+    #[test]
+    fn bind_query_parameters_quotes_and_escapes_text_values() {
+        let query = "insert into key_value (key, value) values ($1, $2)";
+        let bound = Connection::bind_query_parameters(
+            query,
+            &[Some("a'b".to_string()), Some("value".to_string())],
+        )
+        .unwrap();
+
+        assert_eq!(
+            bound,
+            "insert into key_value (key, value) values ('a''b', 'value')"
+        );
+    }
+
+    #[test]
+    fn bind_query_parameters_keeps_placeholders_inside_string_literals() {
+        let query = "select '$1', $1";
+        let bound = Connection::bind_query_parameters(query, &[Some("real".to_string())]).unwrap();
+
+        assert_eq!(bound, "select '$1', 'real'");
+    }
+
+    #[tokio::test]
+    async fn parse_parameterized_insert_builds_insert_statement_without_sql_reparse() {
+        let base_path = PathBuf::from("target/test_pgwire_parameterized_insert");
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        tokio::fs::create_dir_all(&config.data_directory)
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(&config.wal_directory)
+            .await
+            .unwrap();
+        let wal = WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .unwrap();
+        let connection = Connection::new(SharedState {
+            engine: Arc::new(DBEngine::new(config)),
+            wal_manager: Arc::new(Mutex::new(wal)),
+            client_info: ClientInfo {
+                ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+                connection_id: "test".to_string(),
+                database: "rrdb".to_string(),
+            },
+        });
+
+        let statement = connection
+            .parse_parameterized_insert(
+                "INSERT INTO key_value (key, value) VALUES ($1, $2)",
+                &[Some("k1".to_string()), Some("v1".to_string())],
+            )
+            .unwrap();
+
+        let insert = match statement {
+            crate::engine::ast::SQLStatement::DML(DMLStatement::InsertQuery(insert)) => insert,
+            other => panic!("expected insert statement, got {other:?}"),
+        };
+
+        assert_eq!(insert.into_table.unwrap().table_name, "key_value");
+        assert_eq!(insert.columns, vec!["key", "value"]);
     }
 }

--- a/src/pgwire/connection/connection.rs
+++ b/src/pgwire/connection/connection.rs
@@ -7,7 +7,7 @@ use tokio_util::codec::Framed;
 
 use crate::engine::ast::dml::insert::InsertQuery;
 use crate::engine::ast::dml::parts::insert_values::InsertValue;
-use crate::engine::ast::types::{SQLExpression, TableName};
+use crate::engine::ast::types::{DataType, SQLExpression, TableName};
 use crate::engine::ast::{DDLStatement, DMLStatement, OtherStatement, SQLStatement};
 use crate::engine::lexer::predule::Tokenizer;
 use crate::engine::parser::context::ParserContext;
@@ -97,12 +97,27 @@ impl Connection {
     fn query_has_parameters(text: &str) -> bool {
         let bytes = text.as_bytes();
         let mut index = 0;
+        let mut in_string = false;
 
-        while index + 1 < bytes.len() {
-            if bytes[index] == b'$' && bytes[index + 1].is_ascii_digit() {
-                return true;
+        while index < bytes.len() {
+            match bytes[index] {
+                b'\'' => {
+                    index += 1;
+
+                    if in_string && index < bytes.len() && bytes[index] == b'\'' {
+                        index += 1;
+                    } else {
+                        in_string = !in_string;
+                    }
+                }
+                b'$' if !in_string
+                    && index + 1 < bytes.len()
+                    && bytes[index + 1].is_ascii_digit() =>
+                {
+                    return true;
+                }
+                _ => index += 1,
             }
-            index += 1;
         }
 
         false
@@ -120,18 +135,18 @@ impl Connection {
         parameters: &[Option<String>],
     ) -> Result<String, ErrorResponse> {
         let bytes = query.as_bytes();
-        let mut bound = String::with_capacity(query.len());
+        let mut bound = Vec::with_capacity(query.len());
         let mut index = 0;
         let mut in_string = false;
 
         while index < bytes.len() {
             match bytes[index] {
                 b'\'' => {
-                    bound.push('\'');
+                    bound.push(b'\'');
                     index += 1;
 
                     if in_string && index < bytes.len() && bytes[index] == b'\'' {
-                        bound.push('\'');
+                        bound.push(b'\'');
                         index += 1;
                     } else {
                         in_string = !in_string;
@@ -161,19 +176,22 @@ impl Connection {
                         ));
                     }
 
-                    bound.push_str(&Self::quote_parameter(&parameters[parameter_index - 1]));
+                    bound.extend_from_slice(
+                        Self::quote_parameter(&parameters[parameter_index - 1]).as_bytes(),
+                    );
                 }
                 byte => {
-                    bound.push(byte as char);
+                    bound.push(byte);
                     index += 1;
                 }
             }
         }
 
-        Ok(bound)
+        String::from_utf8(bound)
+            .map_err(|error| ErrorResponse::error(SqlState::SYNTAX_ERROR, error.to_string()))
     }
 
-    fn parse_parameterized_insert(
+    async fn parse_parameterized_insert(
         &self,
         query: &str,
         parameters: &[Option<String>],
@@ -211,18 +229,9 @@ impl Connection {
             return None;
         }
 
-        let mut expressions = Vec::with_capacity(placeholders.len());
-        for placeholder in placeholders {
-            let parameter_index = placeholder.strip_prefix('$')?.parse::<usize>().ok()?;
-            if parameter_index == 0 || parameter_index > parameters.len() {
-                return None;
-            }
-
-            let expression = match &parameters[parameter_index - 1] {
-                Some(value) => SQLExpression::String(value.clone()),
-                None => SQLExpression::Null,
-            };
-            expressions.push(Some(expression));
+        let trailing = values[value_end + 1..].trim_start();
+        if !trailing.is_empty() && trailing != ";" {
+            return None;
         }
 
         let table_name = match table.split_once('.') {
@@ -235,6 +244,29 @@ impl Connection {
                 table.to_string(),
             ),
         };
+        let table_config = self
+            .engine
+            .shared_state
+            .engine
+            .get_table_config_cached(table_name.clone())
+            .await
+            .ok()?;
+        let columns_map = table_config.get_columns_map();
+
+        let mut expressions = Vec::with_capacity(placeholders.len());
+        for (column_name, placeholder) in columns.iter().zip(placeholders) {
+            let parameter_index = placeholder.strip_prefix('$')?.parse::<usize>().ok()?;
+            if parameter_index == 0 || parameter_index > parameters.len() {
+                return None;
+            }
+
+            let column = columns_map.get(column_name)?;
+            let expression = Self::parameter_expression_for_column(
+                &parameters[parameter_index - 1],
+                &column.data_type,
+            )?;
+            expressions.push(Some(expression));
+        }
 
         Some(
             InsertQuery::builder()
@@ -244,6 +276,26 @@ impl Connection {
                 .build()
                 .into(),
         )
+    }
+
+    fn parameter_expression_for_column(
+        parameter: &Option<String>,
+        data_type: &DataType,
+    ) -> Option<SQLExpression> {
+        let Some(value) = parameter else {
+            return Some(SQLExpression::Null);
+        };
+
+        match data_type {
+            DataType::Int => value.parse::<i64>().ok().map(SQLExpression::Integer),
+            DataType::Float => value.parse::<f64>().ok().map(SQLExpression::Float),
+            DataType::Boolean => match value.to_ascii_lowercase().as_str() {
+                "true" | "t" | "1" => Some(SQLExpression::Boolean(true)),
+                "false" | "f" | "0" => Some(SQLExpression::Boolean(false)),
+                _ => None,
+            },
+            DataType::Varchar(_) => Some(SQLExpression::String(value.clone())),
+        }
     }
 
     fn returns_rows(statement: &SQLStatement) -> bool {
@@ -440,7 +492,9 @@ impl Connection {
                             Some(statement) => Some(statement),
                             None => match prepared.raw_query {
                                 Some(query) => {
-                                    match self.parse_parameterized_insert(&query, &bind.parameters)
+                                    match self
+                                        .parse_parameterized_insert(&query, &bind.parameters)
+                                        .await
                                     {
                                         Some(statement) => Some(statement),
                                         None => {
@@ -642,7 +696,11 @@ mod tests {
 
     use crate::config::launch_config::LaunchConfig;
     use crate::engine::DBEngine;
-    use crate::engine::ast::DMLStatement;
+    use crate::engine::ast::dml::insert::InsertData;
+    use crate::engine::ast::types::SQLExpression;
+    use crate::engine::ast::{DMLStatement, SQLStatement};
+    use crate::engine::parser::context::ParserContext;
+    use crate::engine::parser::predule::Parser;
     use crate::engine::server::client::ClientInfo;
     use crate::engine::server::shared_state::SharedState;
     use crate::engine::wal::endec::implements::bincode::{BincodeDecoder, BincodeEncoder};
@@ -673,9 +731,30 @@ mod tests {
         assert_eq!(bound, "select '$1', 'real'");
     }
 
-    #[tokio::test]
-    async fn parse_parameterized_insert_builds_insert_statement_without_sql_reparse() {
-        let base_path = PathBuf::from("target/test_pgwire_parameterized_insert");
+    #[test]
+    fn bind_query_parameters_preserves_utf8_query_text() {
+        let query = "insert into 한글_table (이름) values ($1)";
+        let bound = Connection::bind_query_parameters(query, &[Some("값".to_string())]).unwrap();
+
+        assert_eq!(bound, "insert into 한글_table (이름) values ('값')");
+    }
+
+    #[test]
+    fn query_has_parameters_ignores_placeholders_inside_string_literals() {
+        assert!(!Connection::query_has_parameters("select '$1'"));
+        assert!(Connection::query_has_parameters("select '$1', $1"));
+    }
+
+    fn parse_statement(sql: &str) -> SQLStatement {
+        let mut parser = Parser::with_string(sql.to_owned()).unwrap();
+        parser
+            .parse(ParserContext::default().set_default_database("rrdb".to_string()))
+            .unwrap()
+            .remove(0)
+    }
+
+    async fn build_test_connection(test_name: &str) -> Connection {
+        let base_path = PathBuf::from("target").join(test_name);
         if base_path.exists() {
             tokio::fs::remove_dir_all(&base_path).await.unwrap();
         }
@@ -691,7 +770,7 @@ mod tests {
             .build(BincodeDecoder::new(), BincodeEncoder::new())
             .await
             .unwrap();
-        let connection = Connection::new(SharedState {
+        Connection::new(SharedState {
             engine: Arc::new(DBEngine::new(config)),
             wal_manager: Arc::new(Mutex::new(wal)),
             client_info: ClientInfo {
@@ -699,13 +778,44 @@ mod tests {
                 connection_id: "test".to_string(),
                 database: "rrdb".to_string(),
             },
-        });
+        })
+    }
+
+    async fn execute_sql(connection: &Connection, sql: &str) {
+        connection
+            .engine
+            .shared_state
+            .engine
+            .process_query(
+                parse_statement(sql),
+                connection.engine.shared_state.wal_manager.clone(),
+                connection
+                    .engine
+                    .shared_state
+                    .client_info
+                    .connection_id
+                    .clone(),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn parse_parameterized_insert_builds_insert_statement_without_sql_reparse() {
+        let connection = build_test_connection("test_pgwire_parameterized_insert").await;
+        execute_sql(&connection, "create database rrdb").await;
+        execute_sql(
+            &connection,
+            "create table key_value (key varchar(255), value varchar(255))",
+        )
+        .await;
 
         let statement = connection
             .parse_parameterized_insert(
                 "INSERT INTO key_value (key, value) VALUES ($1, $2)",
                 &[Some("k1".to_string()), Some("v1".to_string())],
             )
+            .await
             .unwrap();
 
         let insert = match statement {
@@ -715,5 +825,62 @@ mod tests {
 
         assert_eq!(insert.into_table.unwrap().table_name, "key_value");
         assert_eq!(insert.columns, vec!["key", "value"]);
+    }
+
+    #[tokio::test]
+    async fn parse_parameterized_insert_rejects_multirow_fast_path() {
+        let connection = build_test_connection("test_pgwire_parameterized_insert_multirow").await;
+
+        let statement = connection
+            .parse_parameterized_insert(
+                "INSERT INTO key_value (key, value) VALUES ($1, $2), ($3, $4)",
+                &[
+                    Some("k1".to_string()),
+                    Some("v1".to_string()),
+                    Some("k2".to_string()),
+                    Some("v2".to_string()),
+                ],
+            )
+            .await;
+
+        assert!(statement.is_none());
+    }
+
+    #[tokio::test]
+    async fn parse_parameterized_insert_uses_target_column_types() {
+        let connection = build_test_connection("test_pgwire_parameterized_insert_types").await;
+        execute_sql(&connection, "create database rrdb").await;
+        execute_sql(
+            &connection,
+            "create table typed_values (id int, enabled boolean, ratio float, label varchar(255))",
+        )
+        .await;
+
+        let statement = connection
+            .parse_parameterized_insert(
+                "INSERT INTO typed_values (id, enabled, ratio, label) VALUES ($1, $2, $3, $4)",
+                &[
+                    Some("42".to_string()),
+                    Some("true".to_string()),
+                    Some("3.5".to_string()),
+                    Some("007".to_string()),
+                ],
+            )
+            .await
+            .unwrap();
+
+        let insert = match statement {
+            crate::engine::ast::SQLStatement::DML(DMLStatement::InsertQuery(insert)) => insert,
+            other => panic!("expected insert statement, got {other:?}"),
+        };
+        let InsertData::Values(values) = insert.data else {
+            panic!("expected insert values");
+        };
+        let values = &values[0].list;
+
+        assert_eq!(values[0], Some(SQLExpression::Integer(42)));
+        assert_eq!(values[1], Some(SQLExpression::Boolean(true)));
+        assert_eq!(values[2], Some(SQLExpression::Float(3.5)));
+        assert_eq!(values[3], Some(SQLExpression::String("007".to_string())));
     }
 }

--- a/src/pgwire/connection/prepared_statement.rs
+++ b/src/pgwire/connection/prepared_statement.rs
@@ -4,5 +4,6 @@ use crate::pgwire::protocol::backend::FieldDescription;
 #[derive(Debug, Clone)]
 pub struct PreparedStatement {
     pub statement: Option<SQLStatement>,
+    pub raw_query: Option<String>,
     pub fields: Vec<FieldDescription>,
 }

--- a/src/pgwire/engine/rrdb.rs
+++ b/src/pgwire/engine/rrdb.rs
@@ -155,6 +155,7 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr};
     use std::path::PathBuf;
     use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use tokio::sync::Mutex;
 
@@ -169,7 +170,18 @@ mod tests {
     use crate::pgwire::engine::{Engine, RRDBEngine};
 
     async fn build_test_engine(test_name: &str) -> RRDBEngine {
-        let base_path = PathBuf::from("target").join(test_name);
+        let test_binary = std::env::current_exe()
+            .ok()
+            .and_then(|path| path.file_stem().map(|stem| stem.to_os_string()))
+            .and_then(|stem| stem.into_string().ok())
+            .unwrap_or_else(|| "unknown".to_string());
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let base_path = PathBuf::from("target")
+            .join(test_name)
+            .join(format!("{test_binary}_{now}"));
         if base_path.exists() {
             tokio::fs::remove_dir_all(&base_path).await.unwrap();
         }

--- a/src/pgwire/protocol/connection_codec.rs
+++ b/src/pgwire/protocol/connection_codec.rs
@@ -211,9 +211,11 @@ impl Decoder for ConnectionCodec {
                 if num_params < 0 {
                     return Err(ProtocolError::ParserError);
                 }
+                let mut parameters = Vec::with_capacity(num_params as usize);
                 for _ in 0..num_params {
                     let param_len = Self::read_i32(&mut body)?;
                     if param_len == -1 {
+                        parameters.push(None);
                         continue;
                     }
                     if param_len < -1 {
@@ -224,6 +226,8 @@ impl Decoder for ConnectionCodec {
                     if body.len() < param_len {
                         return Err(ProtocolError::ParserError);
                     }
+                    let param = String::from_utf8(body[..param_len].to_vec())?;
+                    parameters.push(Some(param));
                     body.advance(param_len);
                 }
 
@@ -246,6 +250,7 @@ impl Decoder for ConnectionCodec {
                 ClientMessage::Bind(Bind {
                     portal,
                     prepared_statement_name,
+                    parameters,
                     result_format,
                 })
             }
@@ -337,6 +342,54 @@ mod tests {
         message.put_u8(0);
         message.put_i32(max_rows);
         message
+    }
+
+    fn bind_message(statement: &str, params: &[Option<&str>]) -> BytesMut {
+        let mut body = BytesMut::new();
+        body.put_u8(0);
+        body.put_slice(statement.as_bytes());
+        body.put_u8(0);
+        body.put_i16(0);
+        body.put_i16(params.len() as i16);
+
+        for param in params {
+            match param {
+                Some(value) => {
+                    body.put_i32(value.len() as i32);
+                    body.put_slice(value.as_bytes());
+                }
+                None => body.put_i32(-1),
+            }
+        }
+
+        body.put_i16(0);
+
+        let mut message = BytesMut::new();
+        message.put_u8(b'B');
+        message.put_i32((4 + body.len()) as i32);
+        message.extend_from_slice(&body);
+        message
+    }
+
+    #[test]
+    fn decodes_bind_text_parameters() {
+        let mut codec = ConnectionCodec {
+            startup_received: true,
+        };
+        let mut message = bind_message("sqlx_s_1", &[Some("alpha"), None, Some("42")]);
+
+        let decoded = codec.decode(&mut message).unwrap().unwrap();
+
+        match decoded {
+            ClientMessage::Bind(bind) => {
+                assert_eq!(bind.prepared_statement_name, "sqlx_s_1");
+                assert_eq!(
+                    bind.parameters,
+                    vec![Some("alpha".to_string()), None, Some("42".to_string())]
+                );
+            }
+            other => panic!("expected bind, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/pgwire/protocol/message/client/types/bind.rs
+++ b/src/pgwire/protocol/message/client/types/bind.rs
@@ -4,5 +4,6 @@ use super::BindFormat;
 pub struct Bind {
     pub portal: String,
     pub prepared_statement_name: String,
+    pub parameters: Vec<Option<String>>,
     pub result_format: BindFormat,
 }


### PR DESCRIPTION
resolves: #226

## 설명
1. 불필요한 Lock 주기 최소화 
2. WAL write를 mmap으로 대체 (10초 간격 flush)
3. 세그먼트 쓰기 시에 buffer pool을 통해 디스크 부하 완화

일단 20000 TPS까지는 어떻게 땡겼음. 이제 인덱스만 예쁘게 붙이면 될듯

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 바인드 처리 시 파라미터 타입이 비어 있어도 쿼리 본문을 기반으로 안전하게 준비/실행합니다.
  * 쓰기 작업은 버퍼를 우선 반영하고 플러시 시점에 일괄 반영해 스캔 정확성과 성능이 개선되었습니다.
  * WAL 복구와 내구성 플러시를 강화해 장애 후 데이터 일관성을 더 높였습니다.
* **Bug Fixes**
  * WAL/행 데이터 저장 형식 전환 및 복구 경계 동작이 개선되었습니다.
  * 바인드 메시지의 파라미터와 문자열 이스케이프/NULL 처리 오류가 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->