### PR TITLE
feat: add page-backed btree index manager path

### DIFF
--- a/benches/index_benchmark.rs
+++ b/benches/index_benchmark.rs
@@ -1,11 +1,16 @@
-//! Benchmarks for the B-tree index system (issue #160, PR #191)
+//! Benchmarks for the B-tree index system (issue #160, PR #191; page-backed
+//! disk path added in issue #230)
 //!
 //! Run with:
 //!   cargo bench --bench index_benchmark
 //!
 //! Measures:
 //!   1. BTreeIndex in-memory operations (insert, get, range, remove, update)
-//!   2. IndexManager memory+disk operations (insert with flush, get, range, reload)
+//!   2. IndexManager page-backed B+tree operations (insert, get, range,
+//!      reload) -- as of #230, IndexManager no longer rewrites the whole
+//!      index file on every mutation; each insert only touches the pages
+//!      on the path from the root to the affected leaf (see
+//!      `engine::index::page_btree`).
 //!   3. Scaling: 1K, 10K, 50K, 100K entries
 
 use std::time::{Duration, Instant};
@@ -207,7 +212,7 @@ fn bench_btree_update(n: usize) -> BenchResult {
     }
 }
 
-// ─── IndexManager (memory + disk) Benchmarks ────────────────────────────
+// ─── IndexManager (page-backed B+tree on disk) Benchmarks ──────────────
 
 async fn bench_manager_insert(n: usize) -> BenchResult {
     let dir = std::env::temp_dir().join(format!("rrdb_bench_insert_{}_{}", n, std::process::id()));
@@ -228,7 +233,7 @@ async fn bench_manager_insert(n: usize) -> BenchResult {
 
     let _ = tokio::fs::remove_dir_all(&dir).await;
     BenchResult {
-        name: format!("IndexManager::insert+flush (n={})", n),
+        name: format!("IndexManager::insert (page-backed, n={})", n),
         n,
         total,
     }
@@ -374,13 +379,16 @@ fn main() {
         println!();
     }
 
-    // ── IndexManager (memory + disk) ──
-    println!("--- IndexManager (memory + disk dual-write) ---");
+    // ── IndexManager (page-backed B+tree on disk) ──
+    println!("--- IndexManager (page-backed B+tree, issue #230) ---");
     println!();
 
-    // IndexManager disk writes are O(n^2) due to full-file rewrite on every mutation.
-    // 100K would take ~7 minutes. Cap at 50K for disk benchmarks.
-    let disk_scales: &[usize] = &[1_000, 10_000, 50_000];
+    // Prior to #230, IndexManager rewrote the entire index file on every
+    // mutation (O(n) work per insert, O(n^2) across n inserts), so 100K was
+    // capped out at ~50K to keep the benchmark run time reasonable. The
+    // page-backed B+tree only touches the pages on the root-to-leaf path
+    // per insert, so 100K is included here too.
+    let disk_scales: &[usize] = &[1_000, 10_000, 50_000, 100_000];
 
     let rt = tokio::runtime::Runtime::new().unwrap();
 

--- a/src/engine/actions/ddl/create_index.rs
+++ b/src/engine/actions/ddl/create_index.rs
@@ -1,0 +1,493 @@
+use std::collections::HashSet;
+
+use crate::engine::DBEngine;
+use crate::engine::actions::index::{qualified_index_name, row_index_key};
+use crate::engine::ast::ddl::create_index::CreateIndexQuery;
+use crate::engine::index::{IndexEntry, IndexMeta};
+use crate::engine::types::{
+    ExecuteColumn, ExecuteColumnType, ExecuteField, ExecuteResult, ExecuteRow,
+};
+use crate::errors;
+use crate::errors::execute_error::ExecuteError;
+
+impl DBEngine {
+    pub async fn create_index(&self, query: CreateIndexQuery) -> errors::Result<ExecuteResult> {
+        self.ensure_indices_loaded().await?;
+
+        let table = query.table.clone();
+        let database_name = table
+            .database_name
+            .clone()
+            .ok_or_else(|| ExecuteError::wrap("database name is required".to_string()))?;
+
+        // 테이블 존재 검증
+        let table_config = self.get_table_config_cached(table.clone()).await?;
+
+        // TODO(#217): 다중 컬럼 인덱스 지원
+        if query.columns.len() != 1 {
+            return Err(ExecuteError::wrap(
+                "multi-column indexes are not supported yet".to_string(),
+            ));
+        }
+
+        let column_name = query.columns[0].clone();
+
+        // 컬럼 존재 검증
+        if !table_config
+            .columns
+            .iter()
+            .any(|column| column.name == column_name)
+        {
+            return Err(ExecuteError::wrap(format!(
+                "column '{}' not exists",
+                column_name
+            )));
+        }
+
+        let index_name = qualified_index_name(&database_name, &query.index_name);
+
+        if self.index_manager.get_meta(&index_name).await.is_some() {
+            if query.if_not_exists {
+                return Ok(Self::index_result(format!(
+                    "index already exists, skipped: {}",
+                    query.index_name
+                )));
+            }
+
+            return Err(ExecuteError::wrap(format!(
+                "index '{}' already exists",
+                query.index_name
+            )));
+        }
+
+        let meta = IndexMeta::new(
+            index_name.clone(),
+            table.clone(),
+            column_name.clone(),
+            query.is_unique,
+        );
+
+        self.index_manager.create_index(meta).await?;
+
+        // 기존 행 색인 (backfill)
+        let rows = self.full_scan(table.clone()).await?;
+
+        let mut entries = Vec::new();
+        let mut seen_keys = HashSet::new();
+
+        for (location, row) in &rows {
+            if let Some(key) = row_index_key(row, &column_name) {
+                if query.is_unique && !seen_keys.insert(key.clone()) {
+                    // 고유 제약 위반: 생성한 인덱스를 롤백
+                    let _ = self.index_manager.drop_index(&index_name).await;
+                    return Err(ExecuteError::wrap(format!(
+                        "cannot create unique index '{}': column '{}' contains duplicate values",
+                        query.index_name, column_name
+                    )));
+                }
+
+                entries.push(IndexEntry {
+                    key,
+                    row_path: location.row_index.to_string(),
+                });
+            }
+        }
+
+        if let Err(error) = self
+            .index_manager
+            .replace_entries(&index_name, entries)
+            .await
+        {
+            let _ = self.index_manager.drop_index(&index_name).await;
+            return Err(error);
+        }
+
+        // 새 인덱스의 distinct 통계가 반영되도록 캐시 무효화
+        self.statistics_manager.invalidate(&table).await;
+
+        Ok(Self::index_result(format!(
+            "index created: {}",
+            query.index_name
+        )))
+    }
+
+    pub(crate) fn index_result(message: String) -> ExecuteResult {
+        ExecuteResult::new(
+            vec![ExecuteColumn {
+                name: "desc".into(),
+                data_type: ExecuteColumnType::String,
+            }],
+            vec![ExecuteRow {
+                fields: vec![ExecuteField::String(message)],
+            }],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use tokio::sync::Mutex;
+
+    use crate::config::launch_config::LaunchConfig;
+    use crate::engine::ast::dml::plan::select::scan::ScanType;
+    use crate::engine::ast::dml::plan::select::select_plan::SelectPlanItem;
+    use crate::engine::ast::types::TableName;
+    use crate::engine::optimizer::predule::Optimizer;
+    use crate::engine::parser::predule::{Parser, ParserContext};
+    use crate::engine::types::{ExecuteField, ExecuteResult};
+    use crate::engine::wal::endec::implements::bincode::{BincodeDecoder, BincodeEncoder};
+    use crate::engine::wal::manager::builder::WALBuilder;
+    use crate::engine::{DBEngine, SharedWALManager};
+
+    async fn build_test_engine(test_name: &str) -> (DBEngine, SharedWALManager) {
+        let base_path = PathBuf::from("target/test_index_integration").join(test_name);
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        tokio::fs::create_dir_all(&config.data_directory)
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(&config.wal_directory)
+            .await
+            .unwrap();
+
+        let wal = WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .unwrap();
+
+        (DBEngine::new(config), Arc::new(Mutex::new(wal)))
+    }
+
+    async fn execute_sql(
+        engine: &DBEngine,
+        wal: SharedWALManager,
+        sql: &str,
+    ) -> crate::errors::Result<ExecuteResult> {
+        let mut parser = Parser::with_string(sql.to_string())?;
+        let mut statements =
+            parser.parse(ParserContext::default().set_default_database("rrdb".to_string()))?;
+        let statement = statements.remove(0);
+
+        engine
+            .process_query(statement, wal, "test-connection".to_string())
+            .await
+    }
+
+    fn users_table() -> TableName {
+        TableName::new(Some("rrdb".to_string()), "users".to_string())
+    }
+
+    async fn setup_users_table(engine: &DBEngine, wal: SharedWALManager) {
+        execute_sql(engine, wal.clone(), "create database rrdb;")
+            .await
+            .unwrap();
+        execute_sql(
+            engine,
+            wal,
+            "create table users (id integer primary key, score integer);",
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn create_table_auto_creates_primary_key_index() {
+        let (engine, wal) = build_test_engine("pk_auto_index").await;
+        setup_users_table(&engine, wal.clone()).await;
+
+        let meta = engine
+            .index_manager
+            .get_meta("rrdb.users_pkey")
+            .await
+            .expect("primary key index should be auto-created");
+
+        assert_eq!(meta.column_name, "id");
+        assert!(meta.is_unique);
+        assert_eq!(meta.table_name, users_table());
+    }
+
+    #[tokio::test]
+    async fn primary_key_index_rejects_duplicate_inserts() {
+        let (engine, wal) = build_test_engine("pk_unique").await;
+        setup_users_table(&engine, wal.clone()).await;
+
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "insert into users (id, score) values (1, 10);",
+        )
+        .await
+        .unwrap();
+
+        let duplicated = execute_sql(
+            &engine,
+            wal.clone(),
+            "insert into users (id, score) values (1, 20);",
+        )
+        .await;
+        assert!(duplicated.is_err());
+
+        // 배치 내 중복도 거부
+        let batch_duplicated = execute_sql(
+            &engine,
+            wal.clone(),
+            "insert into users (id, score) values (2, 10), (2, 20);",
+        )
+        .await;
+        assert!(batch_duplicated.is_err());
+
+        // 다른 값은 정상 입력
+        execute_sql(
+            &engine,
+            wal,
+            "insert into users (id, score) values (2, 20);",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            engine.index_manager.len("rrdb.users_pkey").await.unwrap(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn create_index_backfills_existing_rows() {
+        let (engine, wal) = build_test_engine("backfill").await;
+        setup_users_table(&engine, wal.clone()).await;
+
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "insert into users (id, score) values (1, 10), (2, 20), (3, 20);",
+        )
+        .await
+        .unwrap();
+
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "create index users_score_idx on users (score);",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            engine
+                .index_manager
+                .len("rrdb.users_score_idx")
+                .await
+                .unwrap(),
+            3
+        );
+
+        // 중복 값이 있는 컬럼에 unique 인덱스 생성은 실패해야 함
+        let unique_on_duplicates = execute_sql(
+            &engine,
+            wal.clone(),
+            "create unique index users_score_uniq on users (score);",
+        )
+        .await;
+        assert!(unique_on_duplicates.is_err());
+        assert!(
+            engine
+                .index_manager
+                .get_meta("rrdb.users_score_uniq")
+                .await
+                .is_none()
+        );
+
+        // IF NOT EXISTS는 기존 인덱스를 건너뜀
+        execute_sql(
+            &engine,
+            wal,
+            "create index if not exists users_score_idx on users (score);",
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_and_delete_maintain_indexes() {
+        let (engine, wal) = build_test_engine("dml_maintenance").await;
+        setup_users_table(&engine, wal.clone()).await;
+
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "insert into users (id, score) values (1, 10), (2, 20), (3, 30);",
+        )
+        .await
+        .unwrap();
+
+        // UPDATE: 인덱스 컬럼 값 변경
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "update users set id = 20 where id = 2;",
+        )
+        .await
+        .unwrap();
+
+        let result = execute_sql(
+            &engine,
+            wal.clone(),
+            "select score from users where id = 20;",
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(20));
+
+        // UPDATE로 고유 제약 위반 시 실패해야 함
+        let conflict = execute_sql(
+            &engine,
+            wal.clone(),
+            "update users set id = 1 where id = 3;",
+        )
+        .await;
+        assert!(conflict.is_err());
+
+        // DELETE: 세그먼트 압축 후 인덱스가 재구축되어야 함
+        execute_sql(&engine, wal.clone(), "delete from users where id = 1;")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            engine.index_manager.len("rrdb.users_pkey").await.unwrap(),
+            2
+        );
+
+        // 압축으로 row index가 이동한 뒤에도 인덱스 조회가 정확해야 함
+        let result = execute_sql(&engine, wal, "select score from users where id = 3;")
+            .await
+            .unwrap();
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(30));
+    }
+
+    #[tokio::test]
+    async fn drop_index_removes_index_and_selects_still_work() {
+        let (engine, wal) = build_test_engine("drop_index").await;
+        setup_users_table(&engine, wal.clone()).await;
+
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "insert into users (id, score) values (1, 10), (2, 20);",
+        )
+        .await
+        .unwrap();
+
+        // 존재하지 않는 인덱스는 실패, IF EXISTS는 성공
+        assert!(
+            execute_sql(&engine, wal.clone(), "drop index missing_idx;")
+                .await
+                .is_err()
+        );
+        execute_sql(&engine, wal.clone(), "drop index if exists missing_idx;")
+            .await
+            .unwrap();
+
+        execute_sql(&engine, wal.clone(), "drop index users_pkey;")
+            .await
+            .unwrap();
+        assert!(
+            engine
+                .index_manager
+                .get_meta("rrdb.users_pkey")
+                .await
+                .is_none()
+        );
+
+        // 인덱스 없이도 FullScan으로 정상 동작
+        let result = execute_sql(&engine, wal, "select score from users where id = 2;")
+            .await
+            .unwrap();
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(20));
+    }
+
+    #[tokio::test]
+    async fn optimizer_selects_index_scan_for_large_table_and_returns_correct_rows() {
+        let (engine, wal) = build_test_engine("optimizer_index_scan").await;
+        setup_users_table(&engine, wal.clone()).await;
+
+        // 인덱스 스캔이 비용상 유리해지도록 충분한 행을 입력
+        let values = (1..=600)
+            .map(|i| format!("({}, {})", i, i * 10))
+            .collect::<Vec<_>>()
+            .join(", ");
+        execute_sql(
+            &engine,
+            wal.clone(),
+            &format!("insert into users (id, score) values {};", values),
+        )
+        .await
+        .unwrap();
+
+        // 옵티마이저가 IndexScan을 선택하는지 검증
+        let mut parser =
+            Parser::with_string("select score from users where id = 42;".to_string()).unwrap();
+        let statement = parser
+            .parse(ParserContext::default().set_default_database("rrdb".to_string()))
+            .unwrap()
+            .remove(0);
+
+        let query = match statement {
+            crate::engine::ast::SQLStatement::DML(
+                crate::engine::ast::DMLStatement::SelectQuery(query),
+            ) => query,
+            other => panic!("expected select query, got {:?}", other),
+        };
+
+        let context = engine.build_optimizer_context(&users_table()).await;
+        let optimizer = Optimizer::with_context(context);
+        let plan = optimizer.optimize_select(query).await.unwrap();
+
+        match &plan.list[0] {
+            SelectPlanItem::From(from) => match &from.scan {
+                ScanType::IndexScan(index_scan) => {
+                    assert_eq!(index_scan.index_name, "rrdb.users_pkey");
+                }
+                other => panic!("expected IndexScan, got {:?}", other),
+            },
+            other => panic!("expected From plan, got {:?}", other),
+        }
+
+        // 실제 실행 결과 검증 (동등 조건)
+        let result = execute_sql(
+            &engine,
+            wal.clone(),
+            "select score from users where id = 42;",
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(420));
+
+        // 범위 조건 검증
+        let result = execute_sql(
+            &engine,
+            wal.clone(),
+            "select score from users where id > 595 and id <= 598;",
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.rows.len(), 3);
+
+        // 엔진 재기동 후 디스크에서 인덱스를 다시 적재해 동작해야 함
+        let restarted = DBEngine::new(engine.config.as_ref().clone());
+        let result = execute_sql(&restarted, wal, "select score from users where id = 100;")
+            .await
+            .unwrap();
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(1000));
+    }
+}

--- a/src/engine/actions/ddl/create_index.rs
+++ b/src/engine/actions/ddl/create_index.rs
@@ -1,27 +1,33 @@
 use std::collections::HashSet;
 
 use crate::engine::DBEngine;
+use crate::engine::SharedWALManager;
 use crate::engine::actions::index::{qualified_index_name, row_index_key};
 use crate::engine::ast::ddl::create_index::CreateIndexQuery;
 use crate::engine::index::{IndexEntry, IndexMeta};
 use crate::engine::types::{
     ExecuteColumn, ExecuteColumnType, ExecuteField, ExecuteResult, ExecuteRow,
 };
+use crate::engine::wal::types::EntryType;
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
 
 impl DBEngine {
-    pub async fn create_index(&self, query: CreateIndexQuery) -> errors::Result<ExecuteResult> {
+    pub async fn create_index(
+        &self,
+        query: CreateIndexQuery,
+        wal_manager: SharedWALManager,
+    ) -> errors::Result<ExecuteResult> {
         self.ensure_indices_loaded().await?;
 
-        let table = query.table.clone();
-        let database_name = table
+        let database_name = query
+            .table
             .database_name
             .clone()
             .ok_or_else(|| ExecuteError::wrap("database name is required".to_string()))?;
 
         // 테이블 존재 검증
-        let table_config = self.get_table_config_cached(table.clone()).await?;
+        let table_config = self.get_table_config_cached(query.table.clone()).await?;
 
         // TODO(#217): 다중 컬럼 인덱스 지원
         if query.columns.len() != 1 {
@@ -30,13 +36,13 @@ impl DBEngine {
             ));
         }
 
-        let column_name = query.columns[0].clone();
+        let column_name = &query.columns[0];
 
         // 컬럼 존재 검증
         if !table_config
             .columns
             .iter()
-            .any(|column| column.name == column_name)
+            .any(|column| &column.name == column_name)
         {
             return Err(ExecuteError::wrap(format!(
                 "column '{}' not exists",
@@ -60,16 +66,51 @@ impl DBEngine {
             )));
         }
 
-        let meta = IndexMeta::new(
-            index_name.clone(),
-            table.clone(),
-            column_name.clone(),
-            query.is_unique,
-        );
+        // WAL-first: 인덱스 매니저를 변경하기 전에 먼저 durable하게 기록합니다.
+        let wal_payload =
+            bincode::serialize(&query).map_err(|error| ExecuteError::wrap(error.to_string()))?;
+        wal_manager
+            .lock()
+            .await
+            .append_record(EntryType::CreateIndex, Some(wal_payload), None)
+            .await?;
 
-        self.index_manager.create_index(meta).await?;
+        self.create_index_apply(&query).await
+    }
 
-        // 기존 행 색인 (backfill)
+    /// Re-applies a previously WAL-logged CREATE INDEX during crash recovery
+    /// replay. Idempotent: if the index metadata already exists (e.g. the
+    /// crash happened after the metadata was created but before the backfill
+    /// finished), it re-runs the backfill instead of failing.
+    pub(crate) async fn create_index_replay(
+        &self,
+        query: CreateIndexQuery,
+    ) -> errors::Result<ExecuteResult> {
+        self.ensure_indices_loaded().await?;
+        self.create_index_apply(&query).await
+    }
+
+    async fn create_index_apply(&self, query: &CreateIndexQuery) -> errors::Result<ExecuteResult> {
+        let table = query.table.clone();
+        let database_name = table
+            .database_name
+            .clone()
+            .ok_or_else(|| ExecuteError::wrap("database name is required".to_string()))?;
+        let column_name = query.columns[0].clone();
+        let index_name = qualified_index_name(&database_name, &query.index_name);
+
+        if self.index_manager.get_meta(&index_name).await.is_none() {
+            let meta = IndexMeta::new(
+                index_name.clone(),
+                table.clone(),
+                column_name.clone(),
+                query.is_unique,
+            );
+
+            self.index_manager.create_index(meta).await?;
+        }
+
+        // 기존 행 색인 (backfill). replace_entries는 전체 교체이므로 재실행해도 안전합니다.
         let rows = self.full_scan(table.clone()).await?;
 
         let mut entries = Vec::new();
@@ -131,16 +172,64 @@ mod tests {
 
     use tokio::sync::Mutex;
 
+    use tokio::io::AsyncWriteExt;
+
     use crate::config::launch_config::LaunchConfig;
     use crate::engine::ast::dml::plan::select::scan::ScanType;
     use crate::engine::ast::dml::plan::select::select_plan::SelectPlanItem;
     use crate::engine::ast::types::TableName;
+    use crate::engine::ast::{DDLStatement, DMLStatement, SQLStatement};
     use crate::engine::optimizer::predule::Optimizer;
     use crate::engine::parser::predule::{Parser, ParserContext};
     use crate::engine::types::{ExecuteField, ExecuteResult};
     use crate::engine::wal::endec::implements::bincode::{BincodeDecoder, BincodeEncoder};
+    use crate::engine::wal::endec::{WALDecoder, WALEncoder};
     use crate::engine::wal::manager::builder::WALBuilder;
+    use crate::engine::wal::types::{EntryType, WALEntry};
     use crate::engine::{DBEngine, SharedWALManager};
+
+    /// 엔진의 정상 write path(WAL append + apply)를 거치지 않고 WAL 세그먼트
+    /// 파일에 엔트리를 직접 기록합니다. "WAL에는 기록됐지만 아직 테이블/인덱스에
+    /// 반영되지 않은 채 크래시가 발생한 상태"를 시뮬레이션하는 데 사용합니다.
+    ///
+    /// `sequence`는 반드시 이 시점에 WALManager가 쓰고 있는 "현재" 세그먼트여야
+    /// 합니다. 이미 checkpoint된(즉, 실제로 반영이 끝난) 이전 세그먼트에 엔트리를
+    /// 추가하면, 재생 시 이미 적용된 연산까지 함께 재실행되어 데이터가
+    /// 중복됩니다.
+    async fn write_raw_wal_entry(
+        config: &LaunchConfig,
+        sequence: usize,
+        entry_type: EntryType,
+        payload: Vec<u8>,
+    ) {
+        let entry = WALEntry {
+            entry_type,
+            data: Some(payload),
+            timestamp: 0,
+            transaction_id: None,
+            is_continuation: false,
+        };
+
+        let encoder = BincodeEncoder::new();
+        let encoded = encoder.encode(&entry).unwrap();
+
+        let mut frame = Vec::with_capacity(size_of::<u32>() + encoded.len());
+        frame.extend_from_slice(&(encoded.len() as u32).to_le_bytes());
+        frame.extend_from_slice(&encoded);
+
+        let wal_path = PathBuf::from(&config.wal_directory)
+            .join(format!("{:08X}.{}", sequence, config.wal_extension));
+
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&wal_path)
+            .await
+            .unwrap();
+
+        file.write_all(&frame).await.unwrap();
+        file.flush().await.unwrap();
+    }
 
     async fn build_test_engine(test_name: &str) -> (DBEngine, SharedWALManager) {
         let base_path = PathBuf::from("target/test_index_integration").join(test_name);
@@ -354,7 +443,8 @@ mod tests {
         .await;
         assert!(conflict.is_err());
 
-        // DELETE: 세그먼트 압축 후 인덱스가 재구축되어야 함
+        // DELETE: 소프트 삭제 -- row index는 그대로 유지되고 tombstone만 표시되며,
+        // 삭제된 행의 인덱스 항목만 제거됩니다 (세그먼트 재작성/압축 없음).
         execute_sql(&engine, wal.clone(), "delete from users where id = 1;")
             .await
             .unwrap();
@@ -364,7 +454,13 @@ mod tests {
             2
         );
 
-        // 압축으로 row index가 이동한 뒤에도 인덱스 조회가 정확해야 함
+        // 삭제된 행은 더 이상 인덱스로 조회되지 않아야 함
+        let deleted = execute_sql(&engine, wal.clone(), "select score from users where id = 1;")
+            .await
+            .unwrap();
+        assert_eq!(deleted.rows.len(), 0);
+
+        // row index가 이동하지 않으므로 남은 행은 계속 정확히 조회되어야 함
         let result = execute_sql(&engine, wal, "select score from users where id = 3;")
             .await
             .unwrap();
@@ -491,5 +587,230 @@ mod tests {
             .unwrap();
         assert_eq!(result.rows.len(), 1);
         assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(1000));
+    }
+
+    #[tokio::test]
+    async fn wal_replay_reconstructs_insert_after_simulated_crash() {
+        let (engine, wal) = build_test_engine("wal_replay_insert").await;
+        setup_users_table(&engine, wal.clone()).await;
+
+        let mut parser =
+            Parser::with_string("insert into users (id, score) values (7, 70);".to_string())
+                .unwrap();
+        let statement = parser
+            .parse(ParserContext::default().set_default_database("rrdb".to_string()))
+            .unwrap()
+            .remove(0);
+        let insert_query = match statement {
+            SQLStatement::DML(DMLStatement::InsertQuery(query)) => query,
+            other => panic!("expected insert query, got {:?}", other),
+        };
+
+        // WAL에는 기록되었지만 아직 반영되지 않은 채 크래시가 난 상황을 시뮬레이션합니다:
+        // engine.insert()를 거치지 않고 WAL 파일에 직접 엔트리를 씁니다.
+        let config = engine.config.as_ref().clone();
+        let sequence = wal.lock().await.current_sequence();
+        let payload = bincode::serialize(&insert_query).unwrap();
+        write_raw_wal_entry(&config, sequence, EntryType::Insert, payload).await;
+
+        // 재기동 시뮬레이션: 같은 데이터 디렉터리로 새 엔진과 새 WALManager를 빌드합니다.
+        let restarted = DBEngine::new(config.clone());
+        let wal_manager2 = WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .unwrap();
+
+        let pending = wal_manager2.pending_entries().to_vec();
+        assert_eq!(
+            pending.len(),
+            1,
+            "the un-checkpointed insert should be pending replay"
+        );
+
+        restarted.replay_wal(&pending).await.unwrap();
+
+        let rows = restarted.full_scan(users_table()).await.unwrap();
+        assert_eq!(rows.len(), 1);
+
+        let wal2 = Arc::new(Mutex::new(wal_manager2));
+        let result = execute_sql(&restarted, wal2, "select score from users where id = 7;")
+            .await
+            .unwrap();
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(70));
+    }
+
+    #[tokio::test]
+    async fn wal_replay_reconstructs_create_index_after_simulated_crash() {
+        let (engine, wal) = build_test_engine("wal_replay_create_index").await;
+        setup_users_table(&engine, wal.clone()).await;
+
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "insert into users (id, score) values (1, 10), (2, 20), (3, 20);",
+        )
+        .await
+        .unwrap();
+
+        let mut parser =
+            Parser::with_string("create index users_score_idx on users (score);".to_string())
+                .unwrap();
+        let statement = parser
+            .parse(ParserContext::default().set_default_database("rrdb".to_string()))
+            .unwrap()
+            .remove(0);
+        let create_index_query = match statement {
+            SQLStatement::DDL(DDLStatement::CreateIndexQuery(query)) => query,
+            other => panic!("expected create index query, got {:?}", other),
+        };
+
+        // 앞선 INSERT는 정상 경로로 이미 반영되었으므로, row buffer + WAL checkpoint로
+        // durable 경계를 만들어 재생 대상에서 제외합니다 (그렇지 않으면 재생 시 INSERT가
+        // 중복 적용됩니다). 이후 CREATE INDEX만 WAL에 기록되고 아직 인덱스
+        // 매니저에는 반영되지 않은 채 크래시가 난 상황을 시뮬레이션합니다.
+        engine.flush_row_buffers_durable().await.unwrap();
+        wal.lock().await.flush().await.unwrap();
+
+        let config = engine.config.as_ref().clone();
+        let sequence = wal.lock().await.current_sequence();
+        let payload = bincode::serialize(&create_index_query).unwrap();
+        write_raw_wal_entry(&config, sequence, EntryType::CreateIndex, payload).await;
+
+        let restarted = DBEngine::new(config.clone());
+        let wal_manager2 = WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .unwrap();
+
+        let pending = wal_manager2.pending_entries().to_vec();
+        assert_eq!(pending.len(), 1);
+
+        restarted.replay_wal(&pending).await.unwrap();
+
+        assert!(
+            restarted
+                .index_manager
+                .get_meta("rrdb.users_score_idx")
+                .await
+                .is_some(),
+            "replay should recreate the index metadata"
+        );
+        assert_eq!(
+            restarted
+                .index_manager
+                .len("rrdb.users_score_idx")
+                .await
+                .unwrap(),
+            3,
+            "replay should backfill the index from existing rows"
+        );
+    }
+
+    #[tokio::test]
+    async fn wal_replay_reconstructs_drop_index_after_simulated_crash() {
+        let (engine, wal) = build_test_engine("wal_replay_drop_index").await;
+        setup_users_table(&engine, wal.clone()).await;
+
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "create index users_score_idx on users (score);",
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            engine
+                .index_manager
+                .get_meta("rrdb.users_score_idx")
+                .await
+                .is_some()
+        );
+
+        let mut parser = Parser::with_string("drop index users_score_idx;".to_string()).unwrap();
+        let statement = parser
+            .parse(ParserContext::default().set_default_database("rrdb".to_string()))
+            .unwrap()
+            .remove(0);
+        let drop_index_query = match statement {
+            SQLStatement::DDL(DDLStatement::DropIndexQuery(query)) => query,
+            other => panic!("expected drop index query, got {:?}", other),
+        };
+
+        // 앞선 CREATE INDEX는 정상 경로로 이미 반영되었으므로, checkpoint로
+        // durable 경계를 만들어 재생 대상에서 제외합니다. 이후 DROP INDEX만
+        // WAL에 기록되고 아직 인덱스 매니저에는 반영되지 않은 채 크래시가 난
+        // 상황을 시뮬레이션합니다.
+        wal.lock().await.flush().await.unwrap();
+
+        let config = engine.config.as_ref().clone();
+        let sequence = wal.lock().await.current_sequence();
+        let payload = bincode::serialize(&drop_index_query).unwrap();
+        write_raw_wal_entry(&config, sequence, EntryType::DropIndex, payload).await;
+
+        let restarted = DBEngine::new(config.clone());
+        let wal_manager2 = WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .unwrap();
+
+        let pending = wal_manager2.pending_entries().to_vec();
+        assert_eq!(pending.len(), 1);
+
+        restarted.replay_wal(&pending).await.unwrap();
+
+        assert!(
+            restarted
+                .index_manager
+                .get_meta("rrdb.users_score_idx")
+                .await
+                .is_none(),
+            "replay should drop the index"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_wal_first_writes_entry_before_applying_mutation() {
+        let (engine, wal) = build_test_engine("update_wal_first").await;
+        setup_users_table(&engine, wal.clone()).await;
+
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "insert into users (id, score) values (1, 10), (2, 20);",
+        )
+        .await
+        .unwrap();
+
+        // 고유 제약 위반으로 인덱스 반영은 실패하지만, WAL-first이므로 WAL
+        // 엔트리는 이미 기록된 뒤여야 합니다.
+        let result = execute_sql(
+            &engine,
+            wal.clone(),
+            "update users set id = 1 where id = 2;",
+        )
+        .await;
+        assert!(result.is_err());
+
+        let config = engine.config.as_ref().clone();
+        let wal_path = PathBuf::from(&config.wal_directory)
+            .join(format!("{:08X}.{}", 1, config.wal_extension));
+        let content = tokio::fs::read(&wal_path).await.unwrap();
+        let decoder = BincodeDecoder::new();
+        let entries = decoder.decode(&content).unwrap();
+        assert!(
+            entries
+                .iter()
+                .any(|entry| matches!(entry.entry_type, EntryType::Set)),
+            "WAL should already contain the Set entry even though the mutation was rolled back"
+        );
+
+        // 실패 시 인덱스/테이블 반영은 롤백되어 실제 데이터는 변하지 않아야 합니다.
+        let result = execute_sql(&engine, wal, "select score from users where id = 2;")
+            .await
+            .unwrap();
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(20));
     }
 }

--- a/src/engine/actions/ddl/create_table.rs
+++ b/src/engine/actions/ddl/create_table.rs
@@ -1,8 +1,10 @@
 use std::io::ErrorKind as IOErrorKind;
 
 use crate::engine::DBEngine;
+use crate::engine::actions::index::qualified_index_name;
 use crate::engine::ast::ddl::create_table::CreateTableQuery;
 use crate::engine::encoder::schema_encoder::StorageEncoder;
+use crate::engine::index::IndexMeta;
 use crate::engine::schema::table::TableSchema;
 use crate::engine::types::{
     ExecuteColumn, ExecuteColumnType, ExecuteField, ExecuteResult, ExecuteRow,
@@ -56,7 +58,33 @@ impl DBEngine {
             return Err(ExecuteError::wrap(error.to_string()));
         }
 
-        // TODO: primary key 데이터 생성
+        // PRIMARY KEY 자동 인덱스 생성 (#217)
+        let primary_key_columns: Vec<String> = if table_info.primary_key.is_empty() {
+            table_info
+                .columns
+                .iter()
+                .filter(|column| column.primary_key)
+                .map(|column| column.name.clone())
+                .collect()
+        } else {
+            table_info.primary_key.clone()
+        };
+
+        // TODO(#217): 복합 PRIMARY KEY 인덱스는 미지원 (단일 컬럼만 자동 생성)
+        if primary_key_columns.len() == 1 {
+            self.ensure_indices_loaded().await?;
+
+            let index_name = qualified_index_name(&database_name, &format!("{}_pkey", table_name));
+            let meta = IndexMeta::new(
+                index_name,
+                table_info.table.clone(),
+                primary_key_columns[0].clone(),
+                true,
+            );
+
+            self.index_manager.create_index(meta).await?;
+        }
+
         // TODO: unique key 데이터 생성
         // TODO: foreign key 데이터 생성
 

--- a/src/engine/actions/ddl/create_table.rs
+++ b/src/engine/actions/ddl/create_table.rs
@@ -72,7 +72,10 @@ impl DBEngine {
 
         // TODO(#217): 복합 PRIMARY KEY 인덱스는 미지원 (단일 컬럼만 자동 생성)
         if primary_key_columns.len() == 1 {
-            self.ensure_indices_loaded().await?;
+            if let Err(error) = self.ensure_indices_loaded().await {
+                let _ = tokio::fs::remove_dir_all(&table_path).await;
+                return Err(error);
+            }
 
             let index_name = qualified_index_name(&database_name, &format!("{}_pkey", table_name));
             let meta = IndexMeta::new(
@@ -82,7 +85,10 @@ impl DBEngine {
                 true,
             );
 
-            self.index_manager.create_index(meta).await?;
+            if let Err(error) = self.index_manager.create_index(meta).await {
+                let _ = tokio::fs::remove_dir_all(&table_path).await;
+                return Err(error);
+            }
         }
 
         // TODO: unique key 데이터 생성

--- a/src/engine/actions/ddl/drop_database.rs
+++ b/src/engine/actions/ddl/drop_database.rs
@@ -21,6 +21,15 @@ impl DBEngine {
 
         database_path.push(&database_name);
 
+        // 인덱스 메모리 상태 및 통계 정리 (인덱스 파일은 데이터베이스 디렉토리와 함께 삭제됨)
+        self.ensure_indices_loaded().await?;
+        self.index_manager
+            .remove_database_indices(&database_name)
+            .await;
+        self.statistics_manager
+            .invalidate_database(&database_name)
+            .await;
+
         if let Err(error) = tokio::fs::remove_dir_all(database_path.clone()).await {
             match error.kind() {
                 IOErrorKind::NotFound => {

--- a/src/engine/actions/ddl/drop_index.rs
+++ b/src/engine/actions/ddl/drop_index.rs
@@ -1,39 +1,69 @@
 use crate::engine::DBEngine;
+use crate::engine::SharedWALManager;
 use crate::engine::actions::index::qualified_index_name;
 use crate::engine::ast::ddl::drop_index::DropIndexQuery;
 use crate::engine::types::ExecuteResult;
+use crate::engine::wal::types::EntryType;
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
 
 impl DBEngine {
-    pub async fn drop_index(&self, query: DropIndexQuery) -> errors::Result<ExecuteResult> {
+    pub async fn drop_index(
+        &self,
+        query: DropIndexQuery,
+        wal_manager: SharedWALManager,
+    ) -> errors::Result<ExecuteResult> {
         self.ensure_indices_loaded().await?;
 
-        let database_name = query
-            .database_name
-            .clone()
-            .or_else(|| {
-                query
-                    .table
-                    .as_ref()
-                    .and_then(|table| table.database_name.clone())
-            })
-            .ok_or_else(|| ExecuteError::wrap("database name is required".to_string()))?;
+        let database_name = Self::drop_index_database_name(&query)?;
+        let index_name = qualified_index_name(&database_name, &query.index_name);
 
+        if self.index_manager.get_meta(&index_name).await.is_none() {
+            if query.if_exists {
+                return Ok(Self::index_result(format!(
+                    "index not found, skipped: {}",
+                    query.index_name
+                )));
+            }
+
+            return Err(ExecuteError::wrap(format!(
+                "index '{}' not found",
+                query.index_name
+            )));
+        }
+
+        // WAL-first: 인덱스 매니저를 변경하기 전에 먼저 durable하게 기록합니다.
+        let wal_payload =
+            bincode::serialize(&query).map_err(|error| ExecuteError::wrap(error.to_string()))?;
+        wal_manager
+            .lock()
+            .await
+            .append_record(EntryType::DropIndex, Some(wal_payload), None)
+            .await?;
+
+        self.drop_index_apply(&query).await
+    }
+
+    /// Re-applies a previously WAL-logged DROP INDEX during crash recovery
+    /// replay. Idempotent: if the index is already gone, treats it as
+    /// already-applied instead of failing.
+    pub(crate) async fn drop_index_replay(
+        &self,
+        query: DropIndexQuery,
+    ) -> errors::Result<ExecuteResult> {
+        self.ensure_indices_loaded().await?;
+        self.drop_index_apply(&query).await
+    }
+
+    async fn drop_index_apply(&self, query: &DropIndexQuery) -> errors::Result<ExecuteResult> {
+        let database_name = Self::drop_index_database_name(query)?;
         let index_name = qualified_index_name(&database_name, &query.index_name);
 
         let meta = match self.index_manager.get_meta(&index_name).await {
             Some(meta) => meta,
             None => {
-                if query.if_exists {
-                    return Ok(Self::index_result(format!(
-                        "index not found, skipped: {}",
-                        query.index_name
-                    )));
-                }
-
-                return Err(ExecuteError::wrap(format!(
-                    "index '{}' not found",
+                return Ok(Self::index_result(format!(
+                    "index not found, skipped: {}",
                     query.index_name
                 )));
             }
@@ -48,5 +78,18 @@ impl DBEngine {
             "index dropped: {}",
             query.index_name
         )))
+    }
+
+    fn drop_index_database_name(query: &DropIndexQuery) -> errors::Result<String> {
+        query
+            .database_name
+            .clone()
+            .or_else(|| {
+                query
+                    .table
+                    .as_ref()
+                    .and_then(|table| table.database_name.clone())
+            })
+            .ok_or_else(|| ExecuteError::wrap("database name is required".to_string()))
     }
 }

--- a/src/engine/actions/ddl/drop_index.rs
+++ b/src/engine/actions/ddl/drop_index.rs
@@ -1,0 +1,52 @@
+use crate::engine::DBEngine;
+use crate::engine::actions::index::qualified_index_name;
+use crate::engine::ast::ddl::drop_index::DropIndexQuery;
+use crate::engine::types::ExecuteResult;
+use crate::errors;
+use crate::errors::execute_error::ExecuteError;
+
+impl DBEngine {
+    pub async fn drop_index(&self, query: DropIndexQuery) -> errors::Result<ExecuteResult> {
+        self.ensure_indices_loaded().await?;
+
+        let database_name = query
+            .database_name
+            .clone()
+            .or_else(|| {
+                query
+                    .table
+                    .as_ref()
+                    .and_then(|table| table.database_name.clone())
+            })
+            .ok_or_else(|| ExecuteError::wrap("database name is required".to_string()))?;
+
+        let index_name = qualified_index_name(&database_name, &query.index_name);
+
+        let meta = match self.index_manager.get_meta(&index_name).await {
+            Some(meta) => meta,
+            None => {
+                if query.if_exists {
+                    return Ok(Self::index_result(format!(
+                        "index not found, skipped: {}",
+                        query.index_name
+                    )));
+                }
+
+                return Err(ExecuteError::wrap(format!(
+                    "index '{}' not found",
+                    query.index_name
+                )));
+            }
+        };
+
+        self.index_manager.drop_index(&index_name).await?;
+
+        // distinct 통계에서 해당 인덱스가 빠지도록 캐시 무효화
+        self.statistics_manager.invalidate(&meta.table_name).await;
+
+        Ok(Self::index_result(format!(
+            "index dropped: {}",
+            query.index_name
+        )))
+    }
+}

--- a/src/engine/actions/ddl/drop_table.rs
+++ b/src/engine/actions/ddl/drop_table.rs
@@ -17,6 +17,11 @@ impl DBEngine {
 
         self.invalidate_table_config_cache(&table).await;
 
+        // 인덱스 메모리 상태 및 통계 정리 (인덱스 파일은 테이블 디렉토리와 함께 삭제됨)
+        self.ensure_indices_loaded().await?;
+        self.index_manager.remove_table_indices(&table).await;
+        self.statistics_manager.invalidate(&table).await;
+
         let TableName {
             database_name,
             table_name,

--- a/src/engine/actions/ddl/mod.rs
+++ b/src/engine/actions/ddl/mod.rs
@@ -1,6 +1,8 @@
 pub mod alter_database;
 pub mod alter_table;
 pub mod create_database;
+pub mod create_index;
 pub mod create_table;
 pub mod drop_database;
+pub mod drop_index;
 pub mod drop_table;

--- a/src/engine/actions/dml/delete.rs
+++ b/src/engine/actions/dml/delete.rs
@@ -28,8 +28,8 @@ impl DBEngine {
 
         let table = query.from_table.as_ref().unwrap().table.clone();
 
-        // 최적화 작업
-        let optimizer = Optimizer::new();
+        // 최적화 작업 (대상 테이블의 인덱스/통계로 컨텍스트 구성)
+        let optimizer = Optimizer::with_context(self.build_optimizer_context(&table).await);
 
         let plan = optimizer.optimize_delete(query).await?;
 
@@ -59,8 +59,10 @@ impl DBEngine {
 
                             rows.append(&mut result);
                         }
-                        ScanType::IndexScan(_index) => {
-                            unimplemented!()
+                        ScanType::IndexScan(index_scan_plan) => {
+                            let mut result = self.index_scan(table_name, &index_scan_plan).await?;
+
+                            rows.append(&mut result);
                         }
                     }
                 }
@@ -120,6 +122,13 @@ impl DBEngine {
                 .append_record(EntryType::Delete, Some(wal_payload), None)
                 .await?;
             self.delete_table_rows(&table, row_indexes).await?;
+
+            // DELETE는 세그먼트를 압축해 row index가 밀리므로 인덱스를 재구축합니다 (#217)
+            self.ensure_indices_loaded().await?;
+            self.rebuild_table_indices(&table).await?;
+            self.statistics_manager
+                .record_delete(&table, affected_rows)
+                .await;
         }
 
         Ok(ExecuteResult::with_affected_rows(

--- a/src/engine/actions/dml/delete.rs
+++ b/src/engine/actions/dml/delete.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use futures::future::join_all;
 
+use crate::engine::actions::index::row_index_key;
 use crate::engine::ast::dml::delete::DeleteQuery;
 use crate::engine::ast::dml::plan::delete::delete_plan::DeletePlanItem;
 use crate::engine::ast::dml::plan::select::scan::ScanType;
@@ -23,10 +24,30 @@ impl DBEngine {
         query: DeleteQuery,
         wal_manager: SharedWALManager,
     ) -> errors::Result<ExecuteResult> {
-        let wal_payload =
-            bincode::serialize(&query).map_err(|error| ExecuteError::wrap(error.to_string()))?;
+        self.delete_internal(query, Some(wal_manager)).await
+    }
 
+    /// Re-applies a previously WAL-logged DELETE during crash recovery
+    /// replay. Identical to `delete()` but skips the WAL append (the
+    /// operation is already durably recorded in the WAL being replayed).
+    pub(crate) async fn delete_replay(&self, query: DeleteQuery) -> errors::Result<ExecuteResult> {
+        self.delete_internal(query, None).await
+    }
+
+    async fn delete_internal(
+        &self,
+        query: DeleteQuery,
+        wal_manager: Option<SharedWALManager>,
+    ) -> errors::Result<ExecuteResult> {
         let table = query.from_table.as_ref().unwrap().table.clone();
+
+        // WAL-first: 쿼리를 실행/소비하기 전에 페이로드를 미리 직렬화합니다.
+        let wal_payload = match &wal_manager {
+            Some(_) => Some(
+                bincode::serialize(&query).map_err(|error| ExecuteError::wrap(error.to_string()))?,
+            ),
+            None => None,
+        };
 
         // 최적화 작업 (대상 테이블의 인덱스/통계로 컨텍스트 구성)
         let optimizer = Optimizer::with_context(self.build_optimizer_context(&table).await);
@@ -108,24 +129,46 @@ impl DBEngine {
             }
         }
 
-        let row_indexes = rows
-            .into_iter()
-            .map(|(location, _)| location.row_index)
-            .collect::<HashSet<_>>();
+        self.ensure_indices_loaded().await?;
+        let index_metas = self.table_index_metas(&table).await;
+
+        let mut row_indexes = HashSet::new();
+        // 삭제할 인덱스 항목: (index_name, key, row_path)
+        let mut index_removals: Vec<(String, String, String)> = vec![];
+
+        for (location, row) in &rows {
+            row_indexes.insert(location.row_index);
+
+            for meta in &index_metas {
+                if let Some(key) = row_index_key(row, &meta.column_name) {
+                    index_removals.push((
+                        meta.index_name.clone(),
+                        key,
+                        location.row_index.to_string(),
+                    ));
+                }
+            }
+        }
 
         let affected_rows = row_indexes.len();
 
         if !row_indexes.is_empty() {
-            wal_manager
-                .lock()
-                .await
-                .append_record(EntryType::Delete, Some(wal_payload), None)
-                .await?;
+            // WAL-first: 먼저 durable하게 기록한 뒤 실제 데이터/인덱스를 변경합니다.
+            if let Some(wal_manager) = &wal_manager {
+                wal_manager
+                    .lock()
+                    .await
+                    .append_record(EntryType::Delete, wal_payload, None)
+                    .await?;
+            }
+
+            // 소프트 삭제: row index를 유지한 채 tombstone만 표시합니다 (세그먼트 재작성/압축 없음, #217)
             self.delete_table_rows(&table, row_indexes).await?;
 
-            // DELETE는 세그먼트를 압축해 row index가 밀리므로 인덱스를 재구축합니다 (#217)
-            self.ensure_indices_loaded().await?;
-            self.rebuild_table_indices(&table).await?;
+            for (index_name, key, row_path) in &index_removals {
+                self.index_manager.remove(index_name, key, row_path).await?;
+            }
+
             self.statistics_manager
                 .record_delete(&table, affected_rows)
                 .await;

--- a/src/engine/actions/dml/insert.rs
+++ b/src/engine/actions/dml/insert.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use crate::engine::actions::index::row_index_key;
 use crate::engine::ast::dml::insert::{InsertData, InsertQuery};
 use crate::engine::ast::types::SQLExpression;
 use crate::engine::schema::row::{TableDataField, TableDataRow};
@@ -161,6 +162,33 @@ impl DBEngine {
                     rows.push(row);
                 }
 
+                // 인덱스 유지보수 준비 (#217)
+                self.ensure_indices_loaded().await?;
+                let index_metas = self.table_index_metas(into_table).await;
+
+                // 고유 인덱스 사전 검증 (기존 데이터 + 배치 내 중복)
+                for meta in index_metas.iter().filter(|meta| meta.is_unique) {
+                    let mut batch_keys = HashSet::new();
+
+                    for row in &rows {
+                        if let Some(key) = row_index_key(row, &meta.column_name) {
+                            let duplicated = !self
+                                .index_manager
+                                .get(&meta.index_name, &key)
+                                .await?
+                                .is_empty()
+                                || !batch_keys.insert(key);
+
+                            if duplicated {
+                                return Err(ExecuteError::wrap(format!(
+                                    "duplicate key value violates unique index on column '{}'",
+                                    meta.column_name
+                                )));
+                            }
+                        }
+                    }
+                }
+
                 let wal_payload =
                     bson::to_vec(&query).map_err(|error| ExecuteError::wrap(error.to_string()))?;
                 wal_manager
@@ -170,7 +198,24 @@ impl DBEngine {
                     .await?;
 
                 let affected_rows = rows.len();
-                self.append_table_rows(into_table, &rows).await?;
+                let start_index = self.append_table_rows(into_table, &rows).await?;
+
+                // 인덱스 반영
+                for (offset, row) in rows.iter().enumerate() {
+                    let row_path = (start_index + offset).to_string();
+
+                    for meta in &index_metas {
+                        if let Some(key) = row_index_key(row, &meta.column_name) {
+                            self.index_manager
+                                .insert(&meta.index_name, key, row_path.clone())
+                                .await?;
+                        }
+                    }
+                }
+
+                self.statistics_manager
+                    .record_insert(into_table, affected_rows)
+                    .await;
 
                 return Ok(ExecuteResult::with_affected_rows(
                     vec![ExecuteColumn {

--- a/src/engine/actions/dml/insert.rs
+++ b/src/engine/actions/dml/insert.rs
@@ -200,7 +200,10 @@ impl DBEngine {
                 let affected_rows = rows.len();
                 let start_index = self.append_table_rows(into_table, &rows).await?;
 
-                // 인덱스 반영
+                // 인덱스 반영 (#217)
+                // 안전성: append_table_rows가 row_storage_lock으로 직렬화되므로,
+                // start_index는 이 INSERT에 배타적인 범위를 가리킵니다.
+                // index_manager.insert는 자체 내부 동기화로 덮어쓰기를 방지합니다.
                 for (offset, row) in rows.iter().enumerate() {
                     let row_path = (start_index + offset).to_string();
 

--- a/src/engine/actions/dml/insert.rs
+++ b/src/engine/actions/dml/insert.rs
@@ -221,14 +221,39 @@ impl DBEngine {
                 // 안전성: append_table_rows가 row_storage_lock으로 직렬화되므로,
                 // start_index는 이 INSERT에 배타적인 범위를 가리킵니다.
                 // index_manager.insert는 자체 내부 동기화로 덮어쓰기를 방지합니다.
+                //
+                // 인덱스 반영 도중 실패하면, 이미 반영된 인덱스 항목을 되돌리고
+                // 방금 추가한 row들을 tombstone 처리해 테이블 row와 인덱스 상태가
+                // 어긋나지 않도록 합니다.
+                let mut applied_index_entries: Vec<(String, String, String)> = Vec::new();
+
                 for (offset, row) in rows.iter().enumerate() {
                     let row_path = (start_index + offset).to_string();
 
                     for meta in &index_metas {
                         if let Some(key) = row_index_key(row, &meta.column_name) {
-                            self.index_manager
-                                .insert(&meta.index_name, key, row_path.clone())
-                                .await?;
+                            if let Err(error) = self
+                                .index_manager
+                                .insert(&meta.index_name, key.clone(), row_path.clone())
+                                .await
+                            {
+                                for (index_name, applied_key, applied_row_path) in
+                                    applied_index_entries.iter().rev()
+                                {
+                                    let _ = self
+                                        .index_manager
+                                        .remove(index_name, applied_key, applied_row_path)
+                                        .await;
+                                }
+
+                                let row_indexes: HashSet<usize> =
+                                    (start_index..start_index + rows.len()).collect();
+                                let _ = self.delete_table_rows(into_table, row_indexes).await;
+
+                                return Err(error);
+                            }
+
+                            applied_index_entries.push((meta.index_name.clone(), key, row_path.clone()));
                         }
                     }
                 }
@@ -270,5 +295,119 @@ impl DBEngine {
             }],
             0,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use tokio::sync::Mutex;
+
+    use crate::config::launch_config::LaunchConfig;
+    use crate::engine::ast::types::TableName;
+    use crate::engine::parser::predule::{Parser, ParserContext};
+    use crate::engine::types::ExecuteResult;
+    use crate::engine::wal::endec::implements::bincode::{BincodeDecoder, BincodeEncoder};
+    use crate::engine::wal::manager::builder::WALBuilder;
+    use crate::engine::{DBEngine, SharedWALManager};
+
+    async fn build_test_engine(test_name: &str) -> (DBEngine, SharedWALManager) {
+        let base_path = PathBuf::from("target/test_insert_integration").join(test_name);
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        tokio::fs::create_dir_all(&config.data_directory)
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(&config.wal_directory)
+            .await
+            .unwrap();
+
+        let wal = WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .unwrap();
+
+        (DBEngine::new(config), Arc::new(Mutex::new(wal)))
+    }
+
+    async fn execute_sql(
+        engine: &DBEngine,
+        wal: SharedWALManager,
+        sql: &str,
+    ) -> crate::errors::Result<ExecuteResult> {
+        let mut parser = Parser::with_string(sql.to_string()).unwrap();
+        let mut statements = parser
+            .parse(ParserContext::default().set_default_database("rrdb".to_string()))
+            .unwrap();
+        let statement = statements.remove(0);
+
+        engine
+            .process_query(statement, wal, "test-connection".to_string())
+            .await
+    }
+
+    fn users_table() -> TableName {
+        TableName::new(Some("rrdb".to_string()), "users".to_string())
+    }
+
+    /// 두 INSERT를 동시에 실행해 unique 인덱스 사전 검증과 실제
+    /// `index_manager.insert` 사이의 경합 창을 유도합니다. 롤백이 없다면
+    /// 패자 쪽 row가 테이블에는 남고 인덱스에는 반영되지 않는 상태가 됩니다.
+    #[tokio::test]
+    async fn failed_unique_index_insert_does_not_leave_orphan_row() {
+        let (engine, wal) = build_test_engine("orphan_row_rollback").await;
+
+        execute_sql(&engine, wal.clone(), "create database rrdb;")
+            .await
+            .unwrap();
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "create table users (id integer primary key, score integer);",
+        )
+        .await
+        .unwrap();
+
+        let (first, second) = tokio::join!(
+            execute_sql(
+                &engine,
+                wal.clone(),
+                "insert into users (id, score) values (1, 10);"
+            ),
+            execute_sql(
+                &engine,
+                wal.clone(),
+                "insert into users (id, score) values (1, 20);"
+            ),
+        );
+
+        let successes = [&first, &second].iter().filter(|r| r.is_ok()).count();
+        assert_eq!(
+            successes, 1,
+            "exactly one of the racing inserts should succeed"
+        );
+
+        let rows = engine.full_scan(users_table()).await.unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "a failed insert must not leave an orphan row behind"
+        );
+
+        let index_entries = engine
+            .index_manager
+            .scan_all("rrdb.users_pkey")
+            .await
+            .unwrap();
+        assert_eq!(
+            index_entries.len(),
+            rows.len(),
+            "index entry count must match live row count after rollback"
+        );
     }
 }

--- a/src/engine/actions/dml/insert.rs
+++ b/src/engine/actions/dml/insert.rs
@@ -18,6 +18,21 @@ impl DBEngine {
         query: InsertQuery,
         wal_manager: SharedWALManager,
     ) -> errors::Result<ExecuteResult> {
+        self.insert_internal(query, Some(wal_manager)).await
+    }
+
+    /// Re-applies a previously WAL-logged INSERT during crash recovery
+    /// replay. Identical to `insert()` but skips the WAL append (the
+    /// operation is already durably recorded in the WAL being replayed).
+    pub(crate) async fn insert_replay(&self, query: InsertQuery) -> errors::Result<ExecuteResult> {
+        self.insert_internal(query, None).await
+    }
+
+    async fn insert_internal(
+        &self,
+        query: InsertQuery,
+        wal_manager: Option<SharedWALManager>,
+    ) -> errors::Result<ExecuteResult> {
         let into_table = query.into_table.as_ref().unwrap();
 
         let table_name = into_table.clone().table_name;
@@ -189,13 +204,15 @@ impl DBEngine {
                     }
                 }
 
-                let wal_payload = bincode::serialize(&(into_table, &rows))
-                    .map_err(|error| ExecuteError::wrap(error.to_string()))?;
-                wal_manager
-                    .lock()
-                    .await
-                    .append_record(EntryType::Insert, Some(wal_payload), None)
-                    .await?;
+                if let Some(wal_manager) = &wal_manager {
+                    let wal_payload = bincode::serialize(&query)
+                        .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+                    wal_manager
+                        .lock()
+                        .await
+                        .append_record(EntryType::Insert, Some(wal_payload), None)
+                        .await?;
+                }
 
                 let affected_rows = rows.len();
                 let start_index = self.append_table_rows(into_table, &rows).await?;

--- a/src/engine/actions/dml/scan.rs
+++ b/src/engine/actions/dml/scan.rs
@@ -2,23 +2,33 @@ use std::collections::{HashMap, HashSet};
 use std::io::ErrorKind as IOErrorKind;
 use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
+
 
 use crate::engine::DBEngine;
 use crate::engine::ast::dml::plan::select::scan::IndexScanPlan;
 use crate::engine::ast::types::TableName;
 use crate::engine::encoder::schema_encoder::StorageEncoder;
-use crate::engine::row_buffer::{RowBufferWrite, encode_row_frames};
+use crate::engine::row_buffer::{RowBufferWrite, encode_live_row_frames};
 use crate::engine::schema::row::TableDataRow;
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
 
 const ROW_SEGMENT_FILENAME: &str = "00000001.rows";
+const ROW_META_FILENAME: &str = "meta.bin";
 const DEFAULT_ROW_WRITE_BUFFER_LIMIT_BYTES: usize = 16 * 1024 * 1024;
+const ROW_FRAME_LIVE: u8 = 0;
+const ROW_FRAME_TOMBSTONE: u8 = 1;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct RowLocation {
     pub(crate) row_index: usize,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct RowSegmentMeta {
+    next_row_index: usize,
 }
 
 impl DBEngine {
@@ -43,12 +53,13 @@ impl DBEngine {
         Ok(rows
             .into_iter()
             .enumerate()
-            .map(|(row_index, row)| (RowLocation { row_index }, row))
+            .filter_map(|(row_index, row)| row.map(|row| (RowLocation { row_index }, row)))
             .collect())
     }
 
     /// 행을 세그먼트 파일 끝에 추가하고 시작 row index를 반환합니다.
     /// 반환된 시작 인덱스는 인덱스 유지보수(key -> row index)에 사용됩니다.
+    /// 시작 인덱스는 meta.bin + 버퍼 상태를 사용해 계산하므로 세그먼트 전체 스캔이 필요 없습니다.
     pub(crate) async fn append_table_rows(
         &self,
         table_name: &TableName,
@@ -74,27 +85,23 @@ impl DBEngine {
 
         let _guard = self.row_storage_lock.lock().await;
         let segment_path = self.row_segment_path(table_name)?;
+        let meta_path = self.row_segment_meta_path(table_name)?;
 
-        // 버퍼 풀의 현재 행 개수를 시작 인덱스로 사용.
-        // persisted_rows가 적재되지 않았으면 먼저 디스크에서 읽어온다.
-        let start_index = {
-            let pool_guard = self.row_buffer_pool.lock().await;
-            match pool_guard.cached_row_count(&segment_path) {
-                Some(count) => count,
-                None => {
-                    drop(pool_guard);
-                    let disk_rows = self.read_segment_rows(&segment_path).await?;
-                    let count = disk_rows.len();
-                    self.row_buffer_pool
-                        .lock()
-                        .await
-                        .read_rows(segment_path.clone(), || disk_rows);
-                    count
-                }
+        let cached_start_index = { self.row_buffer_pool.lock().await.cached_row_count(&segment_path) };
+        let start_index = match cached_start_index {
+            Some(count) => count,
+            None => {
+                let meta = self.read_segment_meta(&meta_path).await?;
+                let start_index = meta.next_row_index;
+                self.row_buffer_pool
+                    .lock()
+                    .await
+                    .seed_row_count(segment_path.clone(), start_index);
+                start_index
             }
         };
 
-        let frame = encode_row_frames(rows)?;
+        let frame = encode_live_row_frames(rows)?;
 
         let buffered_bytes = {
             self.row_buffer_pool
@@ -137,7 +144,15 @@ impl DBEngine {
             let target = rows.get_mut(row_index).ok_or_else(|| {
                 ExecuteError::wrap(format!("row index '{}' not found", row_index))
             })?;
-            *target = row;
+
+            if target.is_none() {
+                return Err(ExecuteError::wrap(format!(
+                    "row index '{}' is deleted",
+                    row_index
+                )));
+            }
+
+            *target = Some(row);
         }
 
         self.row_buffer_pool
@@ -148,6 +163,8 @@ impl DBEngine {
         Ok(())
     }
 
+    /// DELETE는 세그먼트를 압축하지 않고 tombstone으로 표시합니다.
+    /// row index는 절대 재사용하지 않으므로 인덱스가 안정적으로 유지됩니다.
     pub(crate) async fn delete_table_rows(
         &self,
         table_name: &TableName,
@@ -160,7 +177,7 @@ impl DBEngine {
         let _guard = self.row_storage_lock.lock().await;
         let segment_path = self.row_segment_path(table_name)?;
         let cached_rows = { self.row_buffer_pool.lock().await.cached_rows(&segment_path) };
-        let rows = match cached_rows {
+        let mut rows = match cached_rows {
             Some(rows) => rows,
             None => {
                 let disk_rows = self.read_segment_rows(&segment_path).await?;
@@ -170,12 +187,13 @@ impl DBEngine {
                     .read_rows(segment_path.clone(), || disk_rows)
             }
         };
-        let rows = rows
-            .into_iter()
-            .enumerate()
-            .filter(|(row_index, _)| !row_indexes.contains(row_index))
-            .map(|(_, row)| row)
-            .collect::<Vec<_>>();
+
+        for row_index in row_indexes {
+            let target = rows.get_mut(row_index).ok_or_else(|| {
+                ExecuteError::wrap(format!("row index '{}' not found", row_index))
+            })?;
+            *target = None;
+        }
 
         self.row_buffer_pool
             .lock()
@@ -185,7 +203,12 @@ impl DBEngine {
         Ok(())
     }
 
-    async fn read_segment_rows(&self, segment_path: &Path) -> errors::Result<Vec<TableDataRow>> {
+    /// Reads every frame in the segment in order. `None` marks a tombstoned
+    /// row; the position in the returned Vec is its stable row index.
+    async fn read_segment_rows(
+        &self,
+        segment_path: &Path,
+    ) -> errors::Result<Vec<Option<TableDataRow>>> {
         let content = match tokio::fs::read(segment_path).await {
             Ok(content) => content,
             Err(error) if error.kind() == IOErrorKind::NotFound => return Ok(Vec::new()),
@@ -197,11 +220,14 @@ impl DBEngine {
         let mut offset = 0;
 
         while offset < content.len() {
-            if content.len() - offset < size_of::<u32>() {
+            if content.len() - offset < size_of::<u8>() + size_of::<u32>() {
                 return Err(ExecuteError::wrap(
                     "truncated row segment frame header".to_string(),
                 ));
             }
+
+            let tombstoned = content[offset] != ROW_FRAME_LIVE;
+            offset += size_of::<u8>();
 
             let frame_len = u32::from_le_bytes(
                 content[offset..offset + size_of::<u32>()]
@@ -216,12 +242,17 @@ impl DBEngine {
                 ));
             }
 
-            let row = encoder
-                .decode::<TableDataRow>(&content[offset..offset + frame_len])
-                .map_err(|error| {
-                    ExecuteError::wrap(format!("invalid row segment frame: {}", error))
-                })?;
-            rows.push(row);
+            if tombstoned {
+                rows.push(None);
+            } else {
+                let row = encoder
+                    .decode::<TableDataRow>(&content[offset..offset + frame_len])
+                    .map_err(|error| {
+                        ExecuteError::wrap(format!("invalid row segment frame: {}", error))
+                    })?;
+                rows.push(Some(row));
+            }
+
             offset += frame_len;
         }
 
@@ -275,6 +306,12 @@ impl DBEngine {
             }
         };
 
+        if let Some(parent) = write.segment_path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+        }
+
         let mut file = match tokio::fs::OpenOptions::new()
             .create(true)
             .write(true)
@@ -301,6 +338,14 @@ impl DBEngine {
                 .await
                 .map_err(|error| ExecuteError::wrap(error.to_string()))?;
         }
+
+        self.write_segment_meta(
+            &self.row_segment_meta_path_from_segment_path(&write.segment_path),
+            &RowSegmentMeta {
+                next_row_index: write.next_row_index,
+            },
+        )
+        .await?;
 
         Ok(())
     }
@@ -336,6 +381,18 @@ impl DBEngine {
     }
 
     pub(crate) fn row_segment_path(&self, table_name: &TableName) -> errors::Result<PathBuf> {
+        Ok(self.table_rows_directory(table_name)?.join(ROW_SEGMENT_FILENAME))
+    }
+
+    fn row_segment_meta_path(&self, table_name: &TableName) -> errors::Result<PathBuf> {
+        Ok(self.table_rows_directory(table_name)?.join(ROW_META_FILENAME))
+    }
+
+    fn row_segment_meta_path_from_segment_path(&self, segment_path: &Path) -> PathBuf {
+        segment_path.with_file_name(ROW_META_FILENAME)
+    }
+
+    fn table_rows_directory(&self, table_name: &TableName) -> errors::Result<PathBuf> {
         let database_name = table_name
             .database_name
             .as_ref()
@@ -346,8 +403,43 @@ impl DBEngine {
             .join(database_name)
             .join("tables")
             .join(&table_name.table_name)
-            .join("rows")
-            .join(ROW_SEGMENT_FILENAME))
+            .join("rows"))
+    }
+
+    async fn read_segment_meta(&self, meta_path: &Path) -> errors::Result<RowSegmentMeta> {
+        match tokio::fs::read(meta_path).await {
+            Ok(content) => {
+                let encoder = StorageEncoder::new();
+                encoder.decode::<RowSegmentMeta>(&content).map_err(|error| {
+                    ExecuteError::wrap(format!("invalid row segment meta: {}", error))
+                })
+            }
+            Err(error) if error.kind() == IOErrorKind::NotFound => Ok(RowSegmentMeta::default()),
+            Err(error) => Err(ExecuteError::wrap(error.to_string())),
+        }
+    }
+
+    async fn write_segment_meta(
+        &self,
+        meta_path: &Path,
+        meta: &RowSegmentMeta,
+    ) -> errors::Result<()> {
+        if let Some(parent) = meta_path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+        }
+
+        let encoder = StorageEncoder::new();
+        let encoded = encoder.encode(meta);
+        let temp_path = meta_path.with_extension("bin.tmp");
+
+        tokio::fs::write(&temp_path, encoded)
+            .await
+            .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+        tokio::fs::rename(&temp_path, meta_path)
+            .await
+            .map_err(|error| ExecuteError::wrap(error.to_string()))
     }
 
     /// 인덱스 스캔: 인덱스에서 row index 목록을 조회한 뒤 해당 행만 반환합니다.
@@ -377,7 +469,6 @@ impl DBEngine {
             return Ok(Vec::new());
         }
 
-        // TODO(#195): 세그먼트 프레임 오프셋을 인덱스에 저장해 부분 읽기로 최적화
         let _guard = self.row_storage_lock.lock().await;
         let segment_path = self.row_segment_path(&table_name)?;
         let cached_rows = { self.row_buffer_pool.lock().await.cached_rows(&segment_path) };
@@ -403,8 +494,8 @@ impl DBEngine {
             })?;
 
             match all_rows.get(row_index) {
-                Some(row) => result.push((RowLocation { row_index }, row.clone())),
-                None => {
+                Some(Some(row)) => result.push((RowLocation { row_index }, row.clone())),
+                Some(None) | None => {
                     return Err(ExecuteError::wrap(format!(
                         "index '{}' is out of sync with table data; drop and recreate the index",
                         plan.index_name
@@ -461,12 +552,20 @@ mod tests {
             .unwrap();
 
         let scanned = engine.full_scan(table_name).await.unwrap();
-        let segment_path = rows_path.join("00000001.rows");
+        let mut dir_entries = tokio::fs::read_dir(&rows_path).await.unwrap();
+        let mut segment_file_count = 0;
+        while let Some(entry) = dir_entries.next_entry().await.unwrap() {
+            if entry.file_type().await.unwrap().is_file()
+                && entry.path().extension().and_then(|ext| ext.to_str()) == Some("rows")
+            {
+                segment_file_count += 1;
+            }
+        }
 
         assert_eq!(scanned.len(), 2);
         assert_eq!(scanned[0].1.fields[0].data, TableDataFieldType::Integer(1));
         assert_eq!(scanned[1].1.fields[0].data, TableDataFieldType::Integer(2));
-        assert!(!segment_path.exists());
+        assert_eq!(segment_file_count, 0);
     }
 
     #[tokio::test]
@@ -490,13 +589,6 @@ mod tests {
 
         let engine = DBEngine::new(config);
         let row = |id| TableDataRow {
-            fields: vec![TableDataField {
-                table_name: table_name.clone(),
-                column_name: "id".to_string(),
-                data: TableDataFieldType::Integer(id),
-            }],
-        };
-        let row2 = |id| TableDataRow {
             fields: vec![TableDataField {
                 table_name: table_name.clone(),
                 column_name: "id".to_string(),
@@ -531,9 +623,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_table_rows_removes_buffered_rows_without_flushing_segment_file() {
+    async fn delete_table_rows_tombstones_in_place_and_keeps_row_indices_stable() {
         let base_path = PathBuf::from(format!(
-            "target/test_row_segments/delete_buffered_rows_{}",
+            "target/test_row_segments/soft_delete_stable_{}",
             std::process::id()
         ));
         if base_path.exists() {
@@ -564,12 +656,23 @@ mod tests {
             .unwrap();
 
         engine
-            .delete_table_rows(&table_name, HashSet::from([0, 2]))
+            .delete_table_rows(&table_name, HashSet::from([1usize]))
             .await
             .unwrap();
 
+        let scanned = engine.full_scan(table_name.clone()).await.unwrap();
+        assert_eq!(scanned.len(), 2);
+        assert_eq!(scanned[0].0.row_index, 0);
+        assert_eq!(scanned[0].1.fields[0].data, TableDataFieldType::Integer(1));
+        assert_eq!(scanned[1].0.row_index, 2);
+        assert_eq!(scanned[1].1.fields[0].data, TableDataFieldType::Integer(3));
+
+        let start_index = engine.append_table_rows(&table_name, &[row(4)]).await.unwrap();
+        assert_eq!(start_index, 3);
+
         let scanned = engine.full_scan(table_name).await.unwrap();
-        assert_eq!(scanned.len(), 1);
-        assert_eq!(scanned[0].1.fields[0].data, TableDataFieldType::Integer(2));
+        assert_eq!(scanned.len(), 3);
+        assert_eq!(scanned[2].0.row_index, 3);
+        assert_eq!(scanned[2].1.fields[0].data, TableDataFieldType::Integer(4));
     }
 }

--- a/src/engine/actions/dml/scan.rs
+++ b/src/engine/actions/dml/scan.rs
@@ -10,7 +10,7 @@ use crate::engine::DBEngine;
 use crate::engine::ast::dml::plan::select::scan::IndexScanPlan;
 use crate::engine::ast::types::TableName;
 use crate::engine::encoder::schema_encoder::StorageEncoder;
-use crate::engine::row_buffer::{RowBufferWrite, encode_live_row_frames};
+use crate::engine::row_buffer::{ROW_FRAME_LIVE, RowBufferWrite, encode_live_row_frames};
 use crate::engine::schema::row::TableDataRow;
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
@@ -18,8 +18,7 @@ use crate::errors::execute_error::ExecuteError;
 const ROW_SEGMENT_FILENAME: &str = "00000001.rows";
 const ROW_META_FILENAME: &str = "meta.bin";
 const DEFAULT_ROW_WRITE_BUFFER_LIMIT_BYTES: usize = 16 * 1024 * 1024;
-const ROW_FRAME_LIVE: u8 = 0;
-const ROW_FRAME_TOMBSTONE: u8 = 1;
+
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct RowLocation {

--- a/src/engine/actions/dml/scan.rs
+++ b/src/engine/actions/dml/scan.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use tokio::io::AsyncWriteExt;
 
 use crate::engine::DBEngine;
+use crate::engine::ast::dml::plan::select::scan::IndexScanPlan;
 use crate::engine::ast::types::TableName;
 use crate::engine::encoder::schema_encoder::StorageEncoder;
 use crate::engine::schema::row::TableDataRow;
@@ -33,17 +34,23 @@ impl DBEngine {
             .collect())
     }
 
+    /// 행을 세그먼트 파일 끝에 추가하고 시작 row index를 반환합니다.
+    /// 반환된 시작 인덱스는 인덱스 유지보수(key -> row index)에 사용됩니다.
     pub(crate) async fn append_table_rows(
         &self,
         table_name: &TableName,
         rows: &[TableDataRow],
-    ) -> errors::Result<()> {
+    ) -> errors::Result<usize> {
         if rows.is_empty() {
-            return Ok(());
+            return Ok(0);
         }
 
         let _guard = self.row_storage_lock.lock().await;
         let segment_path = self.row_segment_path(table_name)?;
+
+        // TODO(#217): 행 개수를 메타데이터로 유지해 O(n) 카운트를 제거
+        let start_index = self.read_segment_rows(&segment_path).await?.len();
+
         let encoder = StorageEncoder::new();
         let mut frame = Vec::new();
 
@@ -64,7 +71,9 @@ impl DBEngine {
 
         file.write_all(&frame)
             .await
-            .map_err(|error| ExecuteError::wrap(error.to_string()))
+            .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+
+        Ok(start_index)
     }
 
     pub(crate) async fn update_table_rows(
@@ -174,7 +183,7 @@ impl DBEngine {
             .map_err(|error| ExecuteError::wrap(error.to_string()))
     }
 
-    fn row_segment_path(&self, table_name: &TableName) -> errors::Result<PathBuf> {
+    pub(crate) fn row_segment_path(&self, table_name: &TableName) -> errors::Result<PathBuf> {
         let database_name = table_name
             .database_name
             .as_ref()
@@ -189,7 +198,60 @@ impl DBEngine {
             .join(ROW_SEGMENT_FILENAME))
     }
 
-    pub async fn index_scan(&self, _table_name: TableName) {}
+    /// 인덱스 스캔: 인덱스에서 row index 목록을 조회한 뒤 해당 행만 반환합니다.
+    pub(crate) async fn index_scan(
+        &self,
+        table_name: TableName,
+        plan: &IndexScanPlan,
+    ) -> errors::Result<Vec<(RowLocation, TableDataRow)>> {
+        self.ensure_indices_loaded().await?;
+
+        let row_paths: Vec<String> = match &plan.eq_key {
+            Some(key) => self.index_manager.get(&plan.index_name, key).await?,
+            None => self
+                .index_manager
+                .range(
+                    &plan.index_name,
+                    plan.start_key.as_deref(),
+                    plan.end_key.as_deref(),
+                )
+                .await?
+                .into_iter()
+                .map(|entry| entry.row_path)
+                .collect(),
+        };
+
+        if row_paths.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // TODO(#195): 세그먼트 프레임 오프셋을 인덱스에 저장해 부분 읽기로 최적화
+        let segment_path = self.row_segment_path(&table_name)?;
+        let all_rows = self.read_segment_rows(&segment_path).await?;
+
+        let mut result = Vec::with_capacity(row_paths.len());
+
+        for row_path in row_paths {
+            let row_index = row_path.parse::<usize>().map_err(|_| {
+                ExecuteError::wrap(format!(
+                    "index '{}' has invalid row path '{}'",
+                    plan.index_name, row_path
+                ))
+            })?;
+
+            match all_rows.get(row_index) {
+                Some(row) => result.push((RowLocation { row_index }, row.clone())),
+                None => {
+                    return Err(ExecuteError::wrap(format!(
+                        "index '{}' is out of sync with table data; drop and recreate the index",
+                        plan.index_name
+                    )));
+                }
+            }
+        }
+
+        Ok(result)
+    }
 }
 
 #[cfg(test)]

--- a/src/engine/actions/dml/scan.rs
+++ b/src/engine/actions/dml/scan.rs
@@ -36,7 +36,7 @@ impl DBEngine {
                 self.row_buffer_pool
                     .lock()
                     .await
-                    .read_rows(segment_path, disk_rows)
+                    .read_rows(segment_path, || disk_rows)
             }
         };
 
@@ -75,16 +75,24 @@ impl DBEngine {
         let _guard = self.row_storage_lock.lock().await;
         let segment_path = self.row_segment_path(table_name)?;
 
-        // 버퍼 풀의 현재 행 개수를 시작 인덱스로 사용
-        let start_index = self
-            .row_buffer_pool
-            .lock()
-            .await
-            .cached_row_count(&segment_path)
-            .unwrap_or_else(|| {
-                // 첫 접근 시 persisted_rows가 없으므로 디스크에서 읽어 계산
-                0
-            });
+        // 버퍼 풀의 현재 행 개수를 시작 인덱스로 사용.
+        // persisted_rows가 적재되지 않았으면 먼저 디스크에서 읽어온다.
+        let start_index = {
+            let pool_guard = self.row_buffer_pool.lock().await;
+            match pool_guard.cached_row_count(&segment_path) {
+                Some(count) => count,
+                None => {
+                    drop(pool_guard);
+                    let disk_rows = self.read_segment_rows(&segment_path).await?;
+                    let count = disk_rows.len();
+                    self.row_buffer_pool
+                        .lock()
+                        .await
+                        .read_rows(segment_path.clone(), || disk_rows);
+                    count
+                }
+            }
+        };
 
         let frame = encode_row_frames(rows)?;
 
@@ -121,7 +129,7 @@ impl DBEngine {
                 self.row_buffer_pool
                     .lock()
                     .await
-                    .read_rows(segment_path.clone(), disk_rows)
+                    .read_rows(segment_path.clone(), || disk_rows)
             }
         };
 
@@ -159,7 +167,7 @@ impl DBEngine {
                 self.row_buffer_pool
                     .lock()
                     .await
-                    .read_rows(segment_path.clone(), disk_rows)
+                    .read_rows(segment_path.clone(), || disk_rows)
             }
         };
         let rows = rows
@@ -380,7 +388,7 @@ impl DBEngine {
                 self.row_buffer_pool
                     .lock()
                     .await
-                    .read_rows(segment_path, disk_rows)
+                    .read_rows(segment_path, || disk_rows)
             }
         };
 

--- a/src/engine/actions/dml/select.rs
+++ b/src/engine/actions/dml/select.rs
@@ -147,8 +147,16 @@ impl DBEngine {
     }
 
     pub async fn select(&self, query: SelectQuery) -> errors::Result<ExecuteResult> {
-        // 최적화 작업
-        let optimizer = Optimizer::new();
+        // 최적화 작업 (FROM 대상 테이블의 인덱스/통계로 컨텍스트 구성)
+        let optimizer = match &query.from_table {
+            Some(from_clause) => match &from_clause.from {
+                FromTarget::Table(table_name) => {
+                    Optimizer::with_context(self.build_optimizer_context(table_name).await)
+                }
+                FromTarget::Subquery(_) => Optimizer::new(),
+            },
+            None => Optimizer::new(),
+        };
 
         let select_items = query.select_items.clone();
 
@@ -191,8 +199,15 @@ impl DBEngine {
 
                             rows.append(&mut result);
                         }
-                        ScanType::IndexScan(_index) => {
-                            unimplemented!()
+                        ScanType::IndexScan(index_scan_plan) => {
+                            let mut result = self
+                                .index_scan(table_name, &index_scan_plan)
+                                .await?
+                                .into_iter()
+                                .map(|(_, row)| row)
+                                .collect();
+
+                            rows.append(&mut result);
                         }
                     }
                 }

--- a/src/engine/actions/dml/update.rs
+++ b/src/engine/actions/dml/update.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use futures::future::join_all;
 
+use crate::engine::actions::index::row_index_key;
 use crate::engine::ast::dml::plan::select::scan::ScanType;
 use crate::engine::ast::dml::plan::update::update_plan::UpdatePlanItem;
 use crate::engine::ast::dml::update::UpdateQuery;
@@ -29,8 +30,8 @@ impl DBEngine {
         let table = query.target_table.clone().unwrap().table;
         let update_items = query.update_items.clone();
 
-        // 최적화 작업
-        let optimizer = Optimizer::new();
+        // 최적화 작업 (대상 테이블의 인덱스/통계로 컨텍스트 구성)
+        let optimizer = Optimizer::with_context(self.build_optimizer_context(&table).await);
 
         let plan = optimizer.optimize_update(query).await?;
 
@@ -60,8 +61,10 @@ impl DBEngine {
 
                             rows.append(&mut result);
                         }
-                        ScanType::IndexScan(_index) => {
-                            unimplemented!()
+                        ScanType::IndexScan(index_scan_plan) => {
+                            let mut result = self.index_scan(table_name, &index_scan_plan).await?;
+
+                            rows.append(&mut result);
                         }
                     }
                 }
@@ -119,9 +122,15 @@ impl DBEngine {
             .collect::<Vec<_>>();
 
         // 수정 작업
+        self.ensure_indices_loaded().await?;
+        let index_metas = self.table_index_metas(&table).await;
+
         let mut replacements = HashMap::new();
+        // 인덱스 반영 목록: (index_name, old_key, new_key, row_path)
+        let mut index_operations: Vec<(String, Option<String>, Option<String>, String)> = vec![];
 
         for (location, mut row) in rows.into_iter() {
+            let old_row = row.clone();
             let reduce_context = ReduceContext {
                 row: None,
                 table_alias_map: table_alias_map.clone(),
@@ -150,18 +159,65 @@ impl DBEngine {
                 }
             }
 
+            // 인덱스 컬럼 값 변경 감지 (#217)
+            for meta in &index_metas {
+                let old_key = row_index_key(&old_row, &meta.column_name);
+                let new_key = row_index_key(&row, &meta.column_name);
+
+                if old_key != new_key {
+                    index_operations.push((
+                        meta.index_name.clone(),
+                        old_key,
+                        new_key,
+                        location.row_index.to_string(),
+                    ));
+                }
+            }
+
             replacements.insert(location.row_index, row);
         }
 
         let affected_rows = replacements.len();
 
         if !replacements.is_empty() {
+            // 인덱스 선반영: 고유 제약 위반은 여기서 검출되며, 실패 시 적용분을 되돌립니다
+            let mut applied = 0;
+
+            for (index_name, old_key, new_key, row_path) in &index_operations {
+                if let Err(error) = self
+                    .apply_index_operation(index_name, old_key, new_key, row_path)
+                    .await
+                {
+                    for (index_name, old_key, new_key, row_path) in
+                        index_operations[..applied].iter().rev()
+                    {
+                        let _ = self
+                            .apply_index_operation(index_name, new_key, old_key, row_path)
+                            .await;
+                    }
+
+                    return Err(error);
+                }
+
+                applied += 1;
+            }
+
             wal_manager
                 .lock()
                 .await
                 .append_record(EntryType::Set, Some(wal_payload), None)
                 .await?;
-            self.update_table_rows(&table, replacements).await?;
+
+            if let Err(error) = self.update_table_rows(&table, replacements).await {
+                // 저장 실패 시 인덱스 되돌리기
+                for (index_name, old_key, new_key, row_path) in index_operations.iter().rev() {
+                    let _ = self
+                        .apply_index_operation(index_name, new_key, old_key, row_path)
+                        .await;
+                }
+
+                return Err(error);
+            }
         }
 
         Ok(ExecuteResult::with_affected_rows(

--- a/src/engine/actions/dml/update.rs
+++ b/src/engine/actions/dml/update.rs
@@ -202,11 +202,21 @@ impl DBEngine {
                 applied += 1;
             }
 
-            wal_manager
+            // WAL 기록: 실패 시 선반영한 인덱스 변경을 되돌립니다
+            if let Err(error) = wal_manager
                 .lock()
                 .await
                 .append_record(EntryType::Set, Some(wal_payload), None)
-                .await?;
+                .await
+            {
+                for (index_name, old_key, new_key, row_path) in index_operations.iter().rev() {
+                    let _ = self
+                        .apply_index_operation(index_name, new_key, old_key, row_path)
+                        .await;
+                }
+
+                return Err(error);
+            }
 
             if let Err(error) = self.update_table_rows(&table, replacements).await {
                 // 저장 실패 시 인덱스 되돌리기

--- a/src/engine/actions/dml/update.rs
+++ b/src/engine/actions/dml/update.rs
@@ -210,15 +210,15 @@ impl DBEngine {
             }
 
             // 인덱스 반영: 고유 제약 위반은 여기서 검출되며, 실패 시 적용분을 되돌립니다
-            let mut applied = 0;
-
-            for (index_name, old_key, new_key, row_path) in &index_operations {
+            for (i, (index_name, old_key, new_key, row_path)) in
+                index_operations.iter().enumerate()
+            {
                 if let Err(error) = self
                     .apply_index_operation(index_name, old_key, new_key, row_path)
                     .await
                 {
                     for (index_name, old_key, new_key, row_path) in
-                        index_operations[..applied].iter().rev()
+                        index_operations[..i].iter().rev()
                     {
                         let _ = self
                             .apply_index_operation(index_name, new_key, old_key, row_path)
@@ -227,8 +227,6 @@ impl DBEngine {
 
                     return Err(error);
                 }
-
-                applied += 1;
             }
 
             if let Err(error) = self.update_table_rows(&table, replacements).await {

--- a/src/engine/actions/dml/update.rs
+++ b/src/engine/actions/dml/update.rs
@@ -24,8 +24,28 @@ impl DBEngine {
         query: UpdateQuery,
         wal_manager: SharedWALManager,
     ) -> errors::Result<ExecuteResult> {
-        let wal_payload =
-            bincode::serialize(&query).map_err(|error| ExecuteError::wrap(error.to_string()))?;
+        self.update_internal(query, Some(wal_manager)).await
+    }
+
+    /// Re-applies a previously WAL-logged UPDATE during crash recovery
+    /// replay. Identical to `update()` but skips the WAL append (the
+    /// operation is already durably recorded in the WAL being replayed).
+    pub(crate) async fn update_replay(&self, query: UpdateQuery) -> errors::Result<ExecuteResult> {
+        self.update_internal(query, None).await
+    }
+
+    async fn update_internal(
+        &self,
+        query: UpdateQuery,
+        wal_manager: Option<SharedWALManager>,
+    ) -> errors::Result<ExecuteResult> {
+        // WAL-first: 쿼리를 실행/소비하기 전에 페이로드를 미리 직렬화합니다.
+        let wal_payload = match &wal_manager {
+            Some(_) => Some(
+                bincode::serialize(&query).map_err(|error| ExecuteError::wrap(error.to_string()))?,
+            ),
+            None => None,
+        };
 
         let table = query.target_table.clone().unwrap().table;
         let update_items = query.update_items.clone();
@@ -180,7 +200,16 @@ impl DBEngine {
         let affected_rows = replacements.len();
 
         if !replacements.is_empty() {
-            // 인덱스 선반영: 고유 제약 위반은 여기서 검출되며, 실패 시 적용분을 되돌립니다
+            // WAL-first: 인덱스/테이블을 변경하기 전에 먼저 durable하게 기록합니다.
+            if let Some(wal_manager) = &wal_manager {
+                wal_manager
+                    .lock()
+                    .await
+                    .append_record(EntryType::Set, wal_payload, None)
+                    .await?;
+            }
+
+            // 인덱스 반영: 고유 제약 위반은 여기서 검출되며, 실패 시 적용분을 되돌립니다
             let mut applied = 0;
 
             for (index_name, old_key, new_key, row_path) in &index_operations {
@@ -200,22 +229,6 @@ impl DBEngine {
                 }
 
                 applied += 1;
-            }
-
-            // WAL 기록: 실패 시 선반영한 인덱스 변경을 되돌립니다
-            if let Err(error) = wal_manager
-                .lock()
-                .await
-                .append_record(EntryType::Set, Some(wal_payload), None)
-                .await
-            {
-                for (index_name, old_key, new_key, row_path) in index_operations.iter().rev() {
-                    let _ = self
-                        .apply_index_operation(index_name, new_key, old_key, row_path)
-                        .await;
-                }
-
-                return Err(error);
             }
 
             if let Err(error) = self.update_table_rows(&table, replacements).await {

--- a/src/engine/actions/index.rs
+++ b/src/engine/actions/index.rs
@@ -1,0 +1,190 @@
+//! 인덱스 유지보수를 위한 DBEngine 공용 헬퍼 (#217)
+
+use std::collections::HashMap;
+
+use crate::engine::DBEngine;
+use crate::engine::ast::types::TableName;
+use crate::engine::index::{IndexEntry, IndexMeta, field_to_key};
+use crate::engine::optimizer::cost::BLOCK_SIZE;
+use crate::engine::optimizer::predule::{OptimizerContext, TableStatistics};
+use crate::engine::schema::row::{TableDataFieldType, TableDataRow};
+use crate::errors;
+use crate::errors::execute_error::ExecuteError;
+
+/// 인덱스 이름을 데이터베이스 범위로 한정합니다.
+/// IndexManager는 이름을 전역 키로 사용하므로 데이터베이스 간 충돌을 막습니다.
+pub(crate) fn qualified_index_name(database_name: &str, index_name: &str) -> String {
+    format!("{}.{}", database_name, index_name)
+}
+
+/// 행의 특정 컬럼 값을 인덱스 키로 변환합니다.
+/// NULL 값은 색인하지 않습니다 (PostgreSQL과 동일하게 unique 제약에서도 제외).
+pub(crate) fn row_index_key(row: &TableDataRow, column_name: &str) -> Option<String> {
+    row.fields
+        .iter()
+        .find(|field| field.column_name == column_name)
+        .and_then(|field| match &field.data {
+            TableDataFieldType::Null => None,
+            data => Some(field_to_key(data)),
+        })
+}
+
+impl DBEngine {
+    /// 서버 기동 후 최초 인덱스 사용 시점에 디스크의 인덱스 파일을 메모리로 적재합니다.
+    pub(crate) async fn ensure_indices_loaded(&self) -> errors::Result<()> {
+        self.indices_loaded
+            .get_or_try_init(|| async {
+                let base_path = self.get_data_directory();
+
+                if !base_path.exists() {
+                    return Ok(());
+                }
+
+                let mut entries = tokio::fs::read_dir(&base_path).await.map_err(|error| {
+                    ExecuteError::wrap(format!("failed to read data directory: {}", error))
+                })?;
+
+                while let Some(entry) = entries.next_entry().await.map_err(|error| {
+                    ExecuteError::wrap(format!("failed to read data directory entry: {}", error))
+                })? {
+                    let path = entry.path();
+
+                    if !path.is_dir() {
+                        continue;
+                    }
+
+                    if let Some(database_name) = path.file_name().and_then(|name| name.to_str()) {
+                        self.index_manager
+                            .load_database_indices(database_name)
+                            .await?;
+                    }
+                }
+
+                Ok(())
+            })
+            .await
+            .map(|_| ())
+    }
+
+    /// 테이블에 속한 인덱스 메타 목록을 반환합니다.
+    pub(crate) async fn table_index_metas(&self, table_name: &TableName) -> Vec<IndexMeta> {
+        self.index_manager.indices_for_table(table_name).await
+    }
+
+    /// 인덱스 항목 하나를 (old_key -> new_key)로 반영합니다. UPDATE 유지보수용.
+    pub(crate) async fn apply_index_operation(
+        &self,
+        index_name: &str,
+        old_key: &Option<String>,
+        new_key: &Option<String>,
+        row_path: &str,
+    ) -> errors::Result<()> {
+        match (old_key, new_key) {
+            (Some(old_key), Some(new_key)) => {
+                self.index_manager
+                    .update(index_name, old_key, new_key.clone(), row_path.to_string())
+                    .await
+            }
+            (Some(old_key), None) => self
+                .index_manager
+                .remove(index_name, old_key, row_path)
+                .await
+                .map(|_| ()),
+            (None, Some(new_key)) => {
+                self.index_manager
+                    .insert(index_name, new_key.clone(), row_path.to_string())
+                    .await
+            }
+            (None, None) => Ok(()),
+        }
+    }
+
+    /// 테이블의 모든 인덱스를 현재 행 데이터 기준으로 재구축합니다.
+    /// DELETE는 세그먼트를 압축해 row index가 밀리므로 재구축이 필요합니다.
+    pub(crate) async fn rebuild_table_indices(&self, table_name: &TableName) -> errors::Result<()> {
+        let metas = self.table_index_metas(table_name).await;
+
+        if metas.is_empty() {
+            return Ok(());
+        }
+
+        let rows = self.full_scan(table_name.clone()).await?;
+
+        for meta in metas {
+            let entries = rows
+                .iter()
+                .filter_map(|(location, row)| {
+                    row_index_key(row, &meta.column_name).map(|key| IndexEntry {
+                        key,
+                        row_path: location.row_index.to_string(),
+                    })
+                })
+                .collect();
+
+            self.index_manager
+                .replace_entries(&meta.index_name, entries)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// 테이블 통계를 반환합니다. 캐시가 없으면 실제 스캔으로 계산 후 캐싱합니다.
+    pub(crate) async fn table_statistics(
+        &self,
+        table_name: &TableName,
+    ) -> errors::Result<TableStatistics> {
+        if let Some(statistics) = self.statistics_manager.get(table_name).await {
+            return Ok(statistics);
+        }
+
+        let row_count = self.full_scan(table_name.clone()).await?.len();
+
+        let segment_path = self.row_segment_path(table_name)?;
+        let file_size = tokio::fs::metadata(&segment_path)
+            .await
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        let block_count = file_size.div_ceil(BLOCK_SIZE).max(1) as usize;
+
+        let mut distinct_values = HashMap::new();
+        for meta in self.table_index_metas(table_name).await {
+            if let Ok(distinct) = self.index_manager.distinct_keys(&meta.index_name).await {
+                distinct_values.insert(meta.column_name.clone(), distinct);
+            }
+        }
+
+        let statistics = TableStatistics {
+            row_count,
+            block_count,
+            distinct_values,
+        };
+
+        self.statistics_manager
+            .set(table_name.clone(), statistics.clone())
+            .await;
+
+        Ok(statistics)
+    }
+
+    /// 옵티마이저 컨텍스트를 구성합니다.
+    /// 실패해도 쿼리는 FullScan으로 동작해야 하므로 오류는 빈 컨텍스트로 흡수합니다.
+    pub(crate) async fn build_optimizer_context(&self, table_name: &TableName) -> OptimizerContext {
+        if self.ensure_indices_loaded().await.is_err() {
+            return OptimizerContext::default();
+        }
+
+        let indexes = self.table_index_metas(table_name).await;
+
+        if indexes.is_empty() {
+            return OptimizerContext::default();
+        }
+
+        let statistics = self.table_statistics(table_name).await.ok();
+
+        OptimizerContext {
+            indexes,
+            statistics,
+        }
+    }
+}

--- a/src/engine/actions/index.rs
+++ b/src/engine/actions/index.rs
@@ -168,9 +168,14 @@ impl DBEngine {
     }
 
     /// 옵티마이저 컨텍스트를 구성합니다.
-    /// 실패해도 쿼리는 FullScan으로 동작해야 하므로 오류는 빈 컨텍스트로 흡수합니다.
+    /// 실패해도 쿼리는 FullScan으로 동작해야 하므로 오류는 빈 컨텍스트로 흡수하지만,
+    /// 디버깅을 위해 warn 로그를 남깁니다.
     pub(crate) async fn build_optimizer_context(&self, table_name: &TableName) -> OptimizerContext {
-        if self.ensure_indices_loaded().await.is_err() {
+        if let Err(error) = self.ensure_indices_loaded().await {
+            log::warn!(
+                "build_optimizer_context: ensure_indices_loaded failed for {:?}: {}",
+                table_name, error
+            );
             return OptimizerContext::default();
         }
 
@@ -180,7 +185,16 @@ impl DBEngine {
             return OptimizerContext::default();
         }
 
-        let statistics = self.table_statistics(table_name).await.ok();
+        let statistics = match self.table_statistics(table_name).await {
+            Ok(statistics) => Some(statistics),
+            Err(error) => {
+                log::warn!(
+                    "build_optimizer_context: table_statistics failed for {:?}: {}",
+                    table_name, error
+                );
+                None
+            }
+        };
 
         OptimizerContext {
             indexes,

--- a/src/engine/actions/index.rs
+++ b/src/engine/actions/index.rs
@@ -174,7 +174,8 @@ impl DBEngine {
         if let Err(error) = self.ensure_indices_loaded().await {
             log::warn!(
                 "build_optimizer_context: ensure_indices_loaded failed for {:?}: {}",
-                table_name, error
+                table_name,
+                error
             );
             return OptimizerContext::default();
         }
@@ -190,7 +191,8 @@ impl DBEngine {
             Err(error) => {
                 log::warn!(
                     "build_optimizer_context: table_statistics failed for {:?}: {}",
-                    table_name, error
+                    table_name,
+                    error
                 );
                 None
             }

--- a/src/engine/actions/index.rs
+++ b/src/engine/actions/index.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::engine::DBEngine;
 use crate::engine::ast::types::TableName;
-use crate::engine::index::{IndexEntry, IndexMeta, field_to_key};
+use crate::engine::index::{IndexMeta, field_to_key};
 use crate::engine::optimizer::cost::BLOCK_SIZE;
 use crate::engine::optimizer::predule::{OptimizerContext, TableStatistics};
 use crate::engine::schema::row::{TableDataFieldType, TableDataRow};
@@ -97,36 +97,6 @@ impl DBEngine {
             }
             (None, None) => Ok(()),
         }
-    }
-
-    /// 테이블의 모든 인덱스를 현재 행 데이터 기준으로 재구축합니다.
-    /// DELETE는 세그먼트를 압축해 row index가 밀리므로 재구축이 필요합니다.
-    pub(crate) async fn rebuild_table_indices(&self, table_name: &TableName) -> errors::Result<()> {
-        let metas = self.table_index_metas(table_name).await;
-
-        if metas.is_empty() {
-            return Ok(());
-        }
-
-        let rows = self.full_scan(table_name.clone()).await?;
-
-        for meta in metas {
-            let entries = rows
-                .iter()
-                .filter_map(|(location, row)| {
-                    row_index_key(row, &meta.column_name).map(|key| IndexEntry {
-                        key,
-                        row_path: location.row_index.to_string(),
-                    })
-                })
-                .collect();
-
-            self.index_manager
-                .replace_entries(&meta.index_name, entries)
-                .await?;
-        }
-
-        Ok(())
     }
 
     /// 테이블 통계를 반환합니다. 캐시가 없으면 실제 스캔으로 계산 후 캐싱합니다.

--- a/src/engine/actions/mod.rs
+++ b/src/engine/actions/mod.rs
@@ -1,3 +1,4 @@
 pub mod ddl;
 pub mod dml;
 pub mod etc;
+pub mod index;

--- a/src/engine/ast/ddl/create_index.rs
+++ b/src/engine/ast/ddl/create_index.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::engine::ast::{DDLStatement, SQLStatement, types::TableName};
 
 /*
@@ -5,7 +7,7 @@ CREATE [ UNIQUE ] INDEX [ IF NOT EXISTS ] name ON table_name
     ( column_name [, ...] )
 */
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct CreateIndexQuery {
     pub index_name: String,
     pub table: TableName,

--- a/src/engine/ast/ddl/create_index.rs
+++ b/src/engine/ast/ddl/create_index.rs
@@ -1,18 +1,15 @@
-use crate::engine::ast::{
-    DDLStatement, SQLStatement,
-    types::{Column, TableName},
-};
+use crate::engine::ast::{DDLStatement, SQLStatement, types::TableName};
 
 /*
 CREATE [ UNIQUE ] INDEX [ IF NOT EXISTS ] name ON table_name
     ( column_name [, ...] )
 */
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CreateIndexQuery {
     pub index_name: String,
     pub table: TableName,
-    pub columns: Vec<Column>,
+    pub columns: Vec<String>,
     pub is_unique: bool,
     pub if_not_exists: bool,
 }
@@ -38,8 +35,8 @@ impl CreateIndexQuery {
         self
     }
 
-    pub fn add_column(mut self, column: Column) -> Self {
-        self.columns.push(column);
+    pub fn add_column(mut self, column_name: String) -> Self {
+        self.columns.push(column_name);
         self
     }
 
@@ -60,8 +57,6 @@ impl CreateIndexQuery {
 
 #[cfg(test)]
 mod tests {
-    use crate::engine::ast::types::DataType;
-
     use super::*;
 
     #[test]
@@ -69,12 +64,7 @@ mod tests {
         let query = CreateIndexQuery::builder()
             .set_table(TableName::new(None, "table_name".into()))
             .set_index_name("index_name".into())
-            .add_column(
-                Column::builder()
-                    .set_name("column_name".into())
-                    .set_data_type(DataType::Boolean)
-                    .build(),
-            )
+            .add_column("column_name".into())
             .set_unique(true)
             .set_if_not_exists(true)
             .build();
@@ -82,12 +72,7 @@ mod tests {
         let expected = SQLStatement::DDL(DDLStatement::CreateIndexQuery(CreateIndexQuery {
             table: TableName::new(None, "table_name".into()),
             index_name: "index_name".into(),
-            columns: vec![
-                Column::builder()
-                    .set_name("column_name".into())
-                    .set_data_type(DataType::Boolean)
-                    .build(),
-            ],
+            columns: vec!["column_name".into()],
             is_unique: true,
             if_not_exists: true,
         }));

--- a/src/engine/ast/ddl/drop_index.rs
+++ b/src/engine/ast/ddl/drop_index.rs
@@ -1,0 +1,73 @@
+use crate::engine::ast::{DDLStatement, SQLStatement, types::TableName};
+
+/*
+DROP INDEX [IF EXISTS] index_name [ON [database_name.]table_name];
+*/
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DropIndexQuery {
+    pub index_name: String,
+    /// 인덱스가 속한 데이터베이스명 (파서 컨텍스트 혹은 ON 절에서 결정)
+    pub database_name: Option<String>,
+    /// ON 절로 명시된 테이블 (선택사항)
+    pub table: Option<TableName>,
+    pub if_exists: bool,
+}
+
+impl DropIndexQuery {
+    pub fn builder() -> Self {
+        DropIndexQuery {
+            index_name: "".into(),
+            database_name: None,
+            table: None,
+            if_exists: false,
+        }
+    }
+
+    pub fn set_index_name(mut self, index_name: String) -> Self {
+        self.index_name = index_name;
+        self
+    }
+
+    pub fn set_database_name(mut self, database_name: Option<String>) -> Self {
+        self.database_name = database_name;
+        self
+    }
+
+    pub fn set_table(mut self, table: TableName) -> Self {
+        self.database_name = table.database_name.clone().or(self.database_name);
+        self.table = Some(table);
+        self
+    }
+
+    pub fn set_if_exists(mut self, if_exists: bool) -> Self {
+        self.if_exists = if_exists;
+        self
+    }
+
+    pub fn build(self) -> SQLStatement {
+        SQLStatement::DDL(DDLStatement::DropIndexQuery(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_drop_index() {
+        let query = DropIndexQuery::builder()
+            .set_index_name("index_name".into())
+            .set_table(TableName::new(Some("db".into()), "table_name".into()))
+            .set_if_exists(true)
+            .build();
+
+        let expected = SQLStatement::DDL(DDLStatement::DropIndexQuery(DropIndexQuery {
+            index_name: "index_name".into(),
+            database_name: Some("db".into()),
+            table: Some(TableName::new(Some("db".into()), "table_name".into())),
+            if_exists: true,
+        }));
+
+        assert_eq!(query, expected);
+    }
+}

--- a/src/engine/ast/ddl/drop_index.rs
+++ b/src/engine/ast/ddl/drop_index.rs
@@ -1,9 +1,11 @@
+use serde::{Deserialize, Serialize};
+
 use crate::engine::ast::{DDLStatement, SQLStatement, types::TableName};
 
 /*
 DROP INDEX [IF EXISTS] index_name [ON [database_name.]table_name];
 */
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct DropIndexQuery {
     pub index_name: String,
     /// 인덱스가 속한 데이터베이스명 (파서 컨텍스트 혹은 ON 절에서 결정)

--- a/src/engine/ast/ddl/mod.rs
+++ b/src/engine/ast/ddl/mod.rs
@@ -4,4 +4,5 @@ pub mod create_database;
 pub mod create_index;
 pub mod create_table;
 pub mod drop_database;
+pub mod drop_index;
 pub mod drop_table;

--- a/src/engine/ast/dml/expressions/operators.rs
+++ b/src/engine/ast/dml/expressions/operators.rs
@@ -61,6 +61,7 @@ impl BinaryOperator {
 #[cfg(test)]
 mod tests {
     use super::BinaryOperator;
+    use crate::engine::parser::predule::Parser;
 
     #[test]
     fn test_get_precedence() {
@@ -82,5 +83,83 @@ mod tests {
         assert_eq!(BinaryOperator::NotIn.get_precedence(), 5);
         assert_eq!(BinaryOperator::Is.get_precedence(), 5);
         assert_eq!(BinaryOperator::IsNot.get_precedence(), 5);
+    }
+
+    /// 회귀 테스트: AND/OR/비교 연산자가 섞인 표현식이 올바른 결합 순서로 파싱되는지 검증합니다.
+    /// BinaryOperator::get_precedence의 값 변경 시 이 테스트가 깨져야 합니다.
+    mod operator_precedence_parsing {
+        use crate::engine::ast::dml::expressions::operators::BinaryOperator;
+        use crate::engine::ast::types::SQLExpression;
+        use crate::engine::parser::predule::{Parser, ParserContext};
+
+        fn parse_where(sql: &str) -> SQLExpression {
+            let full_sql = format!("select * from t where {}", sql);
+            let mut parser = Parser::with_string(full_sql).unwrap();
+            let stmts = parser.parse(ParserContext::default()).unwrap();
+            let select = match stmts.into_iter().next().unwrap() {
+                crate::engine::ast::SQLStatement::DML(
+                    crate::engine::ast::DMLStatement::SelectQuery(q),
+                ) => q,
+                _ => panic!("expected select"),
+            };
+            select.where_clause.unwrap().expression
+        }
+
+        fn assert_binary(expr: &SQLExpression, op: BinaryOperator) -> bool {
+            matches!(expr, SQLExpression::Binary(b) if b.operator == op)
+        }
+
+        #[test]
+        fn and_binds_tighter_than_or() {
+            // a OR b AND c  →  a OR (b AND c)
+            let expr = parse_where("a = 1 or b = 2 and c = 3");
+            // 최상위는 OR, 오른쪽 피연산자는 AND여야 함
+            assert!(
+                assert_binary(&expr, BinaryOperator::Or),
+                "expected OR at top level"
+            );
+
+            if let SQLExpression::Binary(b) = &expr {
+                assert!(
+                    assert_binary(&b.lhs, BinaryOperator::Eq),
+                    "left side of OR should be comparison"
+                );
+                assert!(
+                    assert_binary(&b.rhs, BinaryOperator::And),
+                    "right side of OR should be AND (b = 2 AND c = 3)"
+                );
+            }
+        }
+
+        #[test]
+        fn comparisons_bind_tighter_than_and() {
+            // a > b AND c = d  →  (a > b) AND (c = d)
+            let expr = parse_where("a > b and c = d");
+            assert!(
+                assert_binary(&expr, BinaryOperator::And),
+                "expected AND at top level"
+            );
+
+            if let SQLExpression::Binary(b) = &expr {
+                assert!(
+                    assert_binary(&b.lhs, BinaryOperator::Gt),
+                    "left side of AND should be > comparison"
+                );
+                assert!(
+                    assert_binary(&b.rhs, BinaryOperator::Eq),
+                    "right side of AND should be = comparison"
+                );
+            }
+        }
+
+        #[test]
+        fn arithmetic_binds_tighter_than_comparison() {
+            // a + b > c  →  (a + b) > c
+            let expr = parse_where("a + b > c");
+            assert!(
+                assert_binary(&expr, BinaryOperator::Gt),
+                "expected > at top level for arithmetic+comparison"
+            );
+        }
     }
 }

--- a/src/engine/ast/dml/expressions/operators.rs
+++ b/src/engine/ast/dml/expressions/operators.rs
@@ -33,26 +33,27 @@ pub enum UnaryOperator {
 
 impl BinaryOperator {
     // 2항연산자 우선순위 획득
+    // 표준 SQL 우선순위: OR < AND < 비교 연산자 < 덧셈/뺄셈 < 곱셈/나눗셈
     pub fn get_precedence(&self) -> i32 {
         match self {
+            BinaryOperator::Or => 1,
+            BinaryOperator::And => 2,
+            BinaryOperator::Lt => 5,
+            BinaryOperator::Gt => 5,
+            BinaryOperator::Lte => 5,
+            BinaryOperator::Gte => 5,
+            BinaryOperator::Eq => 5,
+            BinaryOperator::Neq => 5,
+            BinaryOperator::Like => 5,
+            BinaryOperator::NotLike => 5,
+            BinaryOperator::In => 5,
+            BinaryOperator::NotIn => 5,
+            BinaryOperator::Is => 5,
+            BinaryOperator::IsNot => 5,
             BinaryOperator::Add => 10,
             BinaryOperator::Sub => 10,
             BinaryOperator::Mul => 40,
             BinaryOperator::Div => 40,
-            BinaryOperator::And => 10,
-            BinaryOperator::Or => 10,
-            BinaryOperator::Lt => 10,
-            BinaryOperator::Gt => 10,
-            BinaryOperator::Lte => 10,
-            BinaryOperator::Gte => 10,
-            BinaryOperator::Eq => 10,
-            BinaryOperator::Neq => 10,
-            BinaryOperator::Like => 10,
-            BinaryOperator::NotLike => 10,
-            BinaryOperator::In => 10,
-            BinaryOperator::NotIn => 10,
-            BinaryOperator::Is => 10,
-            BinaryOperator::IsNot => 10,
         }
     }
 }
@@ -67,19 +68,19 @@ mod tests {
         assert_eq!(BinaryOperator::Sub.get_precedence(), 10);
         assert_eq!(BinaryOperator::Mul.get_precedence(), 40);
         assert_eq!(BinaryOperator::Div.get_precedence(), 40);
-        assert_eq!(BinaryOperator::And.get_precedence(), 10);
-        assert_eq!(BinaryOperator::Or.get_precedence(), 10);
-        assert_eq!(BinaryOperator::Lt.get_precedence(), 10);
-        assert_eq!(BinaryOperator::Gt.get_precedence(), 10);
-        assert_eq!(BinaryOperator::Lte.get_precedence(), 10);
-        assert_eq!(BinaryOperator::Gte.get_precedence(), 10);
-        assert_eq!(BinaryOperator::Eq.get_precedence(), 10);
-        assert_eq!(BinaryOperator::Neq.get_precedence(), 10);
-        assert_eq!(BinaryOperator::Like.get_precedence(), 10);
-        assert_eq!(BinaryOperator::NotLike.get_precedence(), 10);
-        assert_eq!(BinaryOperator::In.get_precedence(), 10);
-        assert_eq!(BinaryOperator::NotIn.get_precedence(), 10);
-        assert_eq!(BinaryOperator::Is.get_precedence(), 10);
-        assert_eq!(BinaryOperator::IsNot.get_precedence(), 10);
+        assert_eq!(BinaryOperator::And.get_precedence(), 2);
+        assert_eq!(BinaryOperator::Or.get_precedence(), 1);
+        assert_eq!(BinaryOperator::Lt.get_precedence(), 5);
+        assert_eq!(BinaryOperator::Gt.get_precedence(), 5);
+        assert_eq!(BinaryOperator::Lte.get_precedence(), 5);
+        assert_eq!(BinaryOperator::Gte.get_precedence(), 5);
+        assert_eq!(BinaryOperator::Eq.get_precedence(), 5);
+        assert_eq!(BinaryOperator::Neq.get_precedence(), 5);
+        assert_eq!(BinaryOperator::Like.get_precedence(), 5);
+        assert_eq!(BinaryOperator::NotLike.get_precedence(), 5);
+        assert_eq!(BinaryOperator::In.get_precedence(), 5);
+        assert_eq!(BinaryOperator::NotIn.get_precedence(), 5);
+        assert_eq!(BinaryOperator::Is.get_precedence(), 5);
+        assert_eq!(BinaryOperator::IsNot.get_precedence(), 5);
     }
 }

--- a/src/engine/ast/dml/plan/select/scan.rs
+++ b/src/engine/ast/dml/plan/select/scan.rs
@@ -1,7 +1,19 @@
-use crate::engine::ast::types::Index;
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ScanType {
     FullScan,
-    IndexScan(Index),
+    IndexScan(IndexScanPlan),
+}
+
+/// 인덱스 스캔 실행 계획.
+/// 키 문자열은 engine::index::field_to_key로 인코딩된 값입니다.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IndexScanPlan {
+    pub index_name: String,
+    pub column_name: String,
+    /// 동등(=) 조건 조회 키. 있으면 point lookup으로 실행됩니다.
+    pub eq_key: Option<String>,
+    /// 범위 시작 키(포함). 배타 경계는 플랜 생성 시점에 "\0" suffix로 보정됩니다.
+    pub start_key: Option<String>,
+    /// 범위 끝 키(제외)
+    pub end_key: Option<String>,
 }

--- a/src/engine/ast/mod.rs
+++ b/src/engine/ast/mod.rs
@@ -11,7 +11,7 @@ use crate::engine::ast::{
         alter_database::AlterDatabaseQuery, alter_table::AlterTableQuery,
         create_database::CreateDatabaseQuery, create_index::CreateIndexQuery,
         create_table::CreateTableQuery, drop_database::DropDatabaseQuery,
-        drop_table::DropTableQuery,
+        drop_index::DropIndexQuery, drop_table::DropTableQuery,
     },
     dml::{delete::DeleteQuery, insert::InsertQuery, select::SelectQuery, update::UpdateQuery},
     other::{
@@ -42,6 +42,7 @@ pub enum DDLStatement {
     AlterTableQuery(AlterTableQuery),
     DropTableQuery(DropTableQuery),
     CreateIndexQuery(CreateIndexQuery),
+    DropIndexQuery(DropIndexQuery),
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/engine/index/btree.rs
+++ b/src/engine/index/btree.rs
@@ -44,6 +44,11 @@ impl BTreeIndex {
         self.tree.values().map(|v| v.len()).sum()
     }
 
+    /// 고유 키 개수 (통계의 distinct value 추정에 사용)
+    pub fn distinct_keys(&self) -> usize {
+        self.tree.len()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/src/engine/index/manager.rs
+++ b/src/engine/index/manager.rs
@@ -332,6 +332,93 @@ impl IndexManager {
         metas.keys().cloned().collect()
     }
 
+    /// 특정 테이블에 속한 인덱스 메타 목록을 반환합니다.
+    pub async fn indices_for_table(
+        &self,
+        table_name: &crate::engine::ast::types::TableName,
+    ) -> Vec<IndexMeta> {
+        let metas = self.metas.read().await;
+        metas
+            .values()
+            .filter(|meta| meta.table_name == *table_name)
+            .cloned()
+            .collect()
+    }
+
+    /// 인덱스의 고유 키 개수를 반환합니다 (통계용).
+    pub async fn distinct_keys(&self, index_name: &str) -> errors::Result<usize> {
+        let indices = self.indices.read().await;
+        let tree = indices
+            .get(index_name)
+            .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
+        Ok(tree.distinct_keys())
+    }
+
+    /// 인덱스 전체 엔트리를 교체합니다.
+    /// CREATE INDEX 백필, DELETE 압축 후 재구축 등에 사용합니다.
+    /// 디스크 기록이 성공한 경우에만 메모리 상태를 교체합니다.
+    pub async fn replace_entries(
+        &self,
+        index_name: &str,
+        entries: Vec<IndexEntry>,
+    ) -> errors::Result<()> {
+        let meta = {
+            let metas = self.metas.read().await;
+            metas
+                .get(index_name)
+                .cloned()
+                .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?
+        };
+
+        self.write_index_file(&meta, &entries).await?;
+
+        let tree = BTreeIndex::from_entries(meta.column_name.clone(), meta.is_unique, entries);
+
+        let mut indices = self.indices.write().await;
+        indices.insert(index_name.to_string(), tree);
+
+        Ok(())
+    }
+
+    /// 테이블에 속한 인덱스의 메모리 상태를 제거합니다.
+    /// 디스크 파일은 테이블 디렉토리와 함께 삭제되는 경우(DROP TABLE)에 사용합니다.
+    pub async fn remove_table_indices(&self, table_name: &crate::engine::ast::types::TableName) {
+        let names: Vec<String> = {
+            let metas = self.metas.read().await;
+            metas
+                .values()
+                .filter(|meta| meta.table_name == *table_name)
+                .map(|meta| meta.index_name.clone())
+                .collect()
+        };
+
+        let mut indices = self.indices.write().await;
+        let mut metas = self.metas.write().await;
+        for name in names {
+            indices.remove(&name);
+            metas.remove(&name);
+        }
+    }
+
+    /// 데이터베이스에 속한 인덱스의 메모리 상태를 제거합니다 (DROP DATABASE).
+    pub async fn remove_database_indices(&self, database_name: &str) {
+        let names: Vec<String> = {
+            let metas = self.metas.read().await;
+            metas
+                .values()
+                .filter(|meta| meta.table_name.database_name.as_deref() == Some(database_name))
+                .map(|meta| meta.index_name.clone())
+                .collect()
+        };
+
+        let mut indices = self.indices.write().await;
+        let mut metas = self.metas.write().await;
+        for name in names {
+            indices.remove(&name);
+            metas.remove(&name);
+        }
+    }
+
     /// Get index meta.
     pub async fn get_meta(&self, index_name: &str) -> Option<IndexMeta> {
         let metas = self.metas.read().await;

--- a/src/engine/index/manager.rs
+++ b/src/engine/index/manager.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use tokio::sync::{Mutex, RwLock};
 
@@ -28,7 +29,7 @@ use super::{IndexEntry, IndexMeta};
 ///    `load_all` (no panic, no crash -- see its doc comment).
 pub struct IndexManager {
     /// Map: index_name -> page-backed B+tree
-    indices: RwLock<HashMap<String, PageBackedBTreeIndex>>,
+    indices: RwLock<HashMap<String, Arc<Mutex<PageBackedBTreeIndex>>>>,
     /// Map: index_name -> IndexMeta
     metas: RwLock<HashMap<String, IndexMeta>>,
     /// Base directory for all indices (usually data_directory)
@@ -109,18 +110,24 @@ impl IndexManager {
             })?;
         }
 
-        // Persist the meta sidecar, then create the (empty) page-backed
-        // data file.
-        self.write_meta_file(&meta).await?;
+        // Create the (empty) page-backed data file first, then persist the
+        // meta sidecar. This order ensures `load_all` (which discovers
+        // indices by scanning for `.meta` files) never sees a meta file
+        // pointing at a missing `.idx` file after a partial failure.
         let tree =
             PageBackedBTreeIndex::create(&file_path, meta.column_name.clone(), meta.is_unique)
                 .await?;
+
+        if let Err(error) = self.write_meta_file(&meta).await {
+            let _ = tokio::fs::remove_file(&file_path).await;
+            return Err(error);
+        }
 
         // Update in-memory state
         {
             let mut indices = self.indices.write().await;
             let mut metas = self.metas.write().await;
-            indices.insert(index_name.clone(), tree);
+            indices.insert(index_name.clone(), Arc::new(Mutex::new(tree)));
             metas.insert(index_name, meta);
         }
 
@@ -175,21 +182,29 @@ impl IndexManager {
     /// handful of pages the insert touches (root, target leaf, and any
     /// split siblings) -- not the whole index file (issue #230).
     ///
-    /// The write lock on the index map is held for the whole call, which
-    /// serializes mutations to a given index the same way the previous
-    /// (in-memory-then-disk) design did; see `page_btree.rs` for why a
-    /// single page-backed tree isn't safe under fully concurrent mutation.
+    /// Fetch an index handle without holding the global index-map lock across
+    /// page I/O. The returned handle has its own per-index mutex, so unrelated
+    /// indexes can proceed independently while operations on the same
+    /// page-backed tree remain serialized.
+    async fn index_handle(
+        &self,
+        index_name: &str,
+    ) -> errors::Result<Arc<Mutex<PageBackedBTreeIndex>>> {
+        let indices = self.indices.read().await;
+        indices
+            .get(index_name)
+            .cloned()
+            .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))
+    }
+
     pub async fn insert(
         &self,
         index_name: &str,
         key: String,
         row_path: String,
     ) -> errors::Result<()> {
-        let indices = self.indices.write().await;
-        let tree = indices
-            .get(index_name)
-            .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-        tree.insert(key, row_path).await
+        let tree = self.index_handle(index_name).await?;
+        tree.lock().await.insert(key, row_path).await
     }
 
     /// Remove a key->row_path from an index, touching only the owning leaf
@@ -200,11 +215,8 @@ impl IndexManager {
         key: &str,
         row_path: &str,
     ) -> errors::Result<bool> {
-        let indices = self.indices.write().await;
-        let tree = indices
-            .get(index_name)
-            .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-        tree.remove(key, row_path).await
+        let tree = self.index_handle(index_name).await?;
+        tree.lock().await.remove(key, row_path).await
     }
 
     /// Update a key for a given row path in an index (remove old mapping,
@@ -216,29 +228,20 @@ impl IndexManager {
         new_key: String,
         row_path: String,
     ) -> errors::Result<()> {
-        let indices = self.indices.write().await;
-        let tree = indices
-            .get(index_name)
-            .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-        tree.update(old_key, new_key, row_path).await
+        let tree = self.index_handle(index_name).await?;
+        tree.lock().await.update(old_key, new_key, row_path).await
     }
 
     /// Look up row paths for an exact key match.
     pub async fn get(&self, index_name: &str, key: &str) -> errors::Result<Vec<String>> {
-        let indices = self.indices.read().await;
-        let tree = indices
-            .get(index_name)
-            .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-        tree.get(key).await
+        let tree = self.index_handle(index_name).await?;
+        tree.lock().await.get(key).await
     }
 
     /// Point lookup for unique index.
     pub async fn get_one(&self, index_name: &str, key: &str) -> errors::Result<Option<String>> {
-        let indices = self.indices.read().await;
-        let tree = indices
-            .get(index_name)
-            .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-        tree.get_one(key).await
+        let tree = self.index_handle(index_name).await?;
+        tree.lock().await.get_one(key).await
     }
 
     /// Range scan on an index.
@@ -248,20 +251,14 @@ impl IndexManager {
         start: Option<&str>,
         end: Option<&str>,
     ) -> errors::Result<Vec<IndexEntry>> {
-        let indices = self.indices.read().await;
-        let tree = indices
-            .get(index_name)
-            .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-        tree.range(start, end).await
+        let tree = self.index_handle(index_name).await?;
+        tree.lock().await.range(start, end).await
     }
 
     /// Full scan on an index.
     pub async fn scan_all(&self, index_name: &str) -> errors::Result<Vec<IndexEntry>> {
-        let indices = self.indices.read().await;
-        let tree = indices
-            .get(index_name)
-            .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-        tree.scan_all().await
+        let tree = self.index_handle(index_name).await?;
+        tree.lock().await.scan_all().await
     }
 
     /// List all index names.
@@ -285,11 +282,8 @@ impl IndexManager {
 
     /// 인덱스의 고유 키 개수를 반환합니다 (통계용).
     pub async fn distinct_keys(&self, index_name: &str) -> errors::Result<usize> {
-        let indices = self.indices.read().await;
-        let tree = indices
-            .get(index_name)
-            .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-        tree.distinct_keys().await
+        let tree = self.index_handle(index_name).await?;
+        tree.lock().await.distinct_keys().await
     }
 
     /// 인덱스 전체 엔트리를 교체합니다.
@@ -327,7 +321,7 @@ impl IndexManager {
         }
 
         let mut indices = self.indices.write().await;
-        indices.insert(index_name.to_string(), tree);
+        indices.insert(index_name.to_string(), Arc::new(Mutex::new(tree)));
 
         Ok(())
     }
@@ -379,11 +373,8 @@ impl IndexManager {
 
     /// Get the number of entries in an index.
     pub async fn len(&self, index_name: &str) -> errors::Result<usize> {
-        let indices = self.indices.read().await;
-        let tree = indices
-            .get(index_name)
-            .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-        tree.len().await
+        let tree = self.index_handle(index_name).await?;
+        tree.lock().await.len().await
     }
 
     /// Load all indices from disk into memory. Called on server startup to
@@ -414,33 +405,51 @@ impl IndexManager {
 
                     match path.extension().and_then(|e| e.to_str()) {
                         Some("meta") => {
-                            let data = tokio::fs::read(&path).await.map_err(|e| {
-                                ExecuteError::wrap(format!(
-                                    "failed to read index meta file {:?}: {}",
-                                    path, e
-                                ))
-                            })?;
+                            let data = match tokio::fs::read(&path).await {
+                                Ok(data) => data,
+                                Err(e) => {
+                                    log::warn!(
+                                        "skipping index meta file {:?}: failed to read: {}",
+                                        path, e
+                                    );
+                                    continue;
+                                }
+                            };
 
-                            let meta: IndexMeta = bincode::deserialize(&data).map_err(|e| {
-                                ExecuteError::wrap(format!(
-                                    "failed to decode index meta file {:?}: {}",
-                                    path, e
-                                ))
-                            })?;
+                            let meta: IndexMeta = match bincode::deserialize(&data) {
+                                Ok(meta) => meta,
+                                Err(e) => {
+                                    log::warn!(
+                                        "skipping index meta file {:?}: failed to decode: {}",
+                                        path, e
+                                    );
+                                    continue;
+                                }
+                            };
 
                             let idx_path = path.with_extension("idx");
-                            let tree = PageBackedBTreeIndex::open(
+                            let tree = match PageBackedBTreeIndex::open(
                                 &idx_path,
                                 meta.column_name.clone(),
                                 meta.is_unique,
                             )
-                            .await?;
+                            .await
+                            {
+                                Ok(tree) => tree,
+                                Err(e) => {
+                                    log::warn!(
+                                        "skipping index {:?}: failed to open {:?}: {}",
+                                        meta.index_name, idx_path, e
+                                    );
+                                    continue;
+                                }
+                            };
 
                             let index_name = meta.index_name.clone();
 
                             let mut indices = self.indices.write().await;
                             let mut metas = self.metas.write().await;
-                            indices.insert(index_name.clone(), tree);
+                            indices.insert(index_name.clone(), Arc::new(Mutex::new(tree)));
                             metas.insert(index_name, meta);
                         }
                         _ => continue,

--- a/src/engine/index/manager.rs
+++ b/src/engine/index/manager.rs
@@ -3,39 +3,36 @@ use std::path::PathBuf;
 
 use tokio::sync::{Mutex, RwLock};
 
-use crate::engine::encoder::schema_encoder::StorageEncoder;
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
 
-use super::btree::BTreeIndex;
+use super::page_btree::PageBackedBTreeIndex;
 use super::{IndexEntry, IndexMeta};
 
-/// IndexFileManager manages a single index file on disk.
-/// Each index is persisted as a BSON-encoded file containing:
-/// - IndexMeta (index name, table, column, uniqueness)
-/// - Vec<IndexEntry> (the actual key->row_path mappings)
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
-struct IndexFile {
-    meta: IndexMeta,
-    entries: Vec<IndexEntry>,
-}
-
-/// IndexManager coordinates in-memory B-tree indices with disk persistence.
+/// IndexManager coordinates page-backed B+tree indices with disk persistence.
 ///
-/// Design (issue #160):
-/// 1. B-tree indices are loaded into memory on startup (`load_all`)
-/// 2. On every mutation (insert/remove/update), memory is updated first,
-///    then the change is flushed to disk (`save_index`)
-/// 3. Disk is the backup; memory is the primary query path
-/// 4. Each index file lives at `<table_path>/index/<index_name>.idx`
+/// Design (issue #230, superseding the full-snapshot-rewrite design from
+/// issue #160):
+/// 1. Each index is a `PageBackedBTreeIndex` (see `page_btree.rs`): a real
+///    disk-facing B+tree where every mutation reads/writes only the pages
+///    it touches, instead of serializing the whole index on every insert.
+/// 2. A small `<index_name>.meta` sidecar file holds the `IndexMeta`
+///    (index/table/column names, uniqueness) next to the page-backed
+///    `<index_name>.idx` data file. The meta file is written once at
+///    `create_index` time and never rewritten.
+/// 3. `load_all`/`load_database_indices` rediscover indices by scanning for
+///    `.meta` files and opening their sibling `.idx` page file -- this is an
+///    on-disk format change from the old full-blob `.idx` files (pre-#230),
+///    which is acceptable since this feature has not shipped yet. Old-style
+///    `.idx` files without a `.meta` sidecar are simply not picked up by
+///    `load_all` (no panic, no crash -- see its doc comment).
 pub struct IndexManager {
-    /// Map: index_name -> in-memory B-tree
-    indices: RwLock<HashMap<String, BTreeIndex>>,
+    /// Map: index_name -> page-backed B+tree
+    indices: RwLock<HashMap<String, PageBackedBTreeIndex>>,
     /// Map: index_name -> IndexMeta
     metas: RwLock<HashMap<String, IndexMeta>>,
     /// Base directory for all indices (usually data_directory)
     base_directory: PathBuf,
-    encoder: StorageEncoder,
     /// Serializes create_index calls to prevent TOCTOU races
     create_lock: Mutex<()>,
 }
@@ -46,12 +43,11 @@ impl IndexManager {
             indices: RwLock::new(HashMap::new()),
             metas: RwLock::new(HashMap::new()),
             base_directory,
-            encoder: StorageEncoder::new(),
             create_lock: Mutex::new(()),
         }
     }
 
-    /// Compute the on-disk path for an index file.
+    /// Compute the on-disk path for an index's page-backed data file.
     /// Structure: <base>/<database>/tables/<table>/index/<index_name>.idx
     fn index_file_path(&self, meta: &IndexMeta) -> PathBuf {
         let database_name = meta
@@ -67,6 +63,21 @@ impl IndexManager {
             .join(table_name)
             .join("index")
             .join(format!("{}.idx", meta.index_name))
+    }
+
+    /// Compute the on-disk path for an index's small metadata sidecar file.
+    fn meta_file_path(&self, meta: &IndexMeta) -> PathBuf {
+        self.index_file_path(meta).with_extension("meta")
+    }
+
+    /// Write the (tiny, fixed-at-creation) IndexMeta sidecar file.
+    async fn write_meta_file(&self, meta: &IndexMeta) -> errors::Result<()> {
+        let path = self.meta_file_path(meta);
+        let encoded = bincode::serialize(meta)
+            .map_err(|e| ExecuteError::wrap(format!("failed to encode index meta: {}", e)))?;
+        tokio::fs::write(&path, encoded)
+            .await
+            .map_err(|e| ExecuteError::wrap(format!("failed to write index meta file: {}", e)))
     }
 
     /// Register a new index: create an empty in-memory B-tree and persist
@@ -98,18 +109,12 @@ impl IndexManager {
             })?;
         }
 
-        // Create empty in-memory tree
-        let tree = BTreeIndex::new(meta.column_name.clone(), meta.is_unique);
-
-        // Persist to disk
-        let file_data = IndexFile {
-            meta: meta.clone(),
-            entries: Vec::new(),
-        };
-        let encoded = self.encoder.encode(&file_data);
-        tokio::fs::write(&file_path, encoded)
-            .await
-            .map_err(|e| ExecuteError::wrap(format!("failed to write index file: {}", e)))?;
+        // Persist the meta sidecar, then create the (empty) page-backed
+        // data file.
+        self.write_meta_file(&meta).await?;
+        let tree =
+            PageBackedBTreeIndex::create(&file_path, meta.column_name.clone(), meta.is_unique)
+                .await?;
 
         // Update in-memory state
         {
@@ -122,7 +127,8 @@ impl IndexManager {
         Ok(())
     }
 
-    /// Drop an index: remove from memory and delete the disk file.
+    /// Drop an index: remove from memory and delete both disk files (the
+    /// page-backed data file and its meta sidecar).
     pub async fn drop_index(&self, index_name: &str) -> errors::Result<()> {
         let meta = {
             let metas = self.metas.read().await;
@@ -140,12 +146,18 @@ impl IndexManager {
         };
 
         let file_path = self.index_file_path(&meta);
+        let meta_path = self.meta_file_path(&meta);
 
         // Remove from disk
         if file_path.exists() {
             tokio::fs::remove_file(&file_path)
                 .await
                 .map_err(|e| ExecuteError::wrap(format!("failed to remove index file: {}", e)))?;
+        }
+        if meta_path.exists() {
+            tokio::fs::remove_file(&meta_path).await.map_err(|e| {
+                ExecuteError::wrap(format!("failed to remove index meta file: {}", e))
+            })?;
         }
 
         // Remove from memory
@@ -159,94 +171,44 @@ impl IndexManager {
         Ok(())
     }
 
-    /// Insert a key->row_path into an index. Updates memory and disk.
+    /// Insert a key->row_path into an index. This reads/writes only the
+    /// handful of pages the insert touches (root, target leaf, and any
+    /// split siblings) -- not the whole index file (issue #230).
     ///
-    /// The write lock is held for the in-memory mutation. Then the lock is
-    /// released and a snapshot is written to disk. If save_index fails, the
-    /// in-memory change is reverted.
+    /// The write lock on the index map is held for the whole call, which
+    /// serializes mutations to a given index the same way the previous
+    /// (in-memory-then-disk) design did; see `page_btree.rs` for why a
+    /// single page-backed tree isn't safe under fully concurrent mutation.
     pub async fn insert(
         &self,
         index_name: &str,
         key: String,
         row_path: String,
     ) -> errors::Result<()> {
-        let (meta, entries) = {
-            let mut indices = self.indices.write().await;
-            let tree = indices
-                .get_mut(index_name)
-                .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-
-            tree.insert(key.clone(), row_path.clone())
-                .map_err(ExecuteError::wrap)?;
-
-            // Snapshot while we hold the lock
-            let metas = self.metas.read().await;
-            let meta = metas.get(index_name).ok_or_else(|| {
-                ExecuteError::wrap(format!("index meta '{}' not found", index_name))
-            })?;
-            (meta.clone(), tree.to_entries())
-        };
-
-        // Disk I/O outside the lock -- avoids deadlock
-        if let Err(e) = self.write_index_file(&meta, &entries).await {
-            // Revert the in-memory change
-            let mut indices = self.indices.write().await;
-            if let Some(tree) = indices.get_mut(index_name) {
-                tree.remove(&key, &row_path);
-            }
-            return Err(e);
-        }
-
-        Ok(())
+        let indices = self.indices.write().await;
+        let tree = indices
+            .get(index_name)
+            .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
+        tree.insert(key, row_path).await
     }
 
-    /// Remove a key->row_path from an index. Updates memory and disk.
-    ///
-    /// Lock is released before disk I/O. If save_index fails, the in-memory
-    /// change is reverted.
+    /// Remove a key->row_path from an index, touching only the owning leaf
+    /// (and its overflow chain, if any).
     pub async fn remove(
         &self,
         index_name: &str,
         key: &str,
         row_path: &str,
     ) -> errors::Result<bool> {
-        let (removed, meta, entries) = {
-            let mut indices = self.indices.write().await;
-            let tree = indices
-                .get_mut(index_name)
-                .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-
-            let removed = tree.remove(key, row_path);
-
-            if removed {
-                let metas = self.metas.read().await;
-                let meta = metas.get(index_name).ok_or_else(|| {
-                    ExecuteError::wrap(format!("index meta '{}' not found", index_name))
-                })?;
-                (removed, meta.clone(), tree.to_entries())
-            } else {
-                return Ok(false);
-            }
-        };
-
-        // Disk I/O outside the lock
-        if let Err(e) = self.write_index_file(&meta, &entries).await {
-            // Re-insert on failure
-            let mut indices = self.indices.write().await;
-            if let Some(tree) = indices.get_mut(index_name) {
-                tree.insert(key.to_string(), row_path.to_string())
-                    .map_err(ExecuteError::wrap)?;
-            }
-            return Err(e);
-        }
-
-        Ok(removed)
+        let indices = self.indices.write().await;
+        let tree = indices
+            .get(index_name)
+            .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
+        tree.remove(key, row_path).await
     }
 
-    /// Update a key for a given row path in an index.
-    ///
-    /// Lock is released before disk I/O. If save_index fails, the in-memory
-    /// change is reverted.
+    /// Update a key for a given row path in an index (remove old mapping,
+    /// insert new one; see `PageBackedBTreeIndex::update`).
     pub async fn update(
         &self,
         index_name: &str,
@@ -254,35 +216,11 @@ impl IndexManager {
         new_key: String,
         row_path: String,
     ) -> errors::Result<()> {
-        let (meta, entries) = {
-            let mut indices = self.indices.write().await;
-            let tree = indices
-                .get_mut(index_name)
-                .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-
-            tree.update(old_key, new_key.clone(), row_path.clone())
-                .map_err(ExecuteError::wrap)?;
-
-            let metas = self.metas.read().await;
-            let meta = metas.get(index_name).ok_or_else(|| {
-                ExecuteError::wrap(format!("index meta '{}' not found", index_name))
-            })?;
-            (meta.clone(), tree.to_entries())
-        };
-
-        // Disk I/O outside the lock
-        if let Err(e) = self.write_index_file(&meta, &entries).await {
-            // Revert: remove new key, re-insert old key
-            let mut indices = self.indices.write().await;
-            if let Some(tree) = indices.get_mut(index_name) {
-                tree.remove(&new_key, &row_path);
-                tree.insert(old_key.to_string(), row_path.to_string())
-                    .map_err(ExecuteError::wrap)?;
-            }
-            return Err(e);
-        }
-
-        Ok(())
+        let indices = self.indices.write().await;
+        let tree = indices
+            .get(index_name)
+            .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
+        tree.update(old_key, new_key, row_path).await
     }
 
     /// Look up row paths for an exact key match.
@@ -291,7 +229,7 @@ impl IndexManager {
         let tree = indices
             .get(index_name)
             .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-        Ok(tree.get(key))
+        tree.get(key).await
     }
 
     /// Point lookup for unique index.
@@ -300,7 +238,7 @@ impl IndexManager {
         let tree = indices
             .get(index_name)
             .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-        Ok(tree.get_one(key))
+        tree.get_one(key).await
     }
 
     /// Range scan on an index.
@@ -314,7 +252,7 @@ impl IndexManager {
         let tree = indices
             .get(index_name)
             .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-        Ok(tree.range(start, end))
+        tree.range(start, end).await
     }
 
     /// Full scan on an index.
@@ -323,7 +261,7 @@ impl IndexManager {
         let tree = indices
             .get(index_name)
             .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-        Ok(tree.scan_all())
+        tree.scan_all().await
     }
 
     /// List all index names.
@@ -351,12 +289,16 @@ impl IndexManager {
         let tree = indices
             .get(index_name)
             .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-        Ok(tree.distinct_keys())
+        tree.distinct_keys().await
     }
 
     /// 인덱스 전체 엔트리를 교체합니다.
     /// CREATE INDEX 백필, DELETE 압축 후 재구축 등에 사용합니다.
-    /// 디스크 기록이 성공한 경우에만 메모리 상태를 교체합니다.
+    ///
+    /// Not a hot path (called once per CREATE INDEX backfill or compaction,
+    /// not per row), so rebuilding by deleting and recreating the
+    /// page-backed file, then inserting each entry, is acceptable even
+    /// though it is O(n log n) rather than a bulk page-loader.
     pub async fn replace_entries(
         &self,
         index_name: &str,
@@ -370,9 +312,19 @@ impl IndexManager {
                 .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?
         };
 
-        self.write_index_file(&meta, &entries).await?;
+        let file_path = self.index_file_path(&meta);
+        if file_path.exists() {
+            tokio::fs::remove_file(&file_path)
+                .await
+                .map_err(|e| ExecuteError::wrap(format!("failed to remove index file: {}", e)))?;
+        }
 
-        let tree = BTreeIndex::from_entries(meta.column_name.clone(), meta.is_unique, entries);
+        let tree =
+            PageBackedBTreeIndex::create(&file_path, meta.column_name.clone(), meta.is_unique)
+                .await?;
+        for entry in entries {
+            tree.insert(entry.key, entry.row_path).await?;
+        }
 
         let mut indices = self.indices.write().await;
         indices.insert(index_name.to_string(), tree);
@@ -431,64 +383,17 @@ impl IndexManager {
         let tree = indices
             .get(index_name)
             .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-        Ok(tree.len())
+        tree.len().await
     }
 
-    /// Persist a single index's full state to disk.
-    /// This is called after every mutation to ensure disk backup is current.
-    #[allow(dead_code)]
-    async fn save_index(&self, index_name: &str) -> errors::Result<()> {
-        let (meta, entries) = self.snapshot_index(index_name).await?;
-        self.write_index_file(&meta, &entries).await
-    }
-
-    /// Read a snapshot of (meta, entries) from the in-memory state.
-    #[allow(dead_code)]
-    async fn snapshot_index(
-        &self,
-        index_name: &str,
-    ) -> errors::Result<(IndexMeta, Vec<IndexEntry>)> {
-        let indices = self.indices.read().await;
-        let metas = self.metas.read().await;
-
-        let tree = indices
-            .get(index_name)
-            .ok_or_else(|| ExecuteError::wrap(format!("index '{}' not found", index_name)))?;
-        let meta = metas
-            .get(index_name)
-            .ok_or_else(|| ExecuteError::wrap(format!("index meta '{}' not found", index_name)))?;
-
-        Ok((meta.clone(), tree.to_entries()))
-    }
-
-    /// Write index data to disk atomically (temp file + rename).
-    /// Does not touch any locks -- pure disk I/O.
-    async fn write_index_file(
-        &self,
-        meta: &IndexMeta,
-        entries: &[IndexEntry],
-    ) -> errors::Result<()> {
-        let file_path = self.index_file_path(meta);
-        let file_data = IndexFile {
-            meta: meta.clone(),
-            entries: entries.to_vec(),
-        };
-        let encoded = self.encoder.encode(&file_data);
-
-        let temp_path = file_path.with_extension("idx.tmp");
-        tokio::fs::write(&temp_path, encoded)
-            .await
-            .map_err(|e| ExecuteError::wrap(format!("failed to write index temp file: {}", e)))?;
-
-        tokio::fs::rename(&temp_path, &file_path)
-            .await
-            .map_err(|e| ExecuteError::wrap(format!("failed to rename index file: {}", e)))?;
-
-        Ok(())
-    }
-
-    /// Load all indices from disk into memory.
-    /// Called on server startup to restore index state.
+    /// Load all indices from disk into memory. Called on server startup to
+    /// restore index state.
+    ///
+    /// Discovers indices by scanning for `.meta` sidecar files and opening
+    /// their sibling page-backed `.idx` file (see the struct doc comment).
+    /// Pre-#230 `.idx` files that predate this sidecar (a single bincode
+    /// blob with no `.meta` file next to it) are silently skipped rather
+    /// than erroring, since this on-disk format has not shipped yet.
     pub async fn load_all(&self, index_directory: &PathBuf) -> errors::Result<()> {
         if !index_directory.exists() {
             return Ok(());
@@ -508,34 +413,35 @@ impl IndexManager {
                     }
 
                     match path.extension().and_then(|e| e.to_str()) {
-                        Some("idx") => {
+                        Some("meta") => {
                             let data = tokio::fs::read(&path).await.map_err(|e| {
                                 ExecuteError::wrap(format!(
-                                    "failed to read index file {:?}: {}",
+                                    "failed to read index meta file {:?}: {}",
                                     path, e
                                 ))
                             })?;
 
-                            let file_data: IndexFile =
-                                self.encoder.decode(data.as_slice()).map_err(|e| {
-                                    ExecuteError::wrap(format!(
-                                        "failed to decode index file {:?}: {}",
-                                        path, e
-                                    ))
-                                })?;
+                            let meta: IndexMeta = bincode::deserialize(&data).map_err(|e| {
+                                ExecuteError::wrap(format!(
+                                    "failed to decode index meta file {:?}: {}",
+                                    path, e
+                                ))
+                            })?;
 
-                            let tree = BTreeIndex::from_entries(
-                                file_data.meta.column_name.clone(),
-                                file_data.meta.is_unique,
-                                file_data.entries,
-                            );
+                            let idx_path = path.with_extension("idx");
+                            let tree = PageBackedBTreeIndex::open(
+                                &idx_path,
+                                meta.column_name.clone(),
+                                meta.is_unique,
+                            )
+                            .await?;
 
-                            let index_name = file_data.meta.index_name.clone();
+                            let index_name = meta.index_name.clone();
 
                             let mut indices = self.indices.write().await;
                             let mut metas = self.metas.write().await;
                             indices.insert(index_name.clone(), tree);
-                            metas.insert(index_name, file_data.meta);
+                            metas.insert(index_name, meta);
                         }
                         _ => continue,
                     }

--- a/src/engine/index/mod.rs
+++ b/src/engine/index/mod.rs
@@ -1,5 +1,8 @@
 pub mod btree;
 pub mod manager;
+pub mod page;
+pub mod page_btree;
+pub mod page_store;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/engine/index/page.rs
+++ b/src/engine/index/page.rs
@@ -1,0 +1,206 @@
+//! Fixed-size disk pages for the page-backed B+tree index (issue #230).
+//!
+//! Each page is encoded into a fixed-size byte buffer so that pages can be
+//! addressed on disk by `offset = superblock_size + page_id * page_size`
+//! (see `page_store.rs`). The encoding is `[tag:u8][len:u32 LE][payload][zero padding]`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::errors;
+use crate::errors::execute_error::ExecuteError;
+
+/// Default page size for index files, in bytes.
+pub const INDEX_PAGE_SIZE: usize = 4096;
+
+/// Page identifier: an offset slot within an index file.
+pub type PageId = u32;
+
+const TAG_LEN: usize = 1;
+const LEN_PREFIX_LEN: usize = 4;
+/// Bytes consumed by the tag+length header before the actual payload.
+pub const PAGE_ENCODING_OVERHEAD: usize = TAG_LEN + LEN_PREFIX_LEN;
+
+const TAG_LEAF: u8 = 1;
+const TAG_INTERNAL: u8 = 2;
+
+/// A single key -> row_path mapping stored in a leaf page.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LeafEntry {
+    pub key: String,
+    pub row_path: String,
+}
+
+/// A leaf page: sorted entries plus a pointer to the next leaf (for range
+/// scans) and an optional overflow page holding additional entries for the
+/// last duplicate-key group when it does not fit in this page (see
+/// `page_btree.rs` for the overflow-chain policy).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct LeafPage {
+    pub entries: Vec<LeafEntry>,
+    pub next_leaf: Option<PageId>,
+    pub overflow: Option<PageId>,
+}
+
+/// An internal (directory) page: separator keys and child page ids.
+/// Invariant: `keys.len() + 1 == children.len()`.
+/// Child `children[i]` holds keys in `[keys[i-1], keys[i])`, with
+/// `children[0]` holding everything below `keys[0]` and `children[last]`
+/// holding everything from `keys[last-1]` onward.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct InternalPage {
+    pub keys: Vec<String>,
+    pub children: Vec<PageId>,
+}
+
+/// A decoded on-disk page.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Page {
+    Leaf(LeafPage),
+    Internal(InternalPage),
+}
+
+/// Encode `page` into a `page_size`-byte buffer.
+///
+/// Returns an error if the serialized payload (plus the tag+length header)
+/// does not fit within `page_size` -- callers are expected to split the page
+/// before this happens; see `page_btree.rs`.
+pub fn encode_page(page: &Page, page_size: usize) -> errors::Result<Vec<u8>> {
+    let (tag, payload) = match page {
+        Page::Leaf(leaf) => (
+            TAG_LEAF,
+            bincode::serialize(leaf)
+                .map_err(|e| ExecuteError::wrap(format!("failed to encode leaf page: {}", e)))?,
+        ),
+        Page::Internal(internal) => (
+            TAG_INTERNAL,
+            bincode::serialize(internal).map_err(|e| {
+                ExecuteError::wrap(format!("failed to encode internal page: {}", e))
+            })?,
+        ),
+    };
+
+    if payload.len() + PAGE_ENCODING_OVERHEAD > page_size {
+        return Err(ExecuteError::wrap(format!(
+            "page payload of {} bytes (+{} byte header) exceeds page size {} bytes",
+            payload.len(),
+            PAGE_ENCODING_OVERHEAD,
+            page_size
+        )));
+    }
+
+    let mut buf = Vec::with_capacity(page_size);
+    buf.push(tag);
+    buf.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+    buf.extend_from_slice(&payload);
+    buf.resize(page_size, 0);
+    Ok(buf)
+}
+
+/// Decode a page previously produced by `encode_page`.
+pub fn decode_page(buf: &[u8]) -> errors::Result<Page> {
+    if buf.len() < PAGE_ENCODING_OVERHEAD {
+        return Err(ExecuteError::wrap(
+            "page buffer too small to contain a header",
+        ));
+    }
+
+    let tag = buf[0];
+    let len = u32::from_le_bytes(buf[TAG_LEN..PAGE_ENCODING_OVERHEAD].try_into().unwrap()) as usize;
+    let payload_end = PAGE_ENCODING_OVERHEAD + len;
+
+    if payload_end > buf.len() {
+        return Err(ExecuteError::wrap(
+            "page payload length exceeds buffer size",
+        ));
+    }
+
+    let payload = &buf[PAGE_ENCODING_OVERHEAD..payload_end];
+
+    match tag {
+        TAG_LEAF => {
+            let leaf: LeafPage = bincode::deserialize(payload)
+                .map_err(|e| ExecuteError::wrap(format!("failed to decode leaf page: {}", e)))?;
+            Ok(Page::Leaf(leaf))
+        }
+        TAG_INTERNAL => {
+            let internal: InternalPage = bincode::deserialize(payload).map_err(|e| {
+                ExecuteError::wrap(format!("failed to decode internal page: {}", e))
+            })?;
+            Ok(Page::Internal(internal))
+        }
+        other => Err(ExecuteError::wrap(format!("unknown page tag {}", other))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn leaf(entries: Vec<(&str, &str)>, next_leaf: Option<PageId>) -> LeafPage {
+        LeafPage {
+            entries: entries
+                .into_iter()
+                .map(|(k, v)| LeafEntry {
+                    key: k.to_string(),
+                    row_path: v.to_string(),
+                })
+                .collect(),
+            next_leaf,
+            overflow: None,
+        }
+    }
+
+    #[test]
+    fn roundtrips_a_leaf_page_preserving_order_and_next_pointer() {
+        let original = leaf(
+            vec![("I:0001", "/r/1"), ("I:0002", "/r/2"), ("I:0002", "/r/3")],
+            Some(7),
+        );
+
+        let encoded = encode_page(&Page::Leaf(original.clone()), INDEX_PAGE_SIZE).unwrap();
+        assert_eq!(encoded.len(), INDEX_PAGE_SIZE);
+
+        let decoded = decode_page(&encoded).unwrap();
+        assert_eq!(decoded, Page::Leaf(original));
+    }
+
+    #[test]
+    fn roundtrips_an_internal_page_preserving_keys_and_children() {
+        let original = InternalPage {
+            keys: vec!["I:0010".to_string(), "I:0020".to_string()],
+            children: vec![1, 2, 3],
+        };
+
+        let encoded = encode_page(&Page::Internal(original.clone()), INDEX_PAGE_SIZE).unwrap();
+        assert_eq!(encoded.len(), INDEX_PAGE_SIZE);
+
+        let decoded = decode_page(&encoded).unwrap();
+        assert_eq!(decoded, Page::Internal(original));
+    }
+
+    #[test]
+    fn rejects_a_page_whose_payload_does_not_fit_in_the_page_size() {
+        let huge = leaf(
+            (0..1000)
+                .map(|i| {
+                    (
+                        Box::leak(format!("I:{:016}", i).into_boxed_str()) as &str,
+                        "/r/x",
+                    )
+                })
+                .collect(),
+            None,
+        );
+
+        let result = encode_page(&Page::Leaf(huge), INDEX_PAGE_SIZE);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn accepts_a_small_page_size_when_payload_fits() {
+        let small = leaf(vec![("I:01", "/r/1")], None);
+        let encoded = encode_page(&Page::Leaf(small.clone()), 128).unwrap();
+        assert_eq!(encoded.len(), 128);
+        assert_eq!(decode_page(&encoded).unwrap(), Page::Leaf(small));
+    }
+}

--- a/src/engine/index/page_btree.rs
+++ b/src/engine/index/page_btree.rs
@@ -190,6 +190,22 @@ impl PageBackedBTreeIndex {
         }
     }
 
+    /// The key shared by every entry in an overflow chain (all entries in a
+    /// chain belong to the same duplicate-key group by construction, so
+    /// only the first page needs to be read).
+    async fn overflow_key(&self, overflow_id: PageId) -> errors::Result<String> {
+        match self.store.read_page(overflow_id).await? {
+            Page::Leaf(overflow) => overflow
+                .entries
+                .first()
+                .map(|e| e.key.clone())
+                .ok_or_else(|| ExecuteError::wrap("corrupt index: empty overflow page")),
+            Page::Internal(_) => Err(ExecuteError::wrap(
+                "corrupt index: overflow pointer references an internal page",
+            )),
+        }
+    }
+
     /// After inserting into `leaf.entries`, write it back -- splitting or
     /// pushing into overflow first if it no longer fits in one page.
     async fn rebalance_leaf_after_insert(
@@ -206,19 +222,62 @@ impl PageBackedBTreeIndex {
             let sibling_entries = leaf.entries.split_off(split_at);
             let separator = sibling_entries[0].key.clone();
 
+            // An overflow chain always holds the tail of a single
+            // duplicate-key group (see the module doc comment), so it must
+            // stay attached to whichever side of the split still holds that
+            // key's resident entries -- not unconditionally follow the new
+            // sibling. Otherwise `get`/`scan_all` silently lose the chain
+            // once it ends up hanging off a leaf for the wrong key.
+            let overflow_stays_with_leaf = match leaf.overflow {
+                Some(overflow_id) => {
+                    let overflow_key = self.overflow_key(overflow_id).await?;
+                    leaf.entries.last().is_some_and(|e| e.key == overflow_key)
+                }
+                None => false,
+            };
+
             let sibling_id = self.store.allocate_page().await?;
+            let (leaf_overflow, sibling_overflow) = if overflow_stays_with_leaf {
+                (leaf.overflow, None)
+            } else {
+                (None, leaf.overflow)
+            };
+
             let sibling = LeafPage {
                 entries: sibling_entries,
                 next_leaf: leaf.next_leaf,
-                overflow: leaf.overflow,
+                overflow: sibling_overflow,
             };
-            leaf.overflow = None;
+            leaf.overflow = leaf_overflow;
             leaf.next_leaf = Some(sibling_id);
 
-            self.store.write_page(page_id, &Page::Leaf(leaf)).await?;
-            self.store
-                .write_page(sibling_id, &Page::Leaf(sibling))
-                .await?;
+            // Whichever side keeps a non-`None` `overflow` pointer is
+            // guaranteed (by the invariant above) to hold a single
+            // homogeneous key, since a leaf only ever has an overflow chain
+            // while its resident entries are all one key. Keeping that
+            // pointer (rather than always dropping it, as before) plus the
+            // new `next_leaf` pointer can occasionally push that side a
+            // few bytes over budget; if so, it's always safe to shed more
+            // of its (single-key) tail into the chain it already owns.
+            if leaf.overflow.is_some()
+                && super::page::encode_page(&Page::Leaf(leaf.clone()), self.store.page_size())
+                    .is_err()
+            {
+                self.push_tail_into_overflow(page_id, leaf).await?;
+            } else {
+                self.store.write_page(page_id, &Page::Leaf(leaf)).await?;
+            }
+
+            if sibling.overflow.is_some()
+                && super::page::encode_page(&Page::Leaf(sibling.clone()), self.store.page_size())
+                    .is_err()
+            {
+                self.push_tail_into_overflow(sibling_id, sibling).await?;
+            } else {
+                self.store
+                    .write_page(sibling_id, &Page::Leaf(sibling))
+                    .await?;
+            }
 
             return Ok(Some((separator, sibling_id)));
         }
@@ -818,6 +877,64 @@ mod tests {
             // Removing one duplicate leaves the rest intact.
             assert!(idx.remove("S:dup", "/dup/0").await.unwrap());
             assert_eq!(idx.get("S:dup").await.unwrap().len(), 199);
+        }
+    }
+
+    #[tokio::test]
+    async fn overflow_chain_stays_with_its_key_when_a_larger_key_splits_the_leaf() {
+        let path = temp_path("overflow_split.idx");
+
+        {
+            let idx = PageBackedBTreeIndex::create(&path, "status".to_string(), false)
+                .await
+                .unwrap();
+
+            // Enough duplicates of a single key to force an overflow chain
+            // while this remains the only (root) leaf.
+            for i in 0..200 {
+                idx.insert("K:dup".to_string(), format!("/dup/{}", i))
+                    .await
+                    .unwrap();
+            }
+            assert_eq!(idx.get("K:dup").await.unwrap().len(), 200);
+
+            // A single larger key lands in the same (only) leaf and forces
+            // it to split. Before the fix, the overflow chain
+            // unconditionally followed the new sibling -- which here holds
+            // the unrelated "Z:after" key -- silently orphaning "K:dup"'s
+            // overflow entries.
+            idx.insert("Z:after".to_string(), "/after/0".to_string())
+                .await
+                .unwrap();
+
+            assert_eq!(idx.get("K:dup").await.unwrap().len(), 200);
+            assert_eq!(
+                idx.get("Z:after").await.unwrap(),
+                vec!["/after/0".to_string()]
+            );
+
+            let all = idx.scan_all().await.unwrap();
+            assert_eq!(all.len(), 201);
+            for w in all.windows(2) {
+                assert!(w[0].key <= w[1].key);
+            }
+        }
+
+        // The fix must survive a reload from disk too.
+        {
+            let idx = PageBackedBTreeIndex::open(&path, "status".to_string(), false)
+                .await
+                .unwrap();
+            assert_eq!(idx.get("K:dup").await.unwrap().len(), 200);
+
+            let all = idx.scan_all().await.unwrap();
+            assert_eq!(all.len(), 201);
+            for w in all.windows(2) {
+                assert!(w[0].key <= w[1].key);
+            }
+
+            let range = idx.range(Some("K:dup"), None).await.unwrap();
+            assert_eq!(range.len(), 201);
         }
     }
 

--- a/src/engine/index/page_btree.rs
+++ b/src/engine/index/page_btree.rs
@@ -1,0 +1,847 @@
+//! Page-backed B+tree index (issue #230).
+//!
+//! Replaces the "mutate an in-memory BTreeMap, then serialize the whole
+//! index to disk" approach in `manager.rs` (which was O(n) per mutation,
+//! O(n^2) across n inserts) with a real disk-facing B+tree: every mutation
+//! reads and writes only the handful of pages it touches.
+//!
+//! Structure, modeled after SimpleDB:
+//! - Leaf pages hold sorted `(key, row_path)` entries plus a `next_leaf`
+//!   pointer, so range scans walk a linked list of leaves without touching
+//!   internal pages.
+//! - Internal pages hold separator keys and child page ids.
+//! - Splits never separate a duplicate-key group across two leaves. If a
+//!   single key's group of row_paths doesn't fit in one leaf page on its
+//!   own (no split point exists), the group is chained into fixed-size
+//!   "overflow" pages hanging off the leaf via `LeafPage::overflow`. This is
+//!   simpler than general overflow-page support (no space reclamation, no
+//!   compaction) but keeps every on-disk page fixed-size, which is what lets
+//!   `PageStore` address pages by simple arithmetic. Documented limitation:
+//!   an overflow chain is never shrunk back down once created, even after
+//!   removes -- acceptable for this MVP since delete does not coalesce.
+//! - Delete does not coalesce/rebalance underfull leaves (spec allows this
+//!   for MVP); a leaf can become empty and just stays in the sibling chain.
+//! - There is no WAL integration here: the existing WAL (`engine::wal`)
+//!   does not currently cover index mutations at all (no references to the
+//!   index module anywhere under `src/engine/wal`), so there is nothing to
+//!   preserve ordering with yet. If index WAL logging is added later, it
+//!   must be written before the corresponding page write, per the
+//!   "WAL-before-page-write" convention used elsewhere in the engine.
+//!
+//! Follow-up TODOs (explicitly out of scope for this MVP pass):
+//! - No free-list reuse of pages freed by deletes/coalescing.
+//! - `PageStore` file IO blocks the async executor thread briefly per page
+//!   (see its module doc); moving to `spawn_blocking` is future work.
+//! - No page cache -- every read/write round-trips to disk.
+
+use std::path::Path;
+
+use crate::errors;
+use crate::errors::execute_error::ExecuteError;
+
+use super::page::{InternalPage, LeafEntry, LeafPage, Page, PageId, INDEX_PAGE_SIZE};
+use super::page_store::PageStore;
+use super::IndexEntry;
+
+/// A boxed, pinned, `Send` future -- needed because `insert_into_subtree`
+/// and `push_tail_into_overflow` recurse through `async fn`, which `rustc`
+/// cannot otherwise turn into a finite-sized state machine.
+type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
+
+/// A page-backed B+tree index for a single column.
+pub struct PageBackedBTreeIndex {
+    store: PageStore,
+    column_name: String,
+    is_unique: bool,
+}
+
+impl PageBackedBTreeIndex {
+    /// Create a brand new, empty index file at `path`.
+    pub async fn create(
+        path: &Path,
+        column_name: String,
+        is_unique: bool,
+    ) -> errors::Result<Self> {
+        let store = PageStore::create(path, INDEX_PAGE_SIZE).await?;
+        Ok(Self {
+            store,
+            column_name,
+            is_unique,
+        })
+    }
+
+    /// Open an existing index file at `path`.
+    pub async fn open(path: &Path, column_name: String, is_unique: bool) -> errors::Result<Self> {
+        let store = PageStore::open(path).await?;
+        Ok(Self {
+            store,
+            column_name,
+            is_unique,
+        })
+    }
+
+    pub fn column_name(&self) -> &str {
+        &self.column_name
+    }
+
+    pub fn is_unique(&self) -> bool {
+        self.is_unique
+    }
+
+    /// Insert a key -> row_path mapping. Errors (without mutating anything)
+    /// if this is a unique index and `key` already has an entry.
+    pub async fn insert(&self, key: String, row_path: String) -> errors::Result<()> {
+        let root = self.store.root_page_id().await?;
+
+        let Some(root_id) = root else {
+            // Empty tree: allocate the very first leaf and make it the root.
+            let leaf_id = self.store.allocate_page().await?;
+            let leaf = LeafPage {
+                entries: vec![LeafEntry { key, row_path }],
+                next_leaf: None,
+                overflow: None,
+            };
+            self.store.write_page(leaf_id, &Page::Leaf(leaf)).await?;
+            self.store.set_root_page_id(Some(leaf_id)).await?;
+            return Ok(());
+        };
+
+        if let Some((sep_key, new_child)) = self.insert_into_subtree(root_id, key, row_path).await?
+        {
+            // Root split: create a new internal root pointing at the old
+            // root and the newly split-off sibling.
+            let new_root_id = self.store.allocate_page().await?;
+            let new_root = InternalPage {
+                keys: vec![sep_key],
+                children: vec![root_id, new_child],
+            };
+            self.store
+                .write_page(new_root_id, &Page::Internal(new_root))
+                .await?;
+            self.store.set_root_page_id(Some(new_root_id)).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Insert into the subtree rooted at `page_id`. Returns
+    /// `Some((separator_key, new_sibling_page_id))` if `page_id`'s page had
+    /// to split, in which case the caller (the parent, or `insert` for the
+    /// root) must link in the new sibling.
+    fn insert_into_subtree<'a>(
+        &'a self,
+        page_id: PageId,
+        key: String,
+        row_path: String,
+    ) -> BoxFuture<'a, errors::Result<Option<(String, PageId)>>> {
+        Box::pin(async move {
+            match self.store.read_page(page_id).await? {
+                Page::Leaf(mut leaf) => {
+                    if self.is_unique {
+                        let exists_elsewhere = leaf.entries.iter().any(|e| e.key == key);
+                        let exists_in_overflow = if let Some(overflow_id) = leaf.overflow {
+                            self.overflow_contains_key(overflow_id, &key).await?
+                        } else {
+                            false
+                        };
+                        if exists_elsewhere || exists_in_overflow {
+                            return Err(ExecuteError::wrap(format!(
+                                "unique index violation on column '{}': key '{}' already exists",
+                                self.column_name, key
+                            )));
+                        }
+                    }
+
+                    let pos = leaf.entries.partition_point(|e| e.key < key);
+                    leaf.entries.insert(pos, LeafEntry { key, row_path });
+
+                    self.rebalance_leaf_after_insert(page_id, leaf).await
+                }
+                Page::Internal(internal) => {
+                    let child_index = internal.keys.partition_point(|sep| *sep <= key);
+                    let child_id = internal.children[child_index];
+
+                    let split = self.insert_into_subtree(child_id, key, row_path).await?;
+
+                    let Some((sep_key, new_child)) = split else {
+                        return Ok(None);
+                    };
+
+                    let mut internal = internal;
+                    internal.keys.insert(child_index, sep_key);
+                    internal.children.insert(child_index + 1, new_child);
+
+                    self.rebalance_internal_after_insert(page_id, internal)
+                        .await
+                }
+            }
+        })
+    }
+
+    /// Check whether an overflow chain (for a single duplicate-key group)
+    /// contains `key`. All entries in a chain share one key by
+    /// construction, so this only needs to look at the first page.
+    async fn overflow_contains_key(&self, overflow_id: PageId, key: &str) -> errors::Result<bool> {
+        match self.store.read_page(overflow_id).await? {
+            Page::Leaf(overflow) => Ok(overflow.entries.first().is_some_and(|e| e.key == key)),
+            Page::Internal(_) => Err(ExecuteError::wrap(
+                "corrupt index: overflow pointer references an internal page",
+            )),
+        }
+    }
+
+    /// After inserting into `leaf.entries`, write it back -- splitting or
+    /// pushing into overflow first if it no longer fits in one page.
+    async fn rebalance_leaf_after_insert(
+        &self,
+        page_id: PageId,
+        mut leaf: LeafPage,
+    ) -> errors::Result<Option<(String, PageId)>> {
+        if super::page::encode_page(&Page::Leaf(leaf.clone()), self.store.page_size()).is_ok() {
+            self.store.write_page(page_id, &Page::Leaf(leaf)).await?;
+            return Ok(None);
+        }
+
+        if let Some(split_at) = find_split_point(&leaf.entries) {
+            let sibling_entries = leaf.entries.split_off(split_at);
+            let separator = sibling_entries[0].key.clone();
+
+            let sibling_id = self.store.allocate_page().await?;
+            let sibling = LeafPage {
+                entries: sibling_entries,
+                next_leaf: leaf.next_leaf,
+                overflow: leaf.overflow,
+            };
+            leaf.overflow = None;
+            leaf.next_leaf = Some(sibling_id);
+
+            self.store.write_page(page_id, &Page::Leaf(leaf)).await?;
+            self.store
+                .write_page(sibling_id, &Page::Leaf(sibling))
+                .await?;
+
+            return Ok(Some((separator, sibling_id)));
+        }
+
+        // Every entry in this leaf shares one key: normal splitting would
+        // separate a duplicate-key group, which is not allowed. Push the
+        // tail of the page into a chained overflow page instead (see the
+        // module doc comment for the tradeoffs of this approach).
+        self.push_tail_into_overflow(page_id, leaf).await?;
+        Ok(None)
+    }
+
+    /// Move entries off the back of `leaf` into a newly allocated overflow
+    /// page (chained via `leaf.overflow`) until `leaf` itself fits in one
+    /// page again. Recurses if the overflow page itself doesn't fit.
+    fn push_tail_into_overflow<'a>(
+        &'a self,
+        page_id: PageId,
+        mut leaf: LeafPage,
+    ) -> BoxFuture<'a, errors::Result<()>> {
+        Box::pin(async move {
+            let mut moved = Vec::new();
+            loop {
+                if super::page::encode_page(&Page::Leaf(leaf.clone()), self.store.page_size())
+                    .is_ok()
+                {
+                    break;
+                }
+                match leaf.entries.pop() {
+                    Some(entry) => moved.insert(0, entry),
+                    None => {
+                        return Err(ExecuteError::wrap(
+                            "a single index entry does not fit within one page; increase INDEX_PAGE_SIZE",
+                        ));
+                    }
+                }
+            }
+
+            let overflow_id = self.store.allocate_page().await?;
+            let overflow_page = LeafPage {
+                entries: moved,
+                next_leaf: None,
+                overflow: leaf.overflow,
+            };
+            leaf.overflow = Some(overflow_id);
+
+            self.store.write_page(page_id, &Page::Leaf(leaf)).await?;
+
+            // The overflow page might itself be too large (a key with an
+            // enormous number of duplicates); recurse to chain further.
+            if super::page::encode_page(&Page::Leaf(overflow_page.clone()), self.store.page_size())
+                .is_ok()
+            {
+                self.store
+                    .write_page(overflow_id, &Page::Leaf(overflow_page))
+                    .await
+            } else {
+                self.push_tail_into_overflow(overflow_id, overflow_page)
+                    .await
+            }
+        })
+    }
+
+    async fn rebalance_internal_after_insert(
+        &self,
+        page_id: PageId,
+        internal: InternalPage,
+    ) -> errors::Result<Option<(String, PageId)>> {
+        if super::page::encode_page(&Page::Internal(internal.clone()), self.store.page_size())
+            .is_ok()
+        {
+            self.store
+                .write_page(page_id, &Page::Internal(internal))
+                .await?;
+            return Ok(None);
+        }
+
+        let mut internal = internal;
+        let split_at = internal.keys.len() / 2;
+        let separator = internal.keys[split_at].clone();
+
+        let sibling_keys = internal.keys.split_off(split_at + 1);
+        internal.keys.pop(); // drop the promoted separator itself
+        let sibling_children = internal.children.split_off(split_at + 1);
+
+        let sibling_id = self.store.allocate_page().await?;
+        let sibling = InternalPage {
+            keys: sibling_keys,
+            children: sibling_children,
+        };
+
+        self.store
+            .write_page(page_id, &Page::Internal(internal))
+            .await?;
+        self.store
+            .write_page(sibling_id, &Page::Internal(sibling))
+            .await?;
+
+        Ok(Some((separator, sibling_id)))
+    }
+
+    /// Find the leaf page id whose key range contains `key` (or would
+    /// contain it, if absent).
+    async fn find_leaf(&self, key: &str) -> errors::Result<Option<PageId>> {
+        let Some(root_id) = self.store.root_page_id().await? else {
+            return Ok(None);
+        };
+
+        let mut current = root_id;
+        loop {
+            match self.store.read_page(current).await? {
+                Page::Leaf(_) => return Ok(Some(current)),
+                Page::Internal(internal) => {
+                    let child_index = internal.keys.partition_point(|sep| sep.as_str() <= key);
+                    current = internal.children[child_index];
+                }
+            }
+        }
+    }
+
+    /// Find the leftmost leaf page id (used for full scans and open-start
+    /// range scans).
+    async fn find_leftmost_leaf(&self) -> errors::Result<Option<PageId>> {
+        let Some(root_id) = self.store.root_page_id().await? else {
+            return Ok(None);
+        };
+
+        let mut current = root_id;
+        loop {
+            match self.store.read_page(current).await? {
+                Page::Leaf(_) => return Ok(Some(current)),
+                Page::Internal(internal) => {
+                    current = internal.children[0];
+                }
+            }
+        }
+    }
+
+    /// Collect all entries for `page_id`'s leaf plus any overflow chain.
+    async fn leaf_entries_with_overflow(&self, page_id: PageId) -> errors::Result<Vec<LeafEntry>> {
+        let leaf = match self.store.read_page(page_id).await? {
+            Page::Leaf(leaf) => leaf,
+            Page::Internal(_) => {
+                return Err(ExecuteError::wrap("corrupt index: expected a leaf page"))
+            }
+        };
+
+        let mut entries = leaf.entries;
+        let mut next_overflow = leaf.overflow;
+        while let Some(overflow_id) = next_overflow {
+            match self.store.read_page(overflow_id).await? {
+                Page::Leaf(overflow) => {
+                    entries.extend(overflow.entries);
+                    next_overflow = overflow.overflow;
+                }
+                Page::Internal(_) => {
+                    return Err(ExecuteError::wrap(
+                        "corrupt index: overflow pointer references an internal page",
+                    ));
+                }
+            }
+        }
+
+        Ok(entries)
+    }
+
+    pub async fn get(&self, key: &str) -> errors::Result<Vec<String>> {
+        let Some(leaf_id) = self.find_leaf(key).await? else {
+            return Ok(Vec::new());
+        };
+
+        let entries = self.leaf_entries_with_overflow(leaf_id).await?;
+        Ok(entries
+            .into_iter()
+            .filter(|e| e.key == key)
+            .map(|e| e.row_path)
+            .collect())
+    }
+
+    pub async fn get_one(&self, key: &str) -> errors::Result<Option<String>> {
+        Ok(self.get(key).await?.into_iter().next())
+    }
+
+    /// Remove a single `(key, row_path)` mapping. Returns `true` if it was
+    /// found and removed. Does not coalesce underfull leaves.
+    pub async fn remove(&self, key: &str, row_path: &str) -> errors::Result<bool> {
+        let Some(leaf_id) = self.find_leaf(key).await? else {
+            return Ok(false);
+        };
+
+        let leaf = match self.store.read_page(leaf_id).await? {
+            Page::Leaf(leaf) => leaf,
+            Page::Internal(_) => {
+                return Err(ExecuteError::wrap("corrupt index: expected a leaf page"))
+            }
+        };
+
+        if let Some(idx) = leaf
+            .entries
+            .iter()
+            .position(|e| e.key == key && e.row_path == row_path)
+        {
+            let mut leaf = leaf;
+            leaf.entries.remove(idx);
+            self.store.write_page(leaf_id, &Page::Leaf(leaf)).await?;
+            return Ok(true);
+        }
+
+        // Walk the overflow chain looking for the entry.
+        let mut next_overflow = leaf.overflow;
+        while let Some(overflow_id) = next_overflow {
+            let mut overflow = match self.store.read_page(overflow_id).await? {
+                Page::Leaf(overflow) => overflow,
+                Page::Internal(_) => {
+                    return Err(ExecuteError::wrap(
+                        "corrupt index: overflow pointer references an internal page",
+                    ));
+                }
+            };
+
+            if let Some(idx) = overflow
+                .entries
+                .iter()
+                .position(|e| e.key == key && e.row_path == row_path)
+            {
+                overflow.entries.remove(idx);
+                self.store
+                    .write_page(overflow_id, &Page::Leaf(overflow))
+                    .await?;
+                return Ok(true);
+            }
+
+            next_overflow = overflow.overflow;
+        }
+
+        Ok(false)
+    }
+
+    /// Update a key for a given row path: remove the old mapping, insert
+    /// the new one. Validates uniqueness before mutating.
+    pub async fn update(
+        &self,
+        old_key: &str,
+        new_key: String,
+        row_path: String,
+    ) -> errors::Result<()> {
+        let old_exists = self.get(old_key).await?.iter().any(|p| p == &row_path);
+        if !old_exists {
+            return Err(ExecuteError::wrap(format!(
+                "cannot update: row_path '{}' not found under key '{}'",
+                row_path, old_key
+            )));
+        }
+
+        if self.is_unique && old_key != new_key && self.get_one(&new_key).await?.is_some() {
+            return Err(ExecuteError::wrap(format!(
+                "unique index violation on column '{}': key '{}' already exists",
+                self.column_name, new_key
+            )));
+        }
+
+        self.remove(old_key, &row_path).await?;
+        self.insert(new_key, row_path).await
+    }
+
+    /// Range scan over `[start, end)`. `None` on either bound means
+    /// unbounded on that side.
+    pub async fn range(
+        &self,
+        start: Option<&str>,
+        end: Option<&str>,
+    ) -> errors::Result<Vec<IndexEntry>> {
+        if start.zip(end).is_some_and(|(s, e)| s > e) {
+            return Ok(Vec::new());
+        }
+
+        let start_leaf = match start {
+            Some(key) => self.find_leaf(key).await?,
+            None => self.find_leftmost_leaf().await?,
+        };
+
+        let Some(mut current) = start_leaf else {
+            return Ok(Vec::new());
+        };
+
+        let mut result = Vec::new();
+        loop {
+            let entries = self.leaf_entries_with_overflow(current).await?;
+            let next_leaf = match self.store.read_page(current).await? {
+                Page::Leaf(leaf) => leaf.next_leaf,
+                Page::Internal(_) => {
+                    return Err(ExecuteError::wrap("corrupt index: expected a leaf page"))
+                }
+            };
+
+            let mut done = false;
+            for entry in entries {
+                if start.is_some_and(|s| entry.key.as_str() < s) {
+                    continue;
+                }
+                if end.is_some_and(|e| entry.key.as_str() >= e) {
+                    done = true;
+                    break;
+                }
+                result.push(IndexEntry {
+                    key: entry.key,
+                    row_path: entry.row_path,
+                });
+            }
+
+            if done {
+                break;
+            }
+            match next_leaf {
+                Some(next) => current = next,
+                None => break,
+            }
+        }
+
+        Ok(result)
+    }
+
+    pub async fn scan_all(&self) -> errors::Result<Vec<IndexEntry>> {
+        self.range(None, None).await
+    }
+
+    /// Total number of `(key, row_path)` entries in the index.
+    pub async fn len(&self) -> errors::Result<usize> {
+        Ok(self.scan_all().await?.len())
+    }
+
+    /// Number of distinct keys in the index.
+    pub async fn distinct_keys(&self) -> errors::Result<usize> {
+        let entries = self.scan_all().await?;
+        let mut count = 0;
+        let mut last_key: Option<&str> = None;
+        for entry in &entries {
+            if last_key != Some(entry.key.as_str()) {
+                count += 1;
+                last_key = Some(entry.key.as_str());
+            }
+        }
+        Ok(count)
+    }
+}
+
+/// Find an index `i` in `[1, entries.len())` such that `entries[i-1].key !=
+/// entries[i].key`, as close to the midpoint as possible. Returns `None` if
+/// every entry shares the same key (the leaf cannot be split without
+/// breaking a duplicate-key group).
+fn find_split_point(entries: &[LeafEntry]) -> Option<usize> {
+    let len = entries.len();
+    if len < 2 {
+        return None;
+    }
+    let mid = len / 2;
+    let max_delta = mid.max(len - mid);
+
+    for delta in 0..=max_delta {
+        let up = mid + delta;
+        if up > 0 && up < len && entries[up - 1].key != entries[up].key {
+            return Some(up);
+        }
+        if delta <= mid {
+            let down = mid - delta;
+            if down > 0 && down < len && entries[down - 1].key != entries[down].key {
+                return Some(down);
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        let dir = std::path::PathBuf::from("target/test_page_btree");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(name);
+        let _ = std::fs::remove_file(&path);
+        path
+    }
+
+    #[tokio::test]
+    async fn insert_then_reload_from_disk_finds_the_entry() {
+        let path = temp_path("insert_reload.idx");
+
+        {
+            let idx = PageBackedBTreeIndex::create(&path, "id".to_string(), false)
+                .await
+                .unwrap();
+            idx.insert("I:001".to_string(), "/r/1".to_string())
+                .await
+                .unwrap();
+        }
+
+        {
+            let idx = PageBackedBTreeIndex::open(&path, "id".to_string(), false)
+                .await
+                .unwrap();
+            let results = idx.get("I:001").await.unwrap();
+            assert_eq!(results, vec!["/r/1".to_string()]);
+        }
+    }
+
+    fn int_key(i: i64) -> String {
+        format!("I:{:020}", i)
+    }
+
+    #[tokio::test]
+    async fn unique_index_rejects_duplicate_key_without_mutating_state() {
+        let path = temp_path("unique_violation.idx");
+        let idx = PageBackedBTreeIndex::create(&path, "id".to_string(), true)
+            .await
+            .unwrap();
+
+        idx.insert("I:001".to_string(), "/r/1".to_string())
+            .await
+            .unwrap();
+
+        let result = idx.insert("I:001".to_string(), "/r/2".to_string()).await;
+        assert!(result.is_err());
+
+        // The failed insert must not have mutated the index.
+        assert_eq!(idx.get("I:001").await.unwrap(), vec!["/r/1".to_string()]);
+        assert_eq!(idx.len().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn remove_then_reload_no_longer_finds_the_entry() {
+        let path = temp_path("remove_reload.idx");
+
+        {
+            let idx = PageBackedBTreeIndex::create(&path, "name".to_string(), false)
+                .await
+                .unwrap();
+            idx.insert("S:alice".to_string(), "/r/1".to_string())
+                .await
+                .unwrap();
+            idx.insert("S:alice".to_string(), "/r/2".to_string())
+                .await
+                .unwrap();
+
+            let removed = idx.remove("S:alice", "/r/1").await.unwrap();
+            assert!(removed);
+            // Removing something already gone returns false, not an error.
+            assert!(!idx.remove("S:alice", "/r/1").await.unwrap());
+        }
+
+        {
+            let idx = PageBackedBTreeIndex::open(&path, "name".to_string(), false)
+                .await
+                .unwrap();
+            assert_eq!(idx.get("S:alice").await.unwrap(), vec!["/r/2".to_string()]);
+            assert_eq!(idx.len().await.unwrap(), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn update_then_reload_moves_the_key() {
+        let path = temp_path("update_reload.idx");
+
+        {
+            let idx = PageBackedBTreeIndex::create(&path, "name".to_string(), true)
+                .await
+                .unwrap();
+            idx.insert("S:old".to_string(), "/r/1".to_string())
+                .await
+                .unwrap();
+            idx.update("S:old", "S:new".to_string(), "/r/1".to_string())
+                .await
+                .unwrap();
+        }
+
+        {
+            let idx = PageBackedBTreeIndex::open(&path, "name".to_string(), true)
+                .await
+                .unwrap();
+            assert!(idx.get("S:old").await.unwrap().is_empty());
+            assert_eq!(
+                idx.get_one("S:new").await.unwrap(),
+                Some("/r/1".to_string())
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn update_rejects_unique_violation_on_new_key() {
+        let path = temp_path("update_unique_violation.idx");
+        let idx = PageBackedBTreeIndex::create(&path, "name".to_string(), true)
+            .await
+            .unwrap();
+
+        idx.insert("S:taken".to_string(), "/r/1".to_string())
+            .await
+            .unwrap();
+        idx.insert("S:mine".to_string(), "/r/2".to_string())
+            .await
+            .unwrap();
+
+        let result = idx
+            .update("S:mine", "S:taken".to_string(), "/r/2".to_string())
+            .await;
+        assert!(result.is_err());
+
+        // Original mapping must still be intact.
+        assert_eq!(
+            idx.get_one("S:mine").await.unwrap(),
+            Some("/r/2".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn inserting_enough_entries_forces_leaf_splits_and_range_scan_still_works() {
+        let path = temp_path("split_range.idx");
+        let idx = PageBackedBTreeIndex::create(&path, "id".to_string(), false)
+            .await
+            .unwrap();
+
+        // INDEX_PAGE_SIZE is 4096 bytes; each entry here is roughly
+        // 30-40 bytes once bincode+header overhead is counted, so a few
+        // hundred inserts guarantees multiple leaf (and likely internal)
+        // page splits.
+        let n = 800;
+        for i in 0..n {
+            idx.insert(int_key(i), format!("/r/{}", i)).await.unwrap();
+        }
+
+        assert_eq!(idx.len().await.unwrap(), n as usize);
+        assert_eq!(idx.distinct_keys().await.unwrap(), n as usize);
+
+        // Range scan across many leaves.
+        let start = int_key(100);
+        let end = int_key(200);
+        let results = idx.range(Some(&start), Some(&end)).await.unwrap();
+        assert_eq!(results.len(), 100);
+        assert_eq!(results[0].key, start);
+        assert_eq!(results.last().unwrap().key, int_key(199));
+
+        // Full scan preserves global sorted order across all leaves.
+        let all = idx.scan_all().await.unwrap();
+        assert_eq!(all.len(), n as usize);
+        for w in all.windows(2) {
+            assert!(w[0].key < w[1].key);
+        }
+
+        // Exact-match get still works after splitting.
+        assert_eq!(idx.get(&int_key(750)).await.unwrap(), vec!["/r/750".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn duplicate_key_group_survives_splits_and_reload() {
+        let path = temp_path("duplicates.idx");
+
+        {
+            let idx = PageBackedBTreeIndex::create(&path, "status".to_string(), false)
+                .await
+                .unwrap();
+
+            // A large duplicate-key group, big enough to overflow a single
+            // leaf page (see module doc comment on the overflow-chain
+            // policy), interleaved with enough distinct keys on either side
+            // to also force normal leaf splits elsewhere in the tree.
+            for i in 0..300 {
+                idx.insert(format!("I:before:{:05}", i), format!("/before/{}", i))
+                    .await
+                    .unwrap();
+            }
+            for i in 0..200 {
+                idx.insert("S:dup".to_string(), format!("/dup/{}", i))
+                    .await
+                    .unwrap();
+            }
+            for i in 0..300 {
+                idx.insert(format!("I:zzafter:{:05}", i), format!("/after/{}", i))
+                    .await
+                    .unwrap();
+            }
+
+            let dups = idx.get("S:dup").await.unwrap();
+            assert_eq!(dups.len(), 200);
+        }
+
+        {
+            let idx = PageBackedBTreeIndex::open(&path, "status".to_string(), false)
+                .await
+                .unwrap();
+            let dups = idx.get("S:dup").await.unwrap();
+            assert_eq!(dups.len(), 200);
+            for i in 0..200 {
+                assert!(dups.contains(&format!("/dup/{}", i)));
+            }
+
+            // Removing one duplicate leaves the rest intact.
+            assert!(idx.remove("S:dup", "/dup/0").await.unwrap());
+            assert_eq!(idx.get("S:dup").await.unwrap().len(), 199);
+        }
+    }
+
+    #[tokio::test]
+    async fn find_split_point_returns_none_when_every_entry_shares_one_key() {
+        let entries: Vec<LeafEntry> = (0..5)
+            .map(|i| LeafEntry {
+                key: "S:dup".to_string(),
+                row_path: format!("/r/{}", i),
+            })
+            .collect();
+        assert_eq!(find_split_point(&entries), None);
+    }
+
+    #[tokio::test]
+    async fn find_split_point_never_separates_a_duplicate_group() {
+        let entries = vec![
+            LeafEntry { key: "a".to_string(), row_path: "1".to_string() },
+            LeafEntry { key: "b".to_string(), row_path: "1".to_string() },
+            LeafEntry { key: "b".to_string(), row_path: "2".to_string() },
+            LeafEntry { key: "b".to_string(), row_path: "3".to_string() },
+            LeafEntry { key: "c".to_string(), row_path: "1".to_string() },
+        ];
+        let split = find_split_point(&entries).unwrap();
+        assert_ne!(entries[split - 1].key, entries[split].key);
+    }
+}

--- a/src/engine/index/page_store.rs
+++ b/src/engine/index/page_store.rs
@@ -1,0 +1,309 @@
+//! Fixed-size page storage for the page-backed B+tree index (issue #230).
+//!
+//! On-disk layout: a small fixed-size superblock, followed by an array of
+//! `page_size`-byte page slots addressed by `page_id` (see `page.rs` for the
+//! per-page encoding). Pages are allocated with a simple bump allocator --
+//! there is no free-list reuse of dropped pages in this MVP.
+//!
+//! File IO is synchronous (`std::fs::File` guarded by a `std::sync::Mutex`)
+//! run inline inside `async fn`s. This briefly blocks the executor thread on
+//! each page read/write; a follow-up could move this onto
+//! `tokio::task::spawn_blocking` to avoid that. Because every mutating
+//! operation only reads/writes the handful of pages it touches (not the
+//! whole file), this is still a large improvement over the previous
+//! full-file snapshot rewrite on every mutation.
+
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::Path;
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+
+use crate::errors;
+use crate::errors::execute_error::ExecuteError;
+
+use super::page::{self, Page, PageId};
+
+const MAGIC: [u8; 4] = *b"RIDX";
+const VERSION: u16 = 1;
+/// Fixed size of the superblock region at the start of the file. Must be
+/// large enough to hold the bincode-encoded `Superblock` below; checked by a
+/// test.
+pub const SUPERBLOCK_SIZE: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct Superblock {
+    magic: [u8; 4],
+    version: u16,
+    page_size: u32,
+    root_page_id: Option<PageId>,
+    next_page_id: PageId,
+}
+
+/// A single index's page-backed storage file.
+pub struct PageStore {
+    file: Mutex<std::fs::File>,
+    page_size: usize,
+}
+
+impl PageStore {
+    /// Create a brand new, empty page store at `path` with the given
+    /// `page_size`. Errors if a file already exists at `path`.
+    pub async fn create(path: &Path, page_size: usize) -> errors::Result<Self> {
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(path)
+            .map_err(|e| ExecuteError::wrap(format!("failed to create index file: {}", e)))?;
+
+        let store = PageStore {
+            file: Mutex::new(file),
+            page_size,
+        };
+
+        store
+            .write_superblock(&Superblock {
+                magic: MAGIC,
+                version: VERSION,
+                page_size: page_size as u32,
+                root_page_id: None,
+                next_page_id: 0,
+            })
+            .await?;
+
+        Ok(store)
+    }
+
+    /// Open an existing page store, reading `page_size` back from its
+    /// superblock.
+    pub async fn open(path: &Path) -> errors::Result<Self> {
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .map_err(|e| ExecuteError::wrap(format!("failed to open index file: {}", e)))?;
+
+        let store = PageStore {
+            file: Mutex::new(file),
+            page_size: page::INDEX_PAGE_SIZE,
+        };
+
+        let sb = store.read_superblock()?;
+        if sb.magic != MAGIC {
+            return Err(ExecuteError::wrap("index file has invalid magic bytes"));
+        }
+
+        Ok(PageStore {
+            file: store.file,
+            page_size: sb.page_size as usize,
+        })
+    }
+
+    pub fn page_size(&self) -> usize {
+        self.page_size
+    }
+
+    fn read_superblock(&self) -> errors::Result<Superblock> {
+        let mut buf = vec![0u8; SUPERBLOCK_SIZE];
+        let mut file = self.file.lock().unwrap();
+        file.seek(SeekFrom::Start(0))
+            .map_err(|e| ExecuteError::wrap(format!("failed to seek to superblock: {}", e)))?;
+        file.read_exact(&mut buf)
+            .map_err(|e| ExecuteError::wrap(format!("failed to read superblock: {}", e)))?;
+
+        bincode::deserialize(&buf)
+            .map_err(|e| ExecuteError::wrap(format!("failed to decode superblock: {}", e)))
+    }
+
+    async fn write_superblock(&self, sb: &Superblock) -> errors::Result<()> {
+        let mut encoded = bincode::serialize(sb)
+            .map_err(|e| ExecuteError::wrap(format!("failed to encode superblock: {}", e)))?;
+        if encoded.len() > SUPERBLOCK_SIZE {
+            return Err(ExecuteError::wrap("superblock exceeds reserved size"));
+        }
+        encoded.resize(SUPERBLOCK_SIZE, 0);
+
+        let mut file = self.file.lock().unwrap();
+        file.seek(SeekFrom::Start(0))
+            .map_err(|e| ExecuteError::wrap(format!("failed to seek to superblock: {}", e)))?;
+        file.write_all(&encoded)
+            .map_err(|e| ExecuteError::wrap(format!("failed to write superblock: {}", e)))?;
+        file.flush()
+            .map_err(|e| ExecuteError::wrap(format!("failed to flush superblock: {}", e)))?;
+
+        Ok(())
+    }
+
+    fn page_offset(&self, page_id: PageId) -> u64 {
+        SUPERBLOCK_SIZE as u64 + (page_id as u64) * (self.page_size as u64)
+    }
+
+    /// Read a page by id. The page must have been previously written via
+    /// `write_page` (or `allocate_page` + `write_page`).
+    pub async fn read_page(&self, page_id: PageId) -> errors::Result<Page> {
+        let mut buf = vec![0u8; self.page_size];
+        {
+            let mut file = self.file.lock().unwrap();
+            file.seek(SeekFrom::Start(self.page_offset(page_id)))
+                .map_err(|e| ExecuteError::wrap(format!("failed to seek to page: {}", e)))?;
+            file.read_exact(&mut buf)
+                .map_err(|e| ExecuteError::wrap(format!("failed to read page {}: {}", page_id, e)))?;
+        }
+        page::decode_page(&buf)
+    }
+
+    /// Write a page at `page_id`, overwriting only that page's fixed slot.
+    pub async fn write_page(&self, page_id: PageId, page: &Page) -> errors::Result<()> {
+        let encoded = page::encode_page(page, self.page_size)?;
+
+        let mut file = self.file.lock().unwrap();
+        file.seek(SeekFrom::Start(self.page_offset(page_id)))
+            .map_err(|e| ExecuteError::wrap(format!("failed to seek to page: {}", e)))?;
+        file.write_all(&encoded)
+            .map_err(|e| ExecuteError::wrap(format!("failed to write page {}: {}", page_id, e)))?;
+        file.flush()
+            .map_err(|e| ExecuteError::wrap(format!("failed to flush page {}: {}", page_id, e)))?;
+
+        Ok(())
+    }
+
+    /// Allocate a fresh page id (bump allocator; no reuse of freed pages).
+    pub async fn allocate_page(&self) -> errors::Result<PageId> {
+        let mut sb = self.read_superblock()?;
+        let id = sb.next_page_id;
+        sb.next_page_id += 1;
+        self.write_superblock(&sb).await?;
+        Ok(id)
+    }
+
+    pub async fn root_page_id(&self) -> errors::Result<Option<PageId>> {
+        Ok(self.read_superblock()?.root_page_id)
+    }
+
+    pub async fn set_root_page_id(&self, root: Option<PageId>) -> errors::Result<()> {
+        let mut sb = self.read_superblock()?;
+        sb.root_page_id = root;
+        self.write_superblock(&sb).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::index::page::{InternalPage, LeafEntry, LeafPage};
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        let dir = std::path::PathBuf::from("target/test_page_store");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(name);
+        let _ = std::fs::remove_file(&path);
+        path
+    }
+
+    #[test]
+    fn superblock_fits_in_its_reserved_size() {
+        let sb = Superblock {
+            magic: MAGIC,
+            version: VERSION,
+            page_size: page::INDEX_PAGE_SIZE as u32,
+            root_page_id: Some(12345),
+            next_page_id: 67890,
+        };
+        let encoded = bincode::serialize(&sb).unwrap();
+        assert!(encoded.len() <= SUPERBLOCK_SIZE);
+    }
+
+    #[tokio::test]
+    async fn allocates_and_persists_pages_across_reopen() {
+        let path = temp_path("alloc_reopen.idx");
+
+        let leaf_id;
+        {
+            let store = PageStore::create(&path, 256).await.unwrap();
+            assert_eq!(store.root_page_id().await.unwrap(), None);
+
+            leaf_id = store.allocate_page().await.unwrap();
+            let page = Page::Leaf(LeafPage {
+                entries: vec![LeafEntry {
+                    key: "I:001".to_string(),
+                    row_path: "/r/1".to_string(),
+                }],
+                next_leaf: None,
+                overflow: None,
+            });
+            store.write_page(leaf_id, &page).await.unwrap();
+            store.set_root_page_id(Some(leaf_id)).await.unwrap();
+        }
+
+        {
+            let store = PageStore::open(&path).await.unwrap();
+            assert_eq!(store.page_size(), 256);
+            assert_eq!(store.root_page_id().await.unwrap(), Some(leaf_id));
+
+            let page = store.read_page(leaf_id).await.unwrap();
+            match page {
+                Page::Leaf(leaf) => {
+                    assert_eq!(leaf.entries.len(), 1);
+                    assert_eq!(leaf.entries[0].key, "I:001");
+                }
+                _ => panic!("expected a leaf page"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn writing_one_page_does_not_disturb_its_neighbors() {
+        let path = temp_path("isolated_writes.idx");
+        let store = PageStore::create(&path, 256).await.unwrap();
+
+        let a = store.allocate_page().await.unwrap();
+        let b = store.allocate_page().await.unwrap();
+
+        store
+            .write_page(
+                a,
+                &Page::Internal(InternalPage {
+                    keys: vec!["I:010".to_string()],
+                    children: vec![1, 2],
+                }),
+            )
+            .await
+            .unwrap();
+        store
+            .write_page(
+                b,
+                &Page::Leaf(LeafPage {
+                    entries: vec![LeafEntry {
+                        key: "I:020".to_string(),
+                        row_path: "/r/2".to_string(),
+                    }],
+                    next_leaf: None,
+                    overflow: None,
+                }),
+            )
+            .await
+            .unwrap();
+
+        match store.read_page(a).await.unwrap() {
+            Page::Internal(p) => assert_eq!(p.keys, vec!["I:010".to_string()]),
+            _ => panic!("expected internal page at a"),
+        }
+        match store.read_page(b).await.unwrap() {
+            Page::Leaf(p) => assert_eq!(p.entries[0].row_path, "/r/2"),
+            _ => panic!("expected leaf page at b"),
+        }
+    }
+
+    #[tokio::test]
+    async fn allocate_page_ids_are_monotonically_increasing() {
+        let path = temp_path("monotonic_ids.idx");
+        let store = PageStore::create(&path, 256).await.unwrap();
+
+        let mut ids = Vec::new();
+        for _ in 0..3 {
+            ids.push(store.allocate_page().await.unwrap());
+        }
+        assert_eq!(ids, vec![0, 1, 2]);
+    }
+}

--- a/src/engine/index/page_store.rs
+++ b/src/engine/index/page_store.rs
@@ -129,8 +129,8 @@ impl PageStore {
             .map_err(|e| ExecuteError::wrap(format!("failed to seek to superblock: {}", e)))?;
         file.write_all(&encoded)
             .map_err(|e| ExecuteError::wrap(format!("failed to write superblock: {}", e)))?;
-        file.flush()
-            .map_err(|e| ExecuteError::wrap(format!("failed to flush superblock: {}", e)))?;
+        file.sync_data()
+            .map_err(|e| ExecuteError::wrap(format!("failed to sync superblock: {}", e)))?;
 
         Ok(())
     }
@@ -162,8 +162,8 @@ impl PageStore {
             .map_err(|e| ExecuteError::wrap(format!("failed to seek to page: {}", e)))?;
         file.write_all(&encoded)
             .map_err(|e| ExecuteError::wrap(format!("failed to write page {}: {}", page_id, e)))?;
-        file.flush()
-            .map_err(|e| ExecuteError::wrap(format!("failed to flush page {}: {}", page_id, e)))?;
+        file.sync_data()
+            .map_err(|e| ExecuteError::wrap(format!("failed to sync page {}: {}", page_id, e)))?;
 
         Ok(())
     }

--- a/src/engine/initialize.rs
+++ b/src/engine/initialize.rs
@@ -206,9 +206,36 @@ impl DBEngine {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use tokio::sync::{Mutex, OnceCell, RwLock};
+
     use crate::config::launch_config::LaunchConfig;
     #[cfg(target_os = "linux")]
     use crate::constants::SYSTEMD_DAEMON_SCRIPT;
+    use crate::engine::DBEngine;
+    use crate::engine::index::manager::IndexManager;
+    use crate::engine::optimizer::statistics::StatisticsManager;
+
+    fn build_test_engine(
+        config: Arc<LaunchConfig>,
+        file_system: Arc<dyn crate::common::fs::FileSystem + Send + Sync>,
+        command_runner: Arc<dyn crate::common::command::CommandRunner + Send + Sync>,
+    ) -> DBEngine {
+        let data_directory = PathBuf::from(config.data_directory.clone());
+
+        DBEngine {
+            config,
+            file_system,
+            command_runner,
+            table_config_cache: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            row_storage_lock: Arc::new(Mutex::new(())),
+            index_manager: Arc::new(IndexManager::new(data_directory)),
+            statistics_manager: Arc::new(StatisticsManager::new()),
+            indices_loaded: Arc::new(OnceCell::new()),
+        }
+    }
 
     #[cfg(target_os = "linux")]
     #[tokio::test]
@@ -566,15 +593,11 @@ wal_extension = "log"
 
         for index in [0, 2, 4, 5, 6] {
             let test_case = &test_cases[index];
-            let executor = DBEngine {
-                config: (test_case.mock_config)(),
-                file_system: (test_case.mock_file_system)(),
-                command_runner: (test_case.mock_command_runner)(),
-                table_config_cache: Arc::new(tokio::sync::RwLock::new(
-                    std::collections::HashMap::new(),
-                )),
-                row_storage_lock: Arc::new(tokio::sync::Mutex::new(())),
-            };
+            let executor = build_test_engine(
+                (test_case.mock_config)(),
+                (test_case.mock_file_system)(),
+                (test_case.mock_command_runner)(),
+            );
 
             let result = executor.init_config(None).await;
 
@@ -627,15 +650,11 @@ wal_extension = "log"
 
         let command_runner = MockCommandRunner::new();
 
-        let executor = DBEngine {
-            config: Arc::new(config),
-            file_system: Arc::new(file_system),
-            command_runner: Arc::new(command_runner),
-            table_config_cache: Arc::new(
-                tokio::sync::RwLock::new(std::collections::HashMap::new()),
-            ),
-            row_storage_lock: Arc::new(tokio::sync::Mutex::new(())),
-        };
+        let executor = build_test_engine(
+            Arc::new(config),
+            Arc::new(file_system),
+            Arc::new(command_runner),
+        );
 
         let result = executor.init_config(Some(base_path)).await;
 
@@ -674,15 +693,11 @@ wal_extension = "log"
             })
         });
 
-        let executor = DBEngine {
-            config: Arc::new(LaunchConfig::default()),
-            file_system: Arc::new(file_system),
-            command_runner: Arc::new(command_runner),
-            table_config_cache: Arc::new(
-                tokio::sync::RwLock::new(std::collections::HashMap::new()),
-            ),
-            row_storage_lock: Arc::new(tokio::sync::Mutex::new(())),
-        };
+        let executor = build_test_engine(
+            Arc::new(LaunchConfig::default()),
+            Arc::new(file_system),
+            Arc::new(command_runner),
+        );
 
         let result = executor.install_daemon().await;
 

--- a/src/engine/lexer/test/select.rs
+++ b/src/engine/lexer/test/select.rs
@@ -4,6 +4,7 @@ use crate::engine::lexer::predule::OperatorToken;
 use crate::engine::lexer::predule::{Token, Tokenizer};
 
 #[test]
+#[allow(clippy::approx_constant)]
 pub fn test_number_literal() {
     struct TestCase {
         name: String,

--- a/src/engine/lexer/tokenizer.rs
+++ b/src/engine/lexer/tokenizer.rs
@@ -140,6 +140,8 @@ impl Tokenizer {
                 "PRIMARY" => Token::Primary,
                 "FOREIGN" => Token::Foreign,
                 "KEY" => Token::Key,
+                "INDEX" => Token::Index,
+                "UNIQUE" => Token::Unique,
                 "ADD" => Token::Add,
                 "RENAME" => Token::Rename,
                 "TO" => Token::To,

--- a/src/engine/lexer/tokens.rs
+++ b/src/engine/lexer/tokens.rs
@@ -49,6 +49,8 @@ pub enum Token {
     Primary,
     Foreign,
     Key,
+    Index,
+    Unique,
     Add,
     If,
     Rename,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -24,6 +24,8 @@ use crate::config::launch_config::LaunchConfig;
 use crate::engine::ast::types::TableName;
 use crate::engine::ast::{DDLStatement, DMLStatement, OtherStatement, SQLStatement};
 use crate::engine::encoder::schema_encoder::StorageEncoder;
+use crate::engine::index::manager::IndexManager;
+use crate::engine::optimizer::statistics::StatisticsManager;
 use crate::engine::schema::table::TableSchema;
 use crate::engine::types::ExecuteResult;
 use crate::engine::wal::endec::implements::bincode::BincodeEncoder;
@@ -40,16 +42,25 @@ pub struct DBEngine {
     pub(crate) command_runner: Arc<dyn CommandRunner + Send + Sync>,
     pub(crate) table_config_cache: Arc<RwLock<HashMap<TableName, TableSchema>>>,
     pub(crate) row_storage_lock: Arc<Mutex<()>>,
+    pub(crate) index_manager: Arc<IndexManager>,
+    pub(crate) statistics_manager: Arc<StatisticsManager>,
+    /// 디스크의 인덱스 파일을 메모리로 적재했는지 여부 (최초 사용 시 1회 적재)
+    pub(crate) indices_loaded: Arc<tokio::sync::OnceCell<()>>,
 }
 
 impl DBEngine {
     pub fn new(config: LaunchConfig) -> Self {
+        let data_directory = PathBuf::from(config.data_directory.clone());
+
         Self {
             config: Arc::new(config),
             file_system: Arc::new(RealFileSystem {}),
             command_runner: Arc::new(RealCommandRunner {}),
             table_config_cache: Arc::new(RwLock::new(HashMap::new())),
             row_storage_lock: Arc::new(Mutex::new(())),
+            index_manager: Arc::new(IndexManager::new(data_directory)),
+            statistics_manager: Arc::new(StatisticsManager::new()),
+            indices_loaded: Arc::new(tokio::sync::OnceCell::new()),
         }
     }
 
@@ -80,6 +91,10 @@ impl DBEngine {
                 self.alter_table(query).await
             }
             SQLStatement::DDL(DDLStatement::DropTableQuery(query)) => self.drop_table(query).await,
+            SQLStatement::DDL(DDLStatement::CreateIndexQuery(query)) => {
+                self.create_index(query).await
+            }
+            SQLStatement::DDL(DDLStatement::DropIndexQuery(query)) => self.drop_index(query).await,
             SQLStatement::DML(DMLStatement::InsertQuery(query)) => {
                 self.insert(query, wal_manager.clone()).await
             }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -22,6 +22,11 @@ use std::sync::Arc;
 use crate::common::command::{CommandRunner, RealCommandRunner};
 use crate::common::fs::{FileSystem, RealFileSystem};
 use crate::config::launch_config::LaunchConfig;
+use crate::engine::ast::ddl::create_index::CreateIndexQuery;
+use crate::engine::ast::ddl::drop_index::DropIndexQuery;
+use crate::engine::ast::dml::delete::DeleteQuery;
+use crate::engine::ast::dml::insert::InsertQuery;
+use crate::engine::ast::dml::update::UpdateQuery;
 use crate::engine::ast::types::TableName;
 use crate::engine::ast::{DDLStatement, DMLStatement, OtherStatement, SQLStatement};
 use crate::engine::encoder::schema_encoder::StorageEncoder;
@@ -32,6 +37,7 @@ use crate::engine::schema::table::TableSchema;
 use crate::engine::types::ExecuteResult;
 use crate::engine::wal::endec::implements::bincode::BincodeEncoder;
 use crate::engine::wal::manager::WALManager;
+use crate::engine::wal::types::{EntryType, WALEntry};
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
 use tokio::sync::{Mutex, RwLock};
@@ -96,9 +102,11 @@ impl DBEngine {
             }
             SQLStatement::DDL(DDLStatement::DropTableQuery(query)) => self.drop_table(query).await,
             SQLStatement::DDL(DDLStatement::CreateIndexQuery(query)) => {
-                self.create_index(query).await
+                self.create_index(query, wal_manager.clone()).await
             }
-            SQLStatement::DDL(DDLStatement::DropIndexQuery(query)) => self.drop_index(query).await,
+            SQLStatement::DDL(DDLStatement::DropIndexQuery(query)) => {
+                self.drop_index(query, wal_manager.clone()).await
+            }
             SQLStatement::DML(DMLStatement::InsertQuery(query)) => {
                 self.insert(query, wal_manager.clone()).await
             }
@@ -124,6 +132,69 @@ impl DBEngine {
             Ok(result) => Ok(result),
             Err(error) => Err(ExecuteError::wrap(error.to_string())),
         }
+    }
+
+    /// Replays WAL entries written but not yet checkpointed before a crash,
+    /// re-executing each recorded operation so its data/index mutation is
+    /// guaranteed to have taken effect (WAL-ahead recovery, mirroring
+    /// PostgreSQL's redo phase). A single entry failing to reapply (e.g. a
+    /// unique-constraint violation, which -- since WAL is written before the
+    /// mutation -- would also have failed the first time around and so never
+    /// actually took effect) is logged and does not abort the rest of
+    /// recovery.
+    pub async fn replay_wal(&self, entries: &[WALEntry]) -> errors::Result<()> {
+        for entry in entries {
+            let data = entry.data.as_deref();
+
+            let result: errors::Result<()> = async {
+                match entry.entry_type {
+                    EntryType::Insert => {
+                        let query = Self::decode_wal_payload::<InsertQuery>(data)?;
+                        self.insert_replay(query).await.map(|_| ())
+                    }
+                    EntryType::Set => {
+                        let query = Self::decode_wal_payload::<UpdateQuery>(data)?;
+                        self.update_replay(query).await.map(|_| ())
+                    }
+                    EntryType::Delete => {
+                        let query = Self::decode_wal_payload::<DeleteQuery>(data)?;
+                        self.delete_replay(query).await.map(|_| ())
+                    }
+                    EntryType::CreateIndex => {
+                        let query = Self::decode_wal_payload::<CreateIndexQuery>(data)?;
+                        self.create_index_replay(query).await.map(|_| ())
+                    }
+                    EntryType::DropIndex => {
+                        let query = Self::decode_wal_payload::<DropIndexQuery>(data)?;
+                        self.drop_index_replay(query).await.map(|_| ())
+                    }
+                    EntryType::Checkpoint
+                    | EntryType::TransactionBegin
+                    | EntryType::TransactionCommit
+                    | EntryType::TransactionRollback => Ok(()),
+                }
+            }
+            .await;
+
+            if let Err(error) = result {
+                log::warn!(
+                    "WAL replay: skipping entry {:?} due to error: {}",
+                    entry.entry_type,
+                    error
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn decode_wal_payload<T>(data: Option<&[u8]>) -> errors::Result<T>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let data =
+            data.ok_or_else(|| ExecuteError::wrap("WAL entry missing payload".to_string()))?;
+        bincode::deserialize(data).map_err(|error| ExecuteError::wrap(error.to_string()))
     }
 }
 

--- a/src/engine/optimizer/cost.rs
+++ b/src/engine/optimizer/cost.rs
@@ -1,0 +1,86 @@
+//! 비용 기반 옵티마이저의 비용 상수 및 공식 (#195)
+//!
+//! 상수 값은 PostgreSQL의 기본 비용 파라미터를 참조했습니다.
+
+/// 순차 페이지 읽기 비용
+pub const SEQ_PAGE_COST: f64 = 1.0;
+/// 임의 페이지 읽기 비용
+pub const RANDOM_PAGE_COST: f64 = 4.0;
+/// 튜플 하나 처리 비용
+pub const CPU_TUPLE_COST: f64 = 0.01;
+/// 연산자 하나 평가 비용
+pub const CPU_OPERATOR_COST: f64 = 0.0025;
+/// 고유값 통계가 없을 때 사용하는 동등 조건 선택도 기본값
+pub const DEFAULT_EQ_SELECTIVITY: f64 = 0.005;
+/// 범위 조건 선택도 기본값
+pub const DEFAULT_RANGE_SELECTIVITY: f64 = 1.0 / 3.0;
+/// 블록 개수 추정에 사용하는 블록 크기 (bytes)
+pub const BLOCK_SIZE: u64 = 8192;
+
+/// 풀 스캔 비용: 모든 블록 순차 읽기 + 모든 튜플 처리
+pub fn full_scan_cost(row_count: usize, block_count: usize) -> f64 {
+    block_count.max(1) as f64 * SEQ_PAGE_COST + row_count as f64 * CPU_TUPLE_COST
+}
+
+/// 인덱스 스캔 비용: B-tree 탐색 + 매칭 튜플별 임의 접근
+pub fn index_scan_cost(row_count: usize, selectivity: f64) -> f64 {
+    let rows = row_count as f64;
+    let matched = (rows * selectivity).max(1.0);
+    let btree_descent = if rows > 1.0 { rows.log2().ceil() } else { 1.0 } * CPU_OPERATOR_COST;
+
+    btree_descent + matched * (RANDOM_PAGE_COST + CPU_TUPLE_COST + CPU_OPERATOR_COST)
+}
+
+/// 동등 조건 선택도: 고유값 개수를 알면 1/ndv, 모르면 기본값
+pub fn eq_selectivity(distinct_values: Option<usize>) -> f64 {
+    match distinct_values {
+        Some(count) if count > 0 => (1.0 / count as f64).min(1.0),
+        _ => DEFAULT_EQ_SELECTIVITY,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn index_scan_beats_full_scan_for_selective_predicate_on_large_table() {
+        let row_count = 10_000;
+        let block_count = 100;
+
+        let full = full_scan_cost(row_count, block_count);
+        let index = index_scan_cost(row_count, eq_selectivity(Some(row_count)));
+
+        assert!(index < full);
+    }
+
+    #[test]
+    fn full_scan_beats_index_scan_on_tiny_table() {
+        let row_count = 3;
+        let block_count = 1;
+
+        let full = full_scan_cost(row_count, block_count);
+        let index = index_scan_cost(row_count, eq_selectivity(Some(row_count)));
+
+        assert!(full < index);
+    }
+
+    #[test]
+    fn full_scan_beats_unselective_range_scan() {
+        let row_count = 10_000;
+        let block_count = 100;
+
+        let full = full_scan_cost(row_count, block_count);
+        let index = index_scan_cost(row_count, DEFAULT_RANGE_SELECTIVITY);
+
+        // 행의 1/3을 임의 접근으로 읽는 것은 풀 스캔보다 비쌈
+        assert!(full < index);
+    }
+
+    #[test]
+    fn eq_selectivity_uses_distinct_values() {
+        assert_eq!(eq_selectivity(Some(100)), 0.01);
+        assert_eq!(eq_selectivity(Some(0)), DEFAULT_EQ_SELECTIVITY);
+        assert_eq!(eq_selectivity(None), DEFAULT_EQ_SELECTIVITY);
+    }
+}

--- a/src/engine/optimizer/mod.rs
+++ b/src/engine/optimizer/mod.rs
@@ -1,3 +1,5 @@
+pub mod cost;
 #[allow(clippy::module_inception)]
 pub mod optimizer;
 pub mod predule;
+pub mod statistics;

--- a/src/engine/optimizer/optimizer.rs
+++ b/src/engine/optimizer/optimizer.rs
@@ -1,28 +1,82 @@
+use std::collections::HashMap;
+
 use crate::engine::ast::dml::delete::DeleteQuery;
+use crate::engine::ast::dml::expressions::operators::{BinaryOperator, UnaryOperator};
 use crate::engine::ast::dml::parts::from::FromTarget;
 use crate::engine::ast::dml::plan::delete::delete_plan::DeletePlan;
 use crate::engine::ast::dml::plan::delete::from::DeleteFromPlan;
 use crate::engine::ast::dml::plan::select::filter::FilterPlan;
 use crate::engine::ast::dml::plan::select::from::SelectFromPlan;
 use crate::engine::ast::dml::plan::select::limit_offset::LimitOffsetPlan;
-use crate::engine::ast::dml::plan::select::scan::ScanType;
+use crate::engine::ast::dml::plan::select::scan::{IndexScanPlan, ScanType};
 use crate::engine::ast::dml::plan::select::select_plan::{SelectPlan, SelectPlanItem};
 use crate::engine::ast::dml::plan::update::from::UpdateFromPlan;
 use crate::engine::ast::dml::plan::update::update_plan::UpdatePlan;
 use crate::engine::ast::dml::select::SelectQuery;
 use crate::engine::ast::dml::update::UpdateQuery;
+use crate::engine::ast::types::{SQLExpression, SelectColumn, TableName};
+use crate::engine::index::{IndexMeta, field_to_key};
+use crate::engine::optimizer::cost;
+use crate::engine::optimizer::statistics::TableStatistics;
+use crate::engine::schema::row::TableDataFieldType;
 use crate::errors;
 
-pub struct Optimizer {}
+/// 옵티마이저가 계획을 세울 때 참조하는 컨텍스트 (#195)
+///
+/// FROM 대상 테이블의 인덱스 목록과 통계 정보를 담습니다.
+/// 컨텍스트가 비어 있으면 항상 FullScan으로 계획합니다.
+#[derive(Debug, Default)]
+pub struct OptimizerContext {
+    pub indexes: Vec<IndexMeta>,
+    pub statistics: Option<TableStatistics>,
+}
+
+/// WHERE 절 분석으로 얻은 컬럼별 키 경계
+#[derive(Debug, Default, Clone)]
+struct ColumnBounds {
+    eq_key: Option<String>,
+    /// 시작 키 (포함)
+    start_key: Option<String>,
+    /// 끝 키 (제외)
+    end_key: Option<String>,
+}
+
+pub struct Optimizer {
+    context: OptimizerContext,
+}
 
 impl Optimizer {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            context: OptimizerContext::default(),
+        }
+    }
+
+    pub fn with_context(context: OptimizerContext) -> Self {
+        Self { context }
     }
 
     pub async fn optimize_select(&self, query: SelectQuery) -> errors::Result<SelectPlan> {
         let mut has_from = false;
         let mut plan = SelectPlan { list: vec![] };
+
+        // 스캔 방식 결정 (조인 쿼리는 아직 FullScan만 지원)
+        // TODO(#195): 조인 실행기가 구현되면 조인 순서 최적화 추가
+        let scan = if query.join_clause.is_empty() {
+            match &query.from_table {
+                Some(from_clause) => match &from_clause.from {
+                    FromTarget::Table(table_name) => self.choose_scan(
+                        table_name,
+                        from_clause.alias.as_ref(),
+                        query.where_clause.as_ref().map(|w| &w.expression),
+                    ),
+                    FromTarget::Subquery(_) => ScanType::FullScan,
+                },
+                None => ScanType::FullScan,
+            }
+        } else {
+            ScanType::FullScan
+        };
 
         // FROM 절 분석
         if let Some(from_clause) = query.from_table {
@@ -34,7 +88,7 @@ impl Optimizer {
                     SelectFromPlan {
                         table_name,
                         alias,
-                        scan: ScanType::FullScan, // TODO: 인덱스 스캔 처리
+                        scan,
                     }
                     .into(),
                 ),
@@ -49,6 +103,7 @@ impl Optimizer {
             }
 
             // WHERE 절 필터링 구성
+            // 인덱스 스캔이 선택되어도 필터는 유지됩니다 (잔여 조건 처리 및 정합성 보장)
             if let Some(where_clause) = query.where_clause {
                 let expression = where_clause.expression;
 
@@ -97,11 +152,17 @@ impl Optimizer {
 
         let target_table = query.target_table.clone().unwrap();
 
+        let scan = self.choose_scan(
+            &target_table.table,
+            target_table.alias.as_ref(),
+            query.where_clause.as_ref().map(|w| &w.expression),
+        );
+
         plan.list.push(
             UpdateFromPlan {
                 table_name: target_table.table.clone(),
                 alias: target_table.alias,
-                scan: ScanType::FullScan, // TODO: 인덱스 스캔 처리
+                scan,
             }
             .into(),
         );
@@ -123,11 +184,17 @@ impl Optimizer {
 
         let target_table = query.from_table.clone().unwrap();
 
+        let scan = self.choose_scan(
+            &target_table.table,
+            target_table.alias.as_ref(),
+            query.where_clause.as_ref().map(|w| &w.expression),
+        );
+
         plan.list.push(
             DeleteFromPlan {
                 table_name: target_table.table.clone(),
                 alias: target_table.alias,
-                scan: ScanType::FullScan, // TODO: 인덱스 스캔 처리
+                scan,
             }
             .into(),
         );
@@ -143,10 +210,566 @@ impl Optimizer {
 
         Ok(plan)
     }
+
+    /// 비용 기반으로 FullScan / IndexScan 중 하나를 선택합니다. (#195)
+    ///
+    /// 1. WHERE 절을 AND 단위로 분해 (heuristic predicate pushdown)
+    /// 2. 인덱스 컬럼에 대한 sargable 조건(=, >, >=, <, <=, BETWEEN)을 추출
+    /// 3. 인덱스별 선택도/비용을 계산해 풀 스캔 비용보다 저렴한 최적 인덱스를 선택
+    fn choose_scan(
+        &self,
+        table_name: &TableName,
+        alias: Option<&String>,
+        where_expression: Option<&SQLExpression>,
+    ) -> ScanType {
+        let statistics = match &self.context.statistics {
+            Some(statistics) => statistics,
+            None => return ScanType::FullScan,
+        };
+
+        let where_expression = match where_expression {
+            Some(expression) => expression,
+            None => return ScanType::FullScan,
+        };
+
+        if self.context.indexes.is_empty() {
+            return ScanType::FullScan;
+        }
+
+        // WHERE 절을 AND 단위 조건으로 분해
+        let mut conjuncts = vec![];
+        collect_conjuncts(where_expression, &mut conjuncts);
+
+        // 컬럼별 키 경계 수집
+        let mut bounds_per_column: HashMap<String, ColumnBounds> = HashMap::new();
+
+        for conjunct in conjuncts {
+            if let Some((column_name, bounds)) =
+                extract_sargable_bounds(conjunct, table_name, alias)
+            {
+                merge_bounds(bounds_per_column.entry(column_name).or_default(), bounds);
+            }
+        }
+
+        if bounds_per_column.is_empty() {
+            return ScanType::FullScan;
+        }
+
+        let full_cost = cost::full_scan_cost(statistics.row_count, statistics.block_count);
+        let mut best: Option<(f64, IndexScanPlan)> = None;
+
+        for index in &self.context.indexes {
+            let bounds = match bounds_per_column.get(&index.column_name) {
+                Some(bounds) => bounds,
+                None => continue,
+            };
+
+            let selectivity = if bounds.eq_key.is_some() {
+                if index.is_unique {
+                    1.0 / statistics.row_count.max(1) as f64
+                } else {
+                    cost::eq_selectivity(
+                        statistics.distinct_values.get(&index.column_name).copied(),
+                    )
+                }
+            } else if bounds.start_key.is_some() || bounds.end_key.is_some() {
+                cost::DEFAULT_RANGE_SELECTIVITY
+            } else {
+                continue;
+            };
+
+            let scan_cost = cost::index_scan_cost(statistics.row_count, selectivity);
+
+            if scan_cost < full_cost && best.as_ref().map(|(c, _)| scan_cost < *c).unwrap_or(true) {
+                best = Some((
+                    scan_cost,
+                    IndexScanPlan {
+                        index_name: index.index_name.clone(),
+                        column_name: index.column_name.clone(),
+                        eq_key: bounds.eq_key.clone(),
+                        start_key: if bounds.eq_key.is_some() {
+                            None
+                        } else {
+                            bounds.start_key.clone()
+                        },
+                        end_key: if bounds.eq_key.is_some() {
+                            None
+                        } else {
+                            bounds.end_key.clone()
+                        },
+                    },
+                ));
+            }
+        }
+
+        match best {
+            Some((_, plan)) => ScanType::IndexScan(plan),
+            None => ScanType::FullScan,
+        }
+    }
 }
 
 impl Default for Optimizer {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// AND로 연결된 표현식을 개별 조건으로 분해합니다.
+fn collect_conjuncts<'a>(expression: &'a SQLExpression, out: &mut Vec<&'a SQLExpression>) {
+    match expression {
+        SQLExpression::Binary(binary) if binary.operator == BinaryOperator::And => {
+            collect_conjuncts(&binary.lhs, out);
+            collect_conjuncts(&binary.rhs, out);
+        }
+        SQLExpression::Parentheses(parentheses) => {
+            collect_conjuncts(&parentheses.expression, out);
+        }
+        _ => out.push(expression),
+    }
+}
+
+/// 리터럴 표현식을 인덱스 키로 변환 가능한 값으로 평가합니다.
+fn literal_to_field(expression: &SQLExpression) -> Option<TableDataFieldType> {
+    match expression {
+        SQLExpression::Integer(value) => Some(TableDataFieldType::Integer(*value)),
+        SQLExpression::Float(value) => Some(TableDataFieldType::Float((*value).into())),
+        SQLExpression::Boolean(value) => Some(TableDataFieldType::Boolean(*value)),
+        SQLExpression::String(value) => Some(TableDataFieldType::String(value.clone())),
+        SQLExpression::Unary(unary) => match (&unary.operator, &unary.operand) {
+            (UnaryOperator::Neg, SQLExpression::Integer(value)) => {
+                Some(TableDataFieldType::Integer(-value))
+            }
+            (UnaryOperator::Neg, SQLExpression::Float(value)) => {
+                Some(TableDataFieldType::Float((-value).into()))
+            }
+            (UnaryOperator::Pos, operand) => literal_to_field(operand),
+            _ => None,
+        },
+        SQLExpression::Parentheses(parentheses) => literal_to_field(&parentheses.expression),
+        _ => None,
+    }
+}
+
+/// 컬럼 참조가 대상 테이블(또는 별칭)을 가리키는지 확인합니다.
+fn column_matches(column: &SelectColumn, table_name: &TableName, alias: Option<&String>) -> bool {
+    match &column.table_name {
+        None => true,
+        Some(name) => name == &table_name.table_name || Some(name) == alias,
+    }
+}
+
+/// 키 문자열 바로 다음으로 정렬되는 배타 경계 키를 만듭니다.
+fn exclusive_after(key: &str) -> String {
+    format!("{}\u{0}", key)
+}
+
+/// 단일 조건에서 (컬럼명, 키 경계)를 추출합니다. sargable하지 않으면 None.
+fn extract_sargable_bounds(
+    expression: &SQLExpression,
+    table_name: &TableName,
+    alias: Option<&String>,
+) -> Option<(String, ColumnBounds)> {
+    match expression {
+        SQLExpression::Binary(binary) => {
+            let (column, literal, operator) = match (&binary.lhs, &binary.rhs) {
+                (SQLExpression::SelectColumn(column), rhs) => {
+                    (column, literal_to_field(rhs)?, binary.operator.clone())
+                }
+                (lhs, SQLExpression::SelectColumn(column)) => (
+                    column,
+                    literal_to_field(lhs)?,
+                    flip_operator(&binary.operator)?,
+                ),
+                _ => return None,
+            };
+
+            if !column_matches(column, table_name, alias) {
+                return None;
+            }
+
+            let key = field_to_key(&literal);
+
+            let bounds = match operator {
+                BinaryOperator::Eq => ColumnBounds {
+                    eq_key: Some(key),
+                    ..Default::default()
+                },
+                BinaryOperator::Gt => ColumnBounds {
+                    start_key: Some(exclusive_after(&key)),
+                    ..Default::default()
+                },
+                BinaryOperator::Gte => ColumnBounds {
+                    start_key: Some(key),
+                    ..Default::default()
+                },
+                BinaryOperator::Lt => ColumnBounds {
+                    end_key: Some(key),
+                    ..Default::default()
+                },
+                BinaryOperator::Lte => ColumnBounds {
+                    end_key: Some(exclusive_after(&key)),
+                    ..Default::default()
+                },
+                _ => return None,
+            };
+
+            Some((column.column_name.clone(), bounds))
+        }
+        SQLExpression::Between(between) => {
+            let column = match &between.a {
+                SQLExpression::SelectColumn(column) => column,
+                _ => return None,
+            };
+
+            if !column_matches(column, table_name, alias) {
+                return None;
+            }
+
+            let start = literal_to_field(&between.x)?;
+            let end = literal_to_field(&between.y)?;
+
+            Some((
+                column.column_name.clone(),
+                ColumnBounds {
+                    eq_key: None,
+                    start_key: Some(field_to_key(&start)),
+                    end_key: Some(exclusive_after(&field_to_key(&end))),
+                },
+            ))
+        }
+        _ => None,
+    }
+}
+
+/// 리터럴이 좌변에 있는 조건(5 < id 등)의 연산자를 뒤집습니다.
+fn flip_operator(operator: &BinaryOperator) -> Option<BinaryOperator> {
+    match operator {
+        BinaryOperator::Eq => Some(BinaryOperator::Eq),
+        BinaryOperator::Gt => Some(BinaryOperator::Lt),
+        BinaryOperator::Gte => Some(BinaryOperator::Lte),
+        BinaryOperator::Lt => Some(BinaryOperator::Gt),
+        BinaryOperator::Lte => Some(BinaryOperator::Gte),
+        _ => None,
+    }
+}
+
+/// 같은 컬럼에 대한 여러 조건의 경계를 병합합니다 (start=max, end=min).
+fn merge_bounds(existing: &mut ColumnBounds, new: ColumnBounds) {
+    if existing.eq_key.is_none() {
+        existing.eq_key = new.eq_key;
+    }
+
+    existing.start_key = match (existing.start_key.take(), new.start_key) {
+        (Some(a), Some(b)) => Some(a.max(b)),
+        (a, b) => a.or(b),
+    };
+
+    existing.end_key = match (existing.end_key.take(), new.end_key) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (a, b) => a.or(b),
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::ast::dml::expressions::binary::BinaryOperatorExpression;
+    use crate::engine::parser::predule::{Parser, ParserContext};
+
+    fn table() -> TableName {
+        TableName::new(Some("rrdb".to_string()), "users".to_string())
+    }
+
+    fn index_meta(name: &str, column: &str, unique: bool) -> IndexMeta {
+        IndexMeta::new(
+            format!("rrdb.{}", name),
+            table(),
+            column.to_string(),
+            unique,
+        )
+    }
+
+    fn statistics(row_count: usize) -> TableStatistics {
+        TableStatistics {
+            row_count,
+            block_count: row_count / 100 + 1,
+            distinct_values: HashMap::from([("id".to_string(), row_count)]),
+        }
+    }
+
+    fn context(row_count: usize, unique: bool) -> OptimizerContext {
+        OptimizerContext {
+            indexes: vec![index_meta("users_pkey", "id", unique)],
+            statistics: Some(statistics(row_count)),
+        }
+    }
+
+    fn eq_expression(column: &str, value: i64) -> SQLExpression {
+        BinaryOperatorExpression {
+            operator: BinaryOperator::Eq,
+            lhs: SelectColumn::new(None, column.to_string()).into(),
+            rhs: SQLExpression::Integer(value),
+        }
+        .into()
+    }
+
+    fn integer_key(value: i64) -> String {
+        field_to_key(&TableDataFieldType::Integer(value))
+    }
+
+    #[test]
+    fn choose_scan_picks_index_for_eq_predicate_on_large_table() {
+        let optimizer = Optimizer::with_context(context(10_000, true));
+        let expression = eq_expression("id", 42);
+
+        let scan = optimizer.choose_scan(&table(), None, Some(&expression));
+
+        match scan {
+            ScanType::IndexScan(plan) => {
+                assert_eq!(plan.index_name, "rrdb.users_pkey");
+                assert_eq!(plan.column_name, "id");
+                assert_eq!(plan.eq_key, Some(integer_key(42)));
+                assert_eq!(plan.start_key, None);
+                assert_eq!(plan.end_key, None);
+            }
+            other => panic!("expected IndexScan, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn choose_scan_prefers_full_scan_on_tiny_table() {
+        let optimizer = Optimizer::with_context(context(3, true));
+        let expression = eq_expression("id", 42);
+
+        let scan = optimizer.choose_scan(&table(), None, Some(&expression));
+
+        assert_eq!(scan, ScanType::FullScan);
+    }
+
+    #[test]
+    fn choose_scan_full_scan_without_index_or_statistics() {
+        let expression = eq_expression("id", 42);
+
+        // 인덱스 없음
+        let optimizer = Optimizer::with_context(OptimizerContext {
+            indexes: vec![],
+            statistics: Some(statistics(10_000)),
+        });
+        assert_eq!(
+            optimizer.choose_scan(&table(), None, Some(&expression)),
+            ScanType::FullScan
+        );
+
+        // 통계 없음
+        let optimizer = Optimizer::with_context(OptimizerContext {
+            indexes: vec![index_meta("users_pkey", "id", true)],
+            statistics: None,
+        });
+        assert_eq!(
+            optimizer.choose_scan(&table(), None, Some(&expression)),
+            ScanType::FullScan
+        );
+
+        // WHERE 절 없음
+        let optimizer = Optimizer::with_context(context(10_000, true));
+        assert_eq!(
+            optimizer.choose_scan(&table(), None, None),
+            ScanType::FullScan
+        );
+    }
+
+    #[test]
+    fn choose_scan_full_scan_for_non_indexed_column() {
+        let optimizer = Optimizer::with_context(context(10_000, true));
+        let expression = eq_expression("name", 42);
+
+        assert_eq!(
+            optimizer.choose_scan(&table(), None, Some(&expression)),
+            ScanType::FullScan
+        );
+    }
+
+    #[test]
+    fn choose_scan_merges_range_bounds_from_and_conjuncts() {
+        // id > 10 AND id <= 20 AND name = 'a' (name은 인덱스 없음)
+        let optimizer = Optimizer::with_context(OptimizerContext {
+            indexes: vec![index_meta("users_pkey", "id", true)],
+            statistics: Some(TableStatistics {
+                row_count: 1_000_000,
+                block_count: 10_000,
+                distinct_values: HashMap::new(),
+            }),
+        });
+
+        let expression: SQLExpression = BinaryOperatorExpression {
+            operator: BinaryOperator::And,
+            lhs: BinaryOperatorExpression {
+                operator: BinaryOperator::Gt,
+                lhs: SelectColumn::new(None, "id".to_string()).into(),
+                rhs: SQLExpression::Integer(10),
+            }
+            .into(),
+            rhs: BinaryOperatorExpression {
+                operator: BinaryOperator::Lte,
+                lhs: SelectColumn::new(None, "id".to_string()).into(),
+                rhs: SQLExpression::Integer(20),
+            }
+            .into(),
+        }
+        .into();
+
+        // 범위 스캔 선택도(1/3)로는 풀 스캔이 더 저렴할 수 있으므로 직접 경계만 검증
+        let mut conjuncts = vec![];
+        collect_conjuncts(&expression, &mut conjuncts);
+        assert_eq!(conjuncts.len(), 2);
+
+        let mut bounds = ColumnBounds::default();
+        for conjunct in conjuncts {
+            let (column, new_bounds) =
+                extract_sargable_bounds(conjunct, &table(), None).expect("sargable");
+            assert_eq!(column, "id");
+            merge_bounds(&mut bounds, new_bounds);
+        }
+
+        assert_eq!(bounds.eq_key, None);
+        assert_eq!(bounds.start_key, Some(exclusive_after(&integer_key(10))));
+        assert_eq!(bounds.end_key, Some(exclusive_after(&integer_key(20))));
+    }
+
+    #[test]
+    fn extract_sargable_bounds_handles_flipped_operands() {
+        // 42 = id
+        let expression: SQLExpression = BinaryOperatorExpression {
+            operator: BinaryOperator::Eq,
+            lhs: SQLExpression::Integer(42),
+            rhs: SelectColumn::new(None, "id".to_string()).into(),
+        }
+        .into();
+
+        let (column, bounds) = extract_sargable_bounds(&expression, &table(), None).unwrap();
+        assert_eq!(column, "id");
+        assert_eq!(bounds.eq_key, Some(integer_key(42)));
+
+        // 42 < id → id > 42
+        let expression: SQLExpression = BinaryOperatorExpression {
+            operator: BinaryOperator::Lt,
+            lhs: SQLExpression::Integer(42),
+            rhs: SelectColumn::new(None, "id".to_string()).into(),
+        }
+        .into();
+
+        let (_, bounds) = extract_sargable_bounds(&expression, &table(), None).unwrap();
+        assert_eq!(bounds.start_key, Some(exclusive_after(&integer_key(42))));
+    }
+
+    #[test]
+    fn extract_sargable_bounds_rejects_other_table_column() {
+        let expression: SQLExpression = BinaryOperatorExpression {
+            operator: BinaryOperator::Eq,
+            lhs: SelectColumn::new(Some("other_table".to_string()), "id".to_string()).into(),
+            rhs: SQLExpression::Integer(42),
+        }
+        .into();
+
+        assert!(extract_sargable_bounds(&expression, &table(), None).is_none());
+
+        // 별칭은 허용
+        let expression: SQLExpression = BinaryOperatorExpression {
+            operator: BinaryOperator::Eq,
+            lhs: SelectColumn::new(Some("u".to_string()), "id".to_string()).into(),
+            rhs: SQLExpression::Integer(42),
+        }
+        .into();
+
+        let alias = "u".to_string();
+        assert!(extract_sargable_bounds(&expression, &table(), Some(&alias)).is_some());
+    }
+
+    #[test]
+    fn literal_to_field_handles_negative_numbers() {
+        let mut parser = Parser::with_string("select 1 from t where id = -5;".into()).unwrap();
+        let statements = parser
+            .parse(ParserContext::default().set_default_database("rrdb".to_string()))
+            .unwrap();
+
+        // 파서가 음수를 어떤 형태로 만들든 literal_to_field가 처리해야 함
+        if let crate::engine::ast::SQLStatement::DML(
+            crate::engine::ast::DMLStatement::SelectQuery(query),
+        ) = &statements[0]
+        {
+            let expression = &query.where_clause.as_ref().unwrap().expression;
+            let mut conjuncts = vec![];
+            collect_conjuncts(expression, &mut conjuncts);
+            let (_, bounds) =
+                extract_sargable_bounds(conjuncts[0], &table(), None).expect("sargable");
+            assert_eq!(
+                bounds.eq_key,
+                Some(field_to_key(&TableDataFieldType::Integer(-5)))
+            );
+        } else {
+            panic!("expected select query");
+        }
+    }
+
+    #[tokio::test]
+    async fn optimize_select_emits_index_scan_with_residual_filter() {
+        let mut parser =
+            Parser::with_string("select * from users where id = 42 and name = 'x';".into())
+                .unwrap();
+        let statements = parser
+            .parse(ParserContext::default().set_default_database("rrdb".to_string()))
+            .unwrap();
+
+        let query = match statements.into_iter().next().unwrap() {
+            crate::engine::ast::SQLStatement::DML(
+                crate::engine::ast::DMLStatement::SelectQuery(query),
+            ) => query,
+            other => panic!("expected select query, got {:?}", other),
+        };
+
+        let optimizer = Optimizer::with_context(context(10_000, true));
+        let plan = optimizer.optimize_select(query).await.unwrap();
+
+        // From(IndexScan) + Filter 두 항목이 있어야 함
+        assert_eq!(plan.list.len(), 2);
+
+        match &plan.list[0] {
+            SelectPlanItem::From(from) => match &from.scan {
+                ScanType::IndexScan(index_scan) => {
+                    assert_eq!(index_scan.eq_key, Some(integer_key(42)));
+                }
+                other => panic!("expected IndexScan, got {:?}", other),
+            },
+            other => panic!("expected From plan, got {:?}", other),
+        }
+
+        assert!(matches!(plan.list[1], SelectPlanItem::Filter(_)));
+    }
+
+    #[tokio::test]
+    async fn optimize_select_keeps_full_scan_for_join_queries() {
+        let mut parser = Parser::with_string(
+            "select * from users u inner join orders o on u.id = o.user_id where u.id = 42;".into(),
+        )
+        .unwrap();
+        let statements = parser
+            .parse(ParserContext::default().set_default_database("rrdb".to_string()))
+            .unwrap();
+
+        let query = match statements.into_iter().next().unwrap() {
+            crate::engine::ast::SQLStatement::DML(
+                crate::engine::ast::DMLStatement::SelectQuery(query),
+            ) => query,
+            other => panic!("expected select query, got {:?}", other),
+        };
+
+        let optimizer = Optimizer::with_context(context(10_000, true));
+        let plan = optimizer.optimize_select(query).await.unwrap();
+
+        match &plan.list[0] {
+            SelectPlanItem::From(from) => assert_eq!(from.scan, ScanType::FullScan),
+            other => panic!("expected From plan, got {:?}", other),
+        }
     }
 }

--- a/src/engine/optimizer/predule.rs
+++ b/src/engine/optimizer/predule.rs
@@ -1,1 +1,2 @@
 pub use super::optimizer::*;
+pub use super::statistics::*;

--- a/src/engine/optimizer/statistics.rs
+++ b/src/engine/optimizer/statistics.rs
@@ -1,0 +1,136 @@
+use std::collections::HashMap;
+
+use tokio::sync::RwLock;
+
+use crate::engine::ast::types::TableName;
+
+/// 테이블 단위 통계 정보 (#195)
+///
+/// 비용 기반 옵티마이저가 스캔 방식을 선택할 때 사용합니다.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TableStatistics {
+    /// 테이블의 행 개수
+    pub row_count: usize,
+    /// 행 세그먼트 파일 크기 기반 블록 개수 추정치
+    pub block_count: usize,
+    /// 컬럼별 고유값 개수 추정치 (인덱스가 있는 컬럼만 채워짐)
+    pub distinct_values: HashMap<String, usize>,
+}
+
+/// 테이블 통계 캐시 관리자.
+///
+/// - 최초 접근 시 실제 스캔 결과로 채워짐 (DBEngine::table_statistics)
+/// - INSERT/DELETE 시 행 개수를 증분 갱신
+/// - DDL 변경 시 invalidate
+pub struct StatisticsManager {
+    statistics: RwLock<HashMap<TableName, TableStatistics>>,
+}
+
+impl StatisticsManager {
+    pub fn new() -> Self {
+        Self {
+            statistics: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub async fn get(&self, table: &TableName) -> Option<TableStatistics> {
+        self.statistics.read().await.get(table).cloned()
+    }
+
+    pub async fn set(&self, table: TableName, statistics: TableStatistics) {
+        self.statistics.write().await.insert(table, statistics);
+    }
+
+    /// INSERT 반영: 캐시된 통계가 있으면 행 개수를 증가시킵니다.
+    pub async fn record_insert(&self, table: &TableName, count: usize) {
+        if let Some(statistics) = self.statistics.write().await.get_mut(table) {
+            statistics.row_count += count;
+        }
+    }
+
+    /// DELETE 반영: 캐시된 통계가 있으면 행 개수를 감소시킵니다.
+    pub async fn record_delete(&self, table: &TableName, count: usize) {
+        if let Some(statistics) = self.statistics.write().await.get_mut(table) {
+            statistics.row_count = statistics.row_count.saturating_sub(count);
+        }
+    }
+
+    pub async fn invalidate(&self, table: &TableName) {
+        self.statistics.write().await.remove(table);
+    }
+
+    /// 데이터베이스 단위 통계 무효화 (DROP DATABASE 등)
+    pub async fn invalidate_database(&self, database_name: &str) {
+        self.statistics
+            .write()
+            .await
+            .retain(|table, _| table.database_name.as_deref() != Some(database_name));
+    }
+}
+
+impl Default for StatisticsManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn table() -> TableName {
+        TableName::new(Some("rrdb".to_string()), "users".to_string())
+    }
+
+    #[tokio::test]
+    async fn record_insert_and_delete_adjust_row_count() {
+        let manager = StatisticsManager::new();
+
+        // 캐시가 없으면 no-op
+        manager.record_insert(&table(), 10).await;
+        assert_eq!(manager.get(&table()).await, None);
+
+        manager
+            .set(
+                table(),
+                TableStatistics {
+                    row_count: 100,
+                    block_count: 1,
+                    distinct_values: HashMap::new(),
+                },
+            )
+            .await;
+
+        manager.record_insert(&table(), 10).await;
+        assert_eq!(manager.get(&table()).await.unwrap().row_count, 110);
+
+        manager.record_delete(&table(), 20).await;
+        assert_eq!(manager.get(&table()).await.unwrap().row_count, 90);
+
+        // saturating_sub 확인
+        manager.record_delete(&table(), 1000).await;
+        assert_eq!(manager.get(&table()).await.unwrap().row_count, 0);
+    }
+
+    #[tokio::test]
+    async fn invalidate_removes_statistics() {
+        let manager = StatisticsManager::new();
+        manager.set(table(), TableStatistics::default()).await;
+
+        manager.invalidate(&table()).await;
+        assert_eq!(manager.get(&table()).await, None);
+    }
+
+    #[tokio::test]
+    async fn invalidate_database_removes_only_matching_tables() {
+        let manager = StatisticsManager::new();
+        let other = TableName::new(Some("other".to_string()), "users".to_string());
+
+        manager.set(table(), TableStatistics::default()).await;
+        manager.set(other.clone(), TableStatistics::default()).await;
+
+        manager.invalidate_database("rrdb").await;
+        assert_eq!(manager.get(&table()).await, None);
+        assert!(manager.get(&other).await.is_some());
+    }
+}

--- a/src/engine/optimizer/statistics.rs
+++ b/src/engine/optimizer/statistics.rs
@@ -66,8 +66,7 @@ impl StatisticsManager {
             // 블록 개수를 비례적으로 감소 (소량 삭제는 block_count에 영향 없음)
             if old_row_count > 0 {
                 let avg_rows_per_block = old_row_count / statistics.block_count.max(1);
-                if avg_rows_per_block > 0 {
-                    let removed_blocks = count / avg_rows_per_block;
+                if let Some(removed_blocks) = count.checked_div(avg_rows_per_block) {
                     statistics.block_count = statistics.block_count.saturating_sub(removed_blocks);
                 }
             }

--- a/src/engine/optimizer/statistics.rs
+++ b/src/engine/optimizer/statistics.rs
@@ -63,13 +63,12 @@ impl StatisticsManager {
             let old_row_count = statistics.row_count;
             statistics.row_count = statistics.row_count.saturating_sub(count);
 
-            // 블록 개수를 비례적으로 감소
+            // 블록 개수를 비례적으로 감소 (소량 삭제는 block_count에 영향 없음)
             if old_row_count > 0 {
                 let avg_rows_per_block = old_row_count / statistics.block_count.max(1);
                 if avg_rows_per_block > 0 {
                     let removed_blocks = count / avg_rows_per_block;
-                    statistics.block_count =
-                        statistics.block_count.saturating_sub(removed_blocks.max(1));
+                    statistics.block_count = statistics.block_count.saturating_sub(removed_blocks);
                 }
             }
         }
@@ -152,5 +151,40 @@ mod tests {
         manager.invalidate_database("rrdb").await;
         assert_eq!(manager.get(&table()).await, None);
         assert!(manager.get(&other).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn record_delete_block_count_is_not_over_decremented_for_small_deletes() {
+        let manager = StatisticsManager::new();
+
+        // 100 rows, 10 blocks → 10 rows/block
+        manager
+            .set(
+                table(),
+                TableStatistics {
+                    row_count: 100,
+                    block_count: 10,
+                    distinct_values: HashMap::new(),
+                },
+            )
+            .await;
+
+        // 3 rows 삭제: 1 block 미만이므로 block_count는 변하지 않아야 함
+        manager.record_delete(&table(), 3).await;
+        let stats = manager.get(&table()).await.unwrap();
+        assert_eq!(stats.row_count, 97);
+        assert_eq!(
+            stats.block_count, 10,
+            "small delete should not reduce block_count"
+        );
+
+        // 10 rows 추가 삭제: 정확히 1 block 분량
+        manager.record_delete(&table(), 10).await;
+        let stats = manager.get(&table()).await.unwrap();
+        assert_eq!(stats.row_count, 87);
+        assert_eq!(
+            stats.block_count, 9,
+            "10 rows = 1 block should reduce block_count by 1"
+        );
     }
 }

--- a/src/engine/optimizer/statistics.rs
+++ b/src/engine/optimizer/statistics.rs
@@ -41,17 +41,37 @@ impl StatisticsManager {
         self.statistics.write().await.insert(table, statistics);
     }
 
-    /// INSERT 반영: 캐시된 통계가 있으면 행 개수를 증가시킵니다.
+    /// INSERT 반영: 캐시된 통계가 있으면 행 개수와 블록 개수를 증분 갱신합니다.
     pub async fn record_insert(&self, table: &TableName, count: usize) {
         if let Some(statistics) = self.statistics.write().await.get_mut(table) {
+            let old_row_count = statistics.row_count;
             statistics.row_count += count;
+
+            // 블록 개수를 비례적으로 갱신 (행 당 평균 블록 수)
+            if old_row_count > 0 {
+                let avg_rows_per_block = old_row_count / statistics.block_count.max(1);
+                if avg_rows_per_block > 0 {
+                    statistics.block_count += count.div_ceil(avg_rows_per_block);
+                }
+            }
         }
     }
 
-    /// DELETE 반영: 캐시된 통계가 있으면 행 개수를 감소시킵니다.
+    /// DELETE 반영: 캐시된 통계가 있으면 행 개수와 블록 개수를 증분 갱신합니다.
     pub async fn record_delete(&self, table: &TableName, count: usize) {
         if let Some(statistics) = self.statistics.write().await.get_mut(table) {
+            let old_row_count = statistics.row_count;
             statistics.row_count = statistics.row_count.saturating_sub(count);
+
+            // 블록 개수를 비례적으로 감소
+            if old_row_count > 0 {
+                let avg_rows_per_block = old_row_count / statistics.block_count.max(1);
+                if avg_rows_per_block > 0 {
+                    let removed_blocks = count / avg_rows_per_block;
+                    statistics.block_count =
+                        statistics.block_count.saturating_sub(removed_blocks.max(1));
+                }
+            }
         }
     }
 

--- a/src/engine/parser/implements/ddl/index.rs
+++ b/src/engine/parser/implements/ddl/index.rs
@@ -1,0 +1,186 @@
+use crate::engine::ast::SQLStatement;
+use crate::engine::ast::ddl::create_index::CreateIndexQuery;
+use crate::engine::ast::ddl::drop_index::DropIndexQuery;
+use crate::engine::lexer::predule::Token;
+use crate::engine::parser::context::ParserContext;
+use crate::engine::parser::predule::Parser;
+use crate::errors;
+use crate::errors::parsing_error::ParsingError;
+
+impl Parser {
+    // CREATE [UNIQUE] INDEX 쿼리 분석
+    // 진입 시점에는 INDEX 토큰까지 소비된 상태입니다.
+    pub(crate) fn handle_create_index_query(
+        &mut self,
+        context: ParserContext,
+        is_unique: bool,
+    ) -> errors::Result<SQLStatement> {
+        if !self.has_next_token() {
+            return Err(ParsingError::wrap("need more tokens".to_string()));
+        }
+
+        let mut query_builder = CreateIndexQuery::builder().set_unique(is_unique);
+
+        // IF NOT EXISTS 파싱
+        let if_not_exists = self.has_if_not_exists()?;
+        query_builder = query_builder.set_if_not_exists(if_not_exists);
+
+        // 인덱스명 파싱
+        if !self.has_next_token() {
+            return Err(ParsingError::wrap("need more tokens".to_string()));
+        }
+
+        let current_token = self.get_next_token();
+
+        let index_name = if let Token::Identifier(name) = current_token {
+            name
+        } else {
+            return Err(ParsingError::wrap(format!(
+                "expected index name. but your input word is '{:?}'",
+                current_token
+            )));
+        };
+
+        query_builder = query_builder.set_index_name(index_name);
+
+        // ON 토큰 체크
+        if !self.has_next_token() {
+            return Err(ParsingError::wrap("need more tokens".to_string()));
+        }
+
+        let current_token = self.get_next_token();
+
+        if Token::On != current_token {
+            return Err(ParsingError::wrap(format!(
+                "expected 'ON'. but your input word is '{:?}'",
+                current_token
+            )));
+        }
+
+        // 테이블명 파싱
+        let table = self.parse_table_name(context)?;
+        query_builder = query_builder.set_table(table);
+
+        // 여는 괄호 체크
+        if !self.has_next_token() {
+            return Err(ParsingError::wrap("need more tokens".to_string()));
+        }
+
+        let current_token = self.get_next_token();
+
+        if Token::LeftParentheses != current_token {
+            return Err(ParsingError::wrap(format!(
+                "expected '('. but your input word is '{:?}'",
+                current_token
+            )));
+        }
+
+        // 닫는 괄호 나올때까지 컬럼명 파싱 반복
+        loop {
+            if !self.has_next_token() {
+                return Err(ParsingError::wrap("need more tokens".to_string()));
+            }
+
+            let current_token = self.get_next_token();
+
+            match current_token {
+                Token::RightParentheses => break,
+                Token::Comma => continue,
+                Token::Identifier(column_name) => {
+                    query_builder = query_builder.add_column(column_name);
+                }
+                _ => {
+                    return Err(ParsingError::wrap(format!(
+                        "expected column name. but your input word is '{:?}'",
+                        current_token
+                    )));
+                }
+            }
+        }
+
+        if !self.has_next_token() {
+            return Ok(query_builder.build());
+        }
+
+        let current_token = self.get_next_token();
+
+        if Token::SemiColon != current_token {
+            return Err(ParsingError::wrap(format!(
+                "expected ';'. but your input word is '{:?}'",
+                current_token
+            )));
+        }
+
+        Ok(query_builder.build())
+    }
+
+    // DROP INDEX 쿼리 분석
+    // 진입 시점에는 INDEX 토큰까지 소비된 상태입니다.
+    pub(crate) fn handle_drop_index_query(
+        &mut self,
+        context: ParserContext,
+    ) -> errors::Result<SQLStatement> {
+        if !self.has_next_token() {
+            return Err(ParsingError::wrap("need more tokens".to_string()));
+        }
+
+        let mut query_builder =
+            DropIndexQuery::builder().set_database_name(context.default_database.clone());
+
+        // IF EXISTS 파싱
+        let if_exists = self.has_if_exists()?;
+        query_builder = query_builder.set_if_exists(if_exists);
+
+        // 인덱스명 파싱
+        if !self.has_next_token() {
+            return Err(ParsingError::wrap("need more tokens".to_string()));
+        }
+
+        let current_token = self.get_next_token();
+
+        let index_name = if let Token::Identifier(name) = current_token {
+            name
+        } else {
+            return Err(ParsingError::wrap(format!(
+                "expected index name. but your input word is '{:?}'",
+                current_token
+            )));
+        };
+
+        query_builder = query_builder.set_index_name(index_name);
+
+        if !self.has_next_token() {
+            return Ok(query_builder.build());
+        }
+
+        let current_token = self.get_next_token();
+
+        match current_token {
+            // 선택적 ON [database_name.]table_name 절
+            Token::On => {
+                let table = self.parse_table_name(context)?;
+                query_builder = query_builder.set_table(table);
+
+                if !self.has_next_token() {
+                    return Ok(query_builder.build());
+                }
+
+                let current_token = self.get_next_token();
+
+                if Token::SemiColon != current_token {
+                    return Err(ParsingError::wrap(format!(
+                        "expected ';'. but your input word is '{:?}'",
+                        current_token
+                    )));
+                }
+
+                Ok(query_builder.build())
+            }
+            Token::SemiColon => Ok(query_builder.build()),
+            _ => Err(ParsingError::wrap(format!(
+                "expected ';' or 'ON'. but your input word is '{:?}'",
+                current_token
+            ))),
+        }
+    }
+}

--- a/src/engine/parser/implements/ddl/index.rs
+++ b/src/engine/parser/implements/ddl/index.rs
@@ -98,6 +98,13 @@ impl Parser {
             }
         }
 
+        if query_builder.columns.is_empty() {
+            return Err(ParsingError::wrap(
+                "expected at least one column name in 'CREATE INDEX ... ON table (...)'"
+                    .to_string(),
+            ));
+        }
+
         if !self.has_next_token() {
             return Ok(query_builder.build());
         }

--- a/src/engine/parser/implements/ddl/mod.rs
+++ b/src/engine/parser/implements/ddl/mod.rs
@@ -1,3 +1,4 @@
 pub mod database;
+pub mod index;
 pub mod table;
 pub mod top_level;

--- a/src/engine/parser/implements/ddl/top_level.rs
+++ b/src/engine/parser/implements/ddl/top_level.rs
@@ -20,8 +20,24 @@ impl Parser {
         match current_token {
             Token::Table => self.handle_create_table_query(context),
             Token::Database => self.handle_create_database_query(),
+            Token::Index => self.handle_create_index_query(context, false),
+            Token::Unique => {
+                if !self.has_next_token() {
+                    return Err(ParsingError::wrap("need more tokens".to_string()));
+                }
+
+                let current_token = self.get_next_token();
+
+                match current_token {
+                    Token::Index => self.handle_create_index_query(context, true),
+                    _ => Err(ParsingError::wrap(format!(
+                        "expected 'INDEX'. but your input word is '{:?}'",
+                        current_token
+                    ))),
+                }
+            }
             _ => Err(ParsingError::wrap(format!(
-                "not supported command. possible commands: (create table, create database). but your input is {:?}",
+                "not supported command. possible commands: (create table, create database, create index). but your input is {:?}",
                 current_token
             ))),
         }
@@ -60,8 +76,9 @@ impl Parser {
         match current_token {
             Token::Table => self.handle_drop_table_query(context),
             Token::Database => self.handle_drop_database_query(),
+            Token::Index => self.handle_drop_index_query(context),
             _ => Err(ParsingError::wrap(
-                "not supported command. possible commands: (drop table, drop database)",
+                "not supported command. possible commands: (drop table, drop database, drop index)",
             )),
         }
     }

--- a/src/engine/parser/test/coverage.rs
+++ b/src/engine/parser/test/coverage.rs
@@ -89,14 +89,18 @@ fn database_and_table_parsers_cover_optional_variants() {
         Token::RightParentheses,
         Token::SemiColon,
     ]);
-    assert!(create_table
-        .handle_create_table_query(ParserContext::default())
-        .is_ok());
+    assert!(
+        create_table
+            .handle_create_table_query(ParserContext::default())
+            .is_ok()
+    );
 
     let mut alter_table = Parser::new(vec![Token::Identifier("foo".into()), Token::SemiColon]);
-    assert!(alter_table
-        .handle_alter_table_query(ParserContext::default())
-        .is_ok());
+    assert!(
+        alter_table
+            .handle_alter_table_query(ParserContext::default())
+            .is_ok()
+    );
 
     let mut add_without_column_keyword = Parser::new(vec![
         Token::Identifier("foo".into()),
@@ -104,9 +108,11 @@ fn database_and_table_parsers_cover_optional_variants() {
         Token::Identifier("bar".into()),
         Token::Identifier("INT".into()),
     ]);
-    assert!(add_without_column_keyword
-        .handle_alter_table_query(ParserContext::default())
-        .is_ok());
+    assert!(
+        add_without_column_keyword
+            .handle_alter_table_query(ParserContext::default())
+            .is_ok()
+    );
 
     let mut alter_type_keyword = Parser::new(vec![
         Token::Identifier("foo".into()),
@@ -115,9 +121,11 @@ fn database_and_table_parsers_cover_optional_variants() {
         Token::Type,
         Token::Identifier("BOOL".into()),
     ]);
-    assert!(alter_type_keyword
-        .handle_alter_table_query(ParserContext::default())
-        .is_ok());
+    assert!(
+        alter_type_keyword
+            .handle_alter_table_query(ParserContext::default())
+            .is_ok()
+    );
 
     let mut drop_table = Parser::new(vec![
         Token::If,
@@ -125,9 +133,11 @@ fn database_and_table_parsers_cover_optional_variants() {
         Token::Identifier("foo".into()),
         Token::SemiColon,
     ]);
-    assert!(drop_table
-        .handle_drop_table_query(ParserContext::default())
-        .is_ok());
+    assert!(
+        drop_table
+            .handle_drop_table_query(ParserContext::default())
+            .is_ok()
+    );
 }
 
 #[test]
@@ -158,8 +168,7 @@ fn dml_parsers_cover_alias_where_and_insert_select_paths() {
 
 #[test]
 fn select_parser_covers_subquery_alias_join_having_and_limit_offset_orders() {
-    let mut subquery =
-        Parser::with_string("SELECT * FROM (SELECT 1) s;".to_owned()).unwrap();
+    let mut subquery = Parser::with_string("SELECT * FROM (SELECT 1) s;".to_owned()).unwrap();
     assert!(subquery.parse(ParserContext::default()).is_ok());
 
     let mut join_query = Parser::with_string(
@@ -192,9 +201,11 @@ fn select_helpers_cover_right_parenthesis_exit_paths() {
         Token::Identifier("a".into()),
         Token::RightParentheses,
     ]);
-    assert!(group_by_parser
-        .handle_select_query(ParserContext::default())
-        .is_ok());
+    assert!(
+        group_by_parser
+            .handle_select_query(ParserContext::default())
+            .is_ok()
+    );
     assert_eq!(group_by_parser.get_next_token(), Token::RightParentheses);
 
     let mut order_by_parser = Parser::new(vec![
@@ -207,9 +218,11 @@ fn select_helpers_cover_right_parenthesis_exit_paths() {
         Token::Identifier("a".into()),
         Token::RightParentheses,
     ]);
-    assert!(order_by_parser
-        .handle_select_query(ParserContext::default())
-        .is_ok());
+    assert!(
+        order_by_parser
+            .handle_select_query(ParserContext::default())
+            .is_ok()
+    );
     assert_eq!(order_by_parser.get_next_token(), Token::RightParentheses);
 }
 
@@ -233,11 +246,18 @@ fn expression_parser_covers_literal_binary_between_subquery_and_function_paths()
 
     for sql in cases {
         let mut parser = Parser::with_string(sql.to_owned()).unwrap();
-        assert!(parser.parse_expression(ParserContext::default()).is_ok(), "{sql}");
+        assert!(
+            parser.parse_expression(ParserContext::default()).is_ok(),
+            "{sql}"
+        );
     }
 
     let mut right_paren = Parser::new(vec![Token::RightParentheses]);
-    assert!(right_paren.parse_expression(ParserContext::default()).is_err());
+    assert!(
+        right_paren
+            .parse_expression(ParserContext::default())
+            .is_err()
+    );
 }
 
 #[test]
@@ -256,19 +276,25 @@ fn select_and_join_helpers_are_callable_directly() {
     assert!(join.right_alias.is_some());
     assert!(join.on.is_some());
 
-    let mut where_parser =
-        Parser::with_string("WHERE 1 = 1".to_owned()).unwrap();
+    let mut where_parser = Parser::with_string("WHERE 1 = 1".to_owned()).unwrap();
     assert!(where_parser.parse_where(ParserContext::default()).is_ok());
 
-    let mut having_parser =
-        Parser::with_string("HAVING 1 = 1".to_owned()).unwrap();
+    let mut having_parser = Parser::with_string("HAVING 1 = 1".to_owned()).unwrap();
     assert!(having_parser.parse_having(ParserContext::default()).is_ok());
 
     let mut limit_parser = Parser::with_string("LIMIT 3".to_owned()).unwrap();
-    assert_eq!(limit_parser.parse_limit(ParserContext::default()).unwrap(), 3);
+    assert_eq!(
+        limit_parser.parse_limit(ParserContext::default()).unwrap(),
+        3
+    );
 
     let mut offset_parser = Parser::with_string("OFFSET 2".to_owned()).unwrap();
-    assert_eq!(offset_parser.parse_offset(ParserContext::default()).unwrap(), 2);
+    assert_eq!(
+        offset_parser
+            .parse_offset(ParserContext::default())
+            .unwrap(),
+        2
+    );
 }
 
 #[test]
@@ -291,9 +317,11 @@ fn insert_parser_covers_multiple_value_tuples_and_default() {
         Token::Default,
         Token::RightParentheses,
     ]);
-    assert!(default_values
-        .handle_insert_query(ParserContext::default())
-        .is_ok());
+    assert!(
+        default_values
+            .handle_insert_query(ParserContext::default())
+            .is_ok()
+    );
 
     let mut expression_values = Parser::new(vec![
         Token::Insert,
@@ -309,9 +337,11 @@ fn insert_parser_covers_multiple_value_tuples_and_default() {
         Token::Integer(2),
         Token::RightParentheses,
     ]);
-    assert!(expression_values
-        .handle_insert_query(ParserContext::default())
-        .is_ok());
+    assert!(
+        expression_values
+            .handle_insert_query(ParserContext::default())
+            .is_ok()
+    );
 
     let mut comma_values = Parser::new(vec![
         Token::Values,
@@ -321,9 +351,11 @@ fn insert_parser_covers_multiple_value_tuples_and_default() {
         Token::Integer(2),
         Token::RightParentheses,
     ]);
-    assert!(comma_values
-        .parse_insert_values(ParserContext::default())
-        .is_ok());
+    assert!(
+        comma_values
+            .parse_insert_values(ParserContext::default())
+            .is_ok()
+    );
 }
 
 #[test]
@@ -332,15 +364,19 @@ fn common_helpers_cover_parse_table_name_error_paths() {
     assert!(no_token.parse_table_name(ParserContext::default()).is_err());
 
     let mut not_identifier = Parser::new(vec![Token::SemiColon]);
-    assert!(not_identifier.parse_table_name(ParserContext::default()).is_err());
+    assert!(
+        not_identifier
+            .parse_table_name(ParserContext::default())
+            .is_err()
+    );
 
-    let mut run_out_after_period = Parser::new(vec![
-        Token::Identifier("foo".into()),
-        Token::Period,
-    ]);
-    assert!(run_out_after_period
-        .parse_table_name(ParserContext::default())
-        .is_err());
+    let mut run_out_after_period =
+        Parser::new(vec![Token::Identifier("foo".into()), Token::Period]);
+    assert!(
+        run_out_after_period
+            .parse_table_name(ParserContext::default())
+            .is_err()
+    );
 
     let mut join_outer_no_next = Parser::new(vec![Token::Left]);
     assert_eq!(join_outer_no_next.get_next_join_type(), None);
@@ -373,9 +409,7 @@ fn expression_parser_propagates_error_from_an_unterminated_function_call() {
         Token::LeftParentheses,
     ]);
 
-    assert!(parser
-        .parse_expression(ParserContext::default())
-        .is_err());
+    assert!(parser.parse_expression(ParserContext::default()).is_err());
 }
 
 #[test]
@@ -387,7 +421,9 @@ fn insert_values_parser_skips_non_expression_tokens_inside_a_tuple() {
         Token::RightParentheses,
     ]);
 
-    let values = parser.parse_insert_values(ParserContext::default()).unwrap();
+    let values = parser
+        .parse_insert_values(ParserContext::default())
+        .unwrap();
     assert!(values[0].list.is_empty());
 }
 
@@ -415,7 +451,9 @@ fn select_parser_covers_select_item_error_paths_and_more_variants() {
 
     let mut semi_after_select =
         Parser::new(vec![Token::Select, Token::Integer(1), Token::SemiColon]);
-    assert!(semi_after_select
-        .handle_select_query(ParserContext::default())
-        .is_ok());
+    assert!(
+        semi_after_select
+            .handle_select_query(ParserContext::default())
+            .is_ok()
+    );
 }

--- a/src/engine/parser/test/expressions.rs
+++ b/src/engine/parser/test/expressions.rs
@@ -18,6 +18,7 @@ use crate::engine::lexer::tokens::Token;
 use crate::engine::parser::predule::Parser;
 
 #[test]
+#[allow(clippy::approx_constant)]
 fn test_parse_expression() {
     struct TestCase {
         name: String,

--- a/src/engine/parser/test/index.rs
+++ b/src/engine/parser/test/index.rs
@@ -1,0 +1,218 @@
+#![cfg(test)]
+
+use crate::engine::ast::ddl::create_index::CreateIndexQuery;
+use crate::engine::ast::ddl::drop_index::DropIndexQuery;
+use crate::engine::ast::types::TableName;
+use crate::engine::parser::context::ParserContext;
+use crate::engine::parser::predule::Parser;
+
+#[test]
+pub fn create_index() {
+    let text = r#"
+        create index foo_id_idx on "foo_db".foo (id);
+    "#
+    .to_owned();
+
+    let mut parser = Parser::with_string(text).unwrap();
+
+    let expected = CreateIndexQuery::builder()
+        .set_index_name("foo_id_idx".to_owned())
+        .set_table(TableName::new(Some("foo_db".to_owned()), "foo".to_owned()))
+        .add_column("id".to_owned())
+        .build();
+
+    assert_eq!(
+        parser.parse(ParserContext::default()).unwrap(),
+        vec![expected],
+    );
+}
+
+#[test]
+pub fn create_unique_index_if_not_exists() {
+    let text = r#"
+        create unique index if not exists foo_id_idx on foo (id, name);
+    "#
+    .to_owned();
+
+    let mut parser = Parser::with_string(text).unwrap();
+
+    let expected = CreateIndexQuery::builder()
+        .set_index_name("foo_id_idx".to_owned())
+        .set_table(TableName::new(Some("rrdb".to_owned()), "foo".to_owned()))
+        .add_column("id".to_owned())
+        .add_column("name".to_owned())
+        .set_unique(true)
+        .set_if_not_exists(true)
+        .build();
+
+    assert_eq!(
+        parser
+            .parse(ParserContext::default().set_default_database("rrdb".to_owned()))
+            .unwrap(),
+        vec![expected],
+    );
+}
+
+#[test]
+pub fn create_index_without_semicolon() {
+    // 입력 끝의 공백: 토크나이저가 EOF 직전의 ')'를 소실하는 기존 동작 우회
+    let text = "create index foo_id_idx on foo (id) ".to_owned();
+
+    let mut parser = Parser::with_string(text).unwrap();
+
+    let expected = CreateIndexQuery::builder()
+        .set_index_name("foo_id_idx".to_owned())
+        .set_table(TableName::new(None, "foo".to_owned()))
+        .add_column("id".to_owned())
+        .build();
+
+    assert_eq!(
+        parser.parse(ParserContext::default()).unwrap(),
+        vec![expected],
+    );
+}
+
+#[test]
+pub fn create_index_errors() {
+    // UNIQUE 뒤에 INDEX가 아닌 토큰
+    assert!(
+        Parser::with_string("create unique table foo;".to_owned())
+            .unwrap()
+            .parse(ParserContext::default())
+            .is_err()
+    );
+
+    // 인덱스명 누락
+    assert!(
+        Parser::with_string("create index on foo (id);".to_owned())
+            .unwrap()
+            .parse(ParserContext::default())
+            .is_err()
+    );
+
+    // ON 누락
+    assert!(
+        Parser::with_string("create index foo_idx foo (id);".to_owned())
+            .unwrap()
+            .parse(ParserContext::default())
+            .is_err()
+    );
+
+    // 여는 괄호 누락
+    assert!(
+        Parser::with_string("create index foo_idx on foo id;".to_owned())
+            .unwrap()
+            .parse(ParserContext::default())
+            .is_err()
+    );
+
+    // 컬럼 자리에 잘못된 토큰
+    assert!(
+        Parser::with_string("create index foo_idx on foo (1);".to_owned())
+            .unwrap()
+            .parse(ParserContext::default())
+            .is_err()
+    );
+
+    // 닫는 괄호 누락
+    assert!(
+        Parser::with_string("create index foo_idx on foo (id".to_owned())
+            .unwrap()
+            .parse(ParserContext::default())
+            .is_err()
+    );
+
+    // 세미콜론 자리에 잘못된 토큰
+    assert!(
+        Parser::with_string("create index foo_idx on foo (id) foo".to_owned())
+            .unwrap()
+            .parse(ParserContext::default())
+            .is_err()
+    );
+}
+
+#[test]
+pub fn drop_index() {
+    let text = r#"
+        drop index foo_id_idx;
+    "#
+    .to_owned();
+
+    let mut parser = Parser::with_string(text).unwrap();
+
+    let expected = DropIndexQuery::builder()
+        .set_database_name(Some("rrdb".to_owned()))
+        .set_index_name("foo_id_idx".to_owned())
+        .build();
+
+    assert_eq!(
+        parser
+            .parse(ParserContext::default().set_default_database("rrdb".to_owned()))
+            .unwrap(),
+        vec![expected],
+    );
+}
+
+#[test]
+pub fn drop_index_if_exists_with_on_clause() {
+    let text = r#"
+        drop index if exists foo_id_idx on "foo_db".foo;
+    "#
+    .to_owned();
+
+    let mut parser = Parser::with_string(text).unwrap();
+
+    let expected = DropIndexQuery::builder()
+        .set_index_name("foo_id_idx".to_owned())
+        .set_table(TableName::new(Some("foo_db".to_owned()), "foo".to_owned()))
+        .set_if_exists(true)
+        .build();
+
+    assert_eq!(
+        parser.parse(ParserContext::default()).unwrap(),
+        vec![expected],
+    );
+}
+
+#[test]
+pub fn drop_index_without_semicolon() {
+    let text = "drop index foo_id_idx".to_owned();
+
+    let mut parser = Parser::with_string(text).unwrap();
+
+    let expected = DropIndexQuery::builder()
+        .set_index_name("foo_id_idx".to_owned())
+        .build();
+
+    assert_eq!(
+        parser.parse(ParserContext::default()).unwrap(),
+        vec![expected],
+    );
+}
+
+#[test]
+pub fn drop_index_errors() {
+    // 인덱스명 누락
+    assert!(
+        Parser::with_string("drop index;".to_owned())
+            .unwrap()
+            .parse(ParserContext::default())
+            .is_err()
+    );
+
+    // 인덱스명 뒤에 잘못된 토큰
+    assert!(
+        Parser::with_string("drop index foo_idx foo;".to_owned())
+            .unwrap()
+            .parse(ParserContext::default())
+            .is_err()
+    );
+
+    // ON 뒤 테이블명 다음에 잘못된 토큰
+    assert!(
+        Parser::with_string("drop index foo_idx on foo foo".to_owned())
+            .unwrap()
+            .parse(ParserContext::default())
+            .is_err()
+    );
+}

--- a/src/engine/parser/test/index.rs
+++ b/src/engine/parser/test/index.rs
@@ -129,6 +129,14 @@ pub fn create_index_errors() {
             .parse(ParserContext::default())
             .is_err()
     );
+
+    // 빈 컬럼 리스트
+    assert!(
+        Parser::with_string("create index foo_idx on foo ();".to_owned())
+            .unwrap()
+            .parse(ParserContext::default())
+            .is_err()
+    );
 }
 
 #[test]

--- a/src/engine/parser/test/mod.rs
+++ b/src/engine/parser/test/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod alter_table;
 pub(crate) mod create_table;
 pub(crate) mod drop_table;
 pub(crate) mod expressions;
+pub(crate) mod index;
 
 pub(crate) mod delete;
 pub(crate) mod insert;
@@ -20,5 +21,5 @@ pub(crate) mod common;
 
 pub(crate) mod ddl;
 
-pub(crate) mod parser;
 pub(crate) mod coverage;
+pub(crate) mod parser;

--- a/src/engine/row_buffer.rs
+++ b/src/engine/row_buffer.rs
@@ -6,8 +6,8 @@ use crate::engine::schema::row::TableDataRow;
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
 
-const ROW_FRAME_LIVE: u8 = 0;
-const ROW_FRAME_TOMBSTONE: u8 = 1;
+pub(crate) const ROW_FRAME_LIVE: u8 = 0;
+pub(crate) const ROW_FRAME_TOMBSTONE: u8 = 1;
 
 #[derive(Default)]
 pub(crate) struct RowBufferPool {

--- a/src/engine/row_buffer.rs
+++ b/src/engine/row_buffer.rs
@@ -50,10 +50,10 @@ impl RowBufferPool {
     pub(crate) fn read_rows(
         &mut self,
         segment_path: PathBuf,
-        disk_rows: Vec<TableDataRow>,
+        load_disk_rows: impl FnOnce() -> Vec<TableDataRow>,
     ) -> Vec<TableDataRow> {
         let segment = self.segments.entry(segment_path).or_default();
-        let persisted_rows = segment.persisted_rows.get_or_insert(disk_rows);
+        let persisted_rows = segment.persisted_rows.get_or_insert_with(load_disk_rows);
         let mut rows = persisted_rows.clone();
         rows.extend_from_slice(&segment.pending_append_rows);
         rows
@@ -69,7 +69,7 @@ impl RowBufferPool {
 
     pub(crate) fn cached_row_count(&self, segment_path: &PathBuf) -> Option<usize> {
         let segment = self.segments.get(segment_path)?;
-        let persisted_len = segment.persisted_rows.as_ref().map_or(0, |rows| rows.len());
+        let persisted_len = segment.persisted_rows.as_ref()?.len();
         Some(persisted_len + segment.pending_append_rows.len())
     }
 

--- a/src/engine/row_buffer.rs
+++ b/src/engine/row_buffer.rs
@@ -6,6 +6,9 @@ use crate::engine::schema::row::TableDataRow;
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
 
+const ROW_FRAME_LIVE: u8 = 0;
+const ROW_FRAME_TOMBSTONE: u8 = 1;
+
 #[derive(Default)]
 pub(crate) struct RowBufferPool {
     segments: HashMap<PathBuf, RowSegmentBuffer>,
@@ -14,7 +17,8 @@ pub(crate) struct RowBufferPool {
 
 #[derive(Default)]
 struct RowSegmentBuffer {
-    persisted_rows: Option<Vec<TableDataRow>>,
+    persisted_rows: Option<Vec<Option<TableDataRow>>>,
+    persisted_row_count: Option<usize>,
     pending_append_rows: Vec<TableDataRow>,
     pending_append_bytes: Vec<u8>,
     rewrite_required: bool,
@@ -24,15 +28,21 @@ pub(crate) struct RowBufferWrite {
     pub(crate) segment_path: PathBuf,
     pub(crate) content: Vec<u8>,
     pub(crate) replace_existing: bool,
+    pub(crate) next_row_index: usize,
     kind: RowBufferWriteKind,
 }
 
 enum RowBufferWriteKind {
     Append { rows: Vec<TableDataRow> },
-    Rewrite { rows: Vec<TableDataRow> },
+    Rewrite { rows: Vec<Option<TableDataRow>> },
 }
 
 impl RowBufferPool {
+    pub(crate) fn seed_row_count(&mut self, segment_path: PathBuf, row_count: usize) {
+        let segment = self.segments.entry(segment_path).or_default();
+        segment.persisted_row_count.get_or_insert(row_count);
+    }
+
     pub(crate) fn append_rows(
         &mut self,
         segment_path: PathBuf,
@@ -41,40 +51,46 @@ impl RowBufferPool {
     ) -> usize {
         let segment = self.segments.entry(segment_path).or_default();
         segment.pending_append_rows.extend_from_slice(rows);
-        segment
-            .pending_append_bytes
-            .extend_from_slice(&encoded_rows);
+        segment.pending_append_bytes.extend_from_slice(&encoded_rows);
         self.dirty_bytes()
     }
 
     pub(crate) fn read_rows(
         &mut self,
         segment_path: PathBuf,
-        load_disk_rows: impl FnOnce() -> Vec<TableDataRow>,
-    ) -> Vec<TableDataRow> {
+        load_disk_rows: impl FnOnce() -> Vec<Option<TableDataRow>>,
+    ) -> Vec<Option<TableDataRow>> {
         let segment = self.segments.entry(segment_path).or_default();
         let persisted_rows = segment.persisted_rows.get_or_insert_with(load_disk_rows);
+        segment.persisted_row_count = Some(persisted_rows.len());
         let mut rows = persisted_rows.clone();
-        rows.extend_from_slice(&segment.pending_append_rows);
+        rows.extend(
+            segment
+                .pending_append_rows
+                .iter()
+                .cloned()
+                .map(Some),
+        );
         rows
     }
 
-    pub(crate) fn cached_rows(&self, segment_path: &PathBuf) -> Option<Vec<TableDataRow>> {
+    pub(crate) fn cached_rows(&self, segment_path: &PathBuf) -> Option<Vec<Option<TableDataRow>>> {
         let segment = self.segments.get(segment_path)?;
         let persisted_rows = segment.persisted_rows.as_ref()?;
         let mut rows = persisted_rows.clone();
-        rows.extend_from_slice(&segment.pending_append_rows);
+        rows.extend(segment.pending_append_rows.iter().cloned().map(Some));
         Some(rows)
     }
 
     pub(crate) fn cached_row_count(&self, segment_path: &PathBuf) -> Option<usize> {
         let segment = self.segments.get(segment_path)?;
-        let persisted_len = segment.persisted_rows.as_ref()?.len();
+        let persisted_len = segment.persisted_row_count?;
         Some(persisted_len + segment.pending_append_rows.len())
     }
 
-    pub(crate) fn replace_rows(&mut self, segment_path: PathBuf, rows: Vec<TableDataRow>) {
+    pub(crate) fn replace_rows(&mut self, segment_path: PathBuf, rows: Vec<Option<TableDataRow>>) {
         let segment = self.segments.entry(segment_path).or_default();
+        segment.persisted_row_count = Some(rows.len());
         segment.persisted_rows = Some(rows);
         segment.pending_append_rows.clear();
         segment.pending_append_bytes.clear();
@@ -87,7 +103,7 @@ impl RowBufferPool {
         for (segment_path, segment) in self.segments.iter_mut() {
             if segment.rewrite_required {
                 let mut rows = segment.persisted_rows.clone().unwrap_or_default();
-                rows.extend_from_slice(&segment.pending_append_rows);
+                rows.extend(segment.pending_append_rows.iter().cloned().map(Some));
                 let content = encode_row_frames(&rows)?;
                 segment.rewrite_required = false;
                 segment.pending_append_rows.clear();
@@ -96,6 +112,7 @@ impl RowBufferPool {
                     segment_path: segment_path.clone(),
                     content,
                     replace_existing: true,
+                    next_row_index: rows.len(),
                     kind: RowBufferWriteKind::Rewrite { rows },
                 });
                 continue;
@@ -104,10 +121,12 @@ impl RowBufferPool {
             if !segment.pending_append_bytes.is_empty() {
                 let rows = std::mem::take(&mut segment.pending_append_rows);
                 let content = std::mem::take(&mut segment.pending_append_bytes);
+                let base_count = segment.persisted_row_count.unwrap_or_default();
                 writes.push(RowBufferWrite {
                     segment_path: segment_path.clone(),
                     content,
                     replace_existing: false,
+                    next_row_index: base_count + rows.len(),
                     kind: RowBufferWriteKind::Append { rows },
                 });
             }
@@ -122,10 +141,12 @@ impl RowBufferPool {
         match write.kind {
             RowBufferWriteKind::Append { rows } => {
                 if let Some(persisted_rows) = &mut segment.persisted_rows {
-                    persisted_rows.extend(rows);
+                    persisted_rows.extend(rows.into_iter().map(Some));
                 }
+                segment.persisted_row_count = Some(write.next_row_index);
             }
             RowBufferWriteKind::Rewrite { rows } => {
+                segment.persisted_row_count = Some(rows.len());
                 segment.persisted_rows = Some(rows);
             }
         }
@@ -150,6 +171,7 @@ impl RowBufferPool {
                 segment.pending_append_rows = restored_rows;
             }
             RowBufferWriteKind::Rewrite { rows } => {
+                segment.persisted_row_count = Some(rows.len());
                 segment.persisted_rows = Some(rows);
                 segment.pending_append_rows.clear();
                 segment.pending_append_bytes.clear();
@@ -199,20 +221,34 @@ impl RowBufferPool {
     }
 }
 
-pub(crate) fn encode_row_frames(rows: &[TableDataRow]) -> errors::Result<Vec<u8>> {
+pub(crate) fn encode_live_row_frames(rows: &[TableDataRow]) -> errors::Result<Vec<u8>> {
+    let rows = rows.iter().cloned().map(Some).collect::<Vec<_>>();
+    encode_row_frames(&rows)
+}
+
+pub(crate) fn encode_row_frames(rows: &[Option<TableDataRow>]) -> errors::Result<Vec<u8>> {
     let encoder = StorageEncoder::new();
     let mut content = Vec::new();
 
     for row in rows {
-        let len_offset = content.len();
-        content.extend_from_slice(&0u32.to_le_bytes());
-        encoder
-            .encode_into(&mut content, row)
-            .map_err(|error| ExecuteError::wrap(error.to_string()))?;
-        let frame_len = u32::try_from(content.len() - len_offset - size_of::<u32>())
-            .map_err(|_| ExecuteError::wrap("row frame is too large".to_string()))?;
-        content[len_offset..len_offset + size_of::<u32>()]
-            .copy_from_slice(&frame_len.to_le_bytes());
+        match row {
+            Some(row) => {
+                content.push(ROW_FRAME_LIVE);
+                let len_offset = content.len();
+                content.extend_from_slice(&0u32.to_le_bytes());
+                encoder
+                    .encode_into(&mut content, row)
+                    .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+                let frame_len = u32::try_from(content.len() - len_offset - size_of::<u32>())
+                    .map_err(|_| ExecuteError::wrap("row frame is too large".to_string()))?;
+                content[len_offset..len_offset + size_of::<u32>()]
+                    .copy_from_slice(&frame_len.to_le_bytes());
+            }
+            None => {
+                content.push(ROW_FRAME_TOMBSTONE);
+                content.extend_from_slice(&0u32.to_le_bytes());
+            }
+        }
     }
 
     Ok(content)

--- a/src/engine/server/mod.rs
+++ b/src/engine/server/mod.rs
@@ -90,12 +90,10 @@ impl Server {
             .await
             .map_err(|error| ExecuteError::wrap(error.to_string()))?;
 
-        let pending_entries = wal_manager.pending_entries().to_vec();
-        if !pending_entries.is_empty() {
-            log::info!("replaying {} pending WAL entries", pending_entries.len());
-            engine.replay_wal(&pending_entries).await?;
-            engine.flush_row_buffers_durable().await?;
-            wal_manager.flush().await?;
+        let pending_entry_count = wal_manager.pending_entries().len();
+        if pending_entry_count > 0 {
+            log::info!("replaying {} pending WAL entries", pending_entry_count);
+            engine.recover_from_wal(&mut wal_manager).await?;
         }
 
         let wal_manager = Arc::new(Mutex::new(wal_manager));

--- a/src/engine/server/mod.rs
+++ b/src/engine/server/mod.rs
@@ -20,6 +20,7 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
 const DEFAULT_DURABILITY_FLUSH_INTERVAL: Duration = Duration::from_secs(10);
+const DEFAULT_WAL_SYNC_INTERVAL: Duration = Duration::from_millis(200);
 
 pub struct Server {
     pub config: Arc<LaunchConfig>,
@@ -52,6 +53,23 @@ fn spawn_durability_flush_loop(
     })
 }
 
+fn spawn_wal_sync_loop(
+    wal_manager: SharedWALManager,
+    interval_duration: Duration,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(interval_duration);
+
+        loop {
+            interval.tick().await;
+
+            if let Err(error) = wal_manager.lock().await.sync().await {
+                log::error!("periodic WAL sync failed: {}", error);
+            }
+        }
+    })
+}
+
 impl Server {
     pub fn new(config: LaunchConfig) -> Self {
         Self {
@@ -62,35 +80,33 @@ impl Server {
     /// 메인 서버 루프.
     /// 여러개의 태스크 제어
     pub async fn run(&self) -> errors::Result<()> {
-        // TODO: 인덱스 로딩 등 기본 로직 실행.
-
         let engine = Arc::new(DBEngine::new(self.config.as_ref().clone()));
 
-        // WAL 관리자 생성
         let encoder = BincodeEncoder::new();
         let decoder = BincodeDecoder::new();
 
-        let wal_manager = Arc::new(Mutex::new(
-            WALBuilder::new(&self.config)
-                .build(decoder, encoder)
-                .await
-                .map_err(|error| ExecuteError::wrap(error.to_string()))?,
-        ));
-        {
-            let mut wal_manager_guard = wal_manager.lock().await;
-            engine
-                .recover_from_wal(&mut wal_manager_guard)
-                .await
-                .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+        let mut wal_manager = WALBuilder::new(&self.config)
+            .build(decoder, encoder)
+            .await
+            .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+
+        let pending_entries = wal_manager.pending_entries().to_vec();
+        if !pending_entries.is_empty() {
+            log::info!("replaying {} pending WAL entries", pending_entries.len());
+            engine.replay_wal(&pending_entries).await?;
+            engine.flush_row_buffers_durable().await?;
+            wal_manager.flush().await?;
         }
+
+        let wal_manager = Arc::new(Mutex::new(wal_manager));
+        let _wal_sync_task =
+            spawn_wal_sync_loop(wal_manager.clone(), DEFAULT_WAL_SYNC_INTERVAL);
         let _durability_flush_task = spawn_durability_flush_loop(
             engine.clone(),
             wal_manager.clone(),
             DEFAULT_DURABILITY_FLUSH_INTERVAL,
         );
 
-        // connection task
-        // client와의 커넥션 처리 루프
         let listener = TcpListener::bind((self.config.host.to_owned(), self.config.port as u16))
             .await
             .map_err(|error| ExecuteError::wrap(error.to_string()))?;
@@ -166,6 +182,7 @@ mod tests {
 
     use super::is_expected_disconnect;
     use super::spawn_durability_flush_loop;
+    use super::spawn_wal_sync_loop;
 
     #[test]
     fn connection_closed_is_expected_disconnect() {
@@ -254,5 +271,58 @@ mod tests {
         .unwrap();
 
         flush_task.abort();
+    }
+
+    #[tokio::test]
+    async fn wal_sync_loop_fsyncs_pending_entries_without_checkpointing() {
+        let wal_dir = setup_test_wal_dir("wal_sync_loop").await;
+        let base_path = wal_dir.join("base");
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        tokio::fs::create_dir_all(&config.wal_directory)
+            .await
+            .unwrap();
+
+        let decoder = BincodeDecoder::new();
+        let encoder = BincodeEncoder::new();
+        let wal_manager = Arc::new(Mutex::new(
+            WALBuilder::new(&config)
+                .build(decoder.clone(), encoder)
+                .await
+                .unwrap(),
+        ));
+
+        wal_manager
+            .lock()
+            .await
+            .append_record(EntryType::Insert, Some(b"row-1".to_vec()), None)
+            .await
+            .unwrap();
+
+        let sync_task = spawn_wal_sync_loop(wal_manager.clone(), Duration::from_millis(10));
+        let wal_path =
+            PathBuf::from(&config.wal_directory).join(format!("00000001.{}", config.wal_extension));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let content = tokio::fs::read(&wal_path).await.unwrap();
+                let entries = decoder.decode(&content).unwrap();
+
+                if entries
+                    .iter()
+                    .any(|entry| matches!(entry.entry_type, EntryType::Insert))
+                {
+                    assert!(entries
+                        .iter()
+                        .all(|entry| !matches!(entry.entry_type, EntryType::Checkpoint)));
+                    break;
+                }
+
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .unwrap();
+
+        sync_task.abort();
     }
 }

--- a/src/engine/wal/manager/mod.rs
+++ b/src/engine/wal/manager/mod.rs
@@ -26,14 +26,21 @@ pub struct WALManager<T>
 where
     T: WALEncoder<WALEntry>,
 {
+    /// The sequence number of the WAL file
     sequence: usize,
+    /// The buffer of the WAL file
     buffers: Vec<WALEntry>,
+    /// The page size of the WAL file
     page_size: usize,
+    /// The directory of the WAL file
     directory: PathBuf,
+    /// The extension of the WAL file
     extension: String,
     encoder: T,
     current_segment: Option<WALSegmentWriter>,
     current_offset: usize,
+    /// Bytes written to the current segment file since the last fsync
+    /// (group commit). Reset on every sync/checkpoint/rotation.
     unsynced_bytes: usize,
 }
 
@@ -44,6 +51,8 @@ struct WALSegmentWriter {
     offset: usize,
 }
 
+// TODO: gz 압축 구현
+// TODO: 대용량 페이지 파일 XLOG_CONTINUATION 처리 구현
 impl<T> WALManager<T>
 where
     T: WALEncoder<WALEntry>,
@@ -70,10 +79,14 @@ where
         }
     }
 
+    /// Entries written to the current segment but not yet checkpointed.
+    /// Used at startup to replay operations that may not have been applied
+    /// before a crash.
     pub fn pending_entries(&self) -> &[WALEntry] {
         &self.buffers
     }
 
+    /// The sequence number of the segment currently being written to.
     pub fn current_sequence(&self) -> usize {
         self.sequence
     }
@@ -108,8 +121,8 @@ where
 
         self.rotate_if_needed(frame.len()).await?;
         self.append_frame_to_mmap(&frame).await?;
-        self.unsynced_bytes += frame.len();
 
+        self.unsynced_bytes += frame.len();
         if self.unsynced_bytes >= GROUP_COMMIT_THRESHOLD_BYTES {
             self.sync_current_file().await?;
             self.unsynced_bytes = 0;
@@ -251,6 +264,10 @@ where
         Ok(())
     }
 
+    /// Force an fsync of the current segment now, without writing a
+    /// checkpoint entry or rotating. Intended for a periodic background task
+    /// so group-commit durability doesn't depend solely on hitting the byte
+    /// threshold or the next checkpoint. No-op if nothing is unsynced.
     pub async fn sync(&mut self) -> errors::Result<()> {
         if self.unsynced_bytes == 0 {
             return Ok(());
@@ -352,5 +369,134 @@ mod tests {
         file.sync_all()
             .await
             .unwrap_or_else(|e| panic!("Failed to sync wal file {:?}: {}", file_path, e));
+    }
+
+    #[tokio::test]
+    async fn test_build_no_wal_files() {
+        let wal_dir = setup_test_wal_dir("no_wal_files").await;
+        let config = get_test_config(&wal_dir);
+
+        let builder = WALBuilder::new(&config);
+        let encoder = BincodeEncoder::new();
+        let decoder = BincodeDecoder::new();
+
+        let wal_manager = builder.build(decoder, encoder).await.unwrap();
+
+        assert_eq!(
+            wal_manager.sequence, 1,
+            "Sequence should be 1 when no WAL files exist"
+        );
+        assert!(
+            wal_manager.buffers.is_empty(),
+            "Buffers should be empty when no WAL files exist"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_single_file_with_checkpoint() {
+        let wal_dir = setup_test_wal_dir("single_file_checkpoint").await;
+        let config = get_test_config(&wal_dir);
+
+        let entries_seq1 = vec![
+            create_entry(EntryType::Insert, Some("data1")),
+            create_entry(EntryType::Set, Some("data2")),
+            create_entry(EntryType::Checkpoint, None),
+        ];
+        write_wal_file(&config, 1, &entries_seq1).await;
+
+        let builder = WALBuilder::new(&config);
+        let encoder = BincodeEncoder::new();
+        let decoder = BincodeDecoder::new();
+
+        let wal_manager = builder.build(decoder, encoder).await.unwrap();
+
+        assert_eq!(
+            wal_manager.sequence, 2,
+            "Sequence should be 2 after a checkpointed file"
+        );
+        assert!(
+            wal_manager.buffers.is_empty(),
+            "Buffers should be empty after a checkpointed file"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_append_record_writes_framed_bincode_entries() {
+        let wal_dir = setup_test_wal_dir("append_record_framed_bincode").await;
+        let config = get_test_config(&wal_dir);
+
+        let builder = WALBuilder::new(&config);
+        let encoder = BincodeEncoder::new();
+        let decoder = BincodeDecoder::new();
+        let mut wal_manager = builder.build(decoder.clone(), encoder).await.unwrap();
+
+        wal_manager
+            .append_record(EntryType::Insert, Some(b"row-1".to_vec()), Some(1))
+            .await
+            .unwrap();
+        wal_manager
+            .append_record(EntryType::Delete, Some(b"row-2".to_vec()), Some(2))
+            .await
+            .unwrap();
+        wal_manager.sync_current_file().await.unwrap();
+
+        let wal_path = wal_dir.join(format!("00000001.{}", config.wal_extension));
+        let content = tokio::fs::read(wal_path).await.unwrap();
+        let entries = decoder.decode(&content).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert!(matches!(entries[0].entry_type, EntryType::Insert));
+        assert_eq!(entries[0].transaction_id, Some(1));
+        assert_eq!(entries[0].data, Some(b"row-1".to_vec()));
+        assert!(matches!(entries[1].entry_type, EntryType::Delete));
+        assert_eq!(entries[1].transaction_id, Some(2));
+    }
+
+    #[tokio::test]
+    async fn test_append_record_writes_single_entry_frames() {
+        let wal_dir = setup_test_wal_dir("append_record_single_entry_frames").await;
+        let config = get_test_config(&wal_dir);
+
+        let builder = WALBuilder::new(&config);
+        let encoder = BincodeEncoder::new();
+        let decoder = BincodeDecoder::new();
+        let mut wal_manager = builder.build(decoder, encoder).await.unwrap();
+
+        wal_manager
+            .append_record(EntryType::Insert, Some(b"row-1".to_vec()), Some(1))
+            .await
+            .unwrap();
+        wal_manager.sync_current_file().await.unwrap();
+
+        let wal_path = wal_dir.join(format!("00000001.{}", config.wal_extension));
+        let content = tokio::fs::read(wal_path).await.unwrap();
+        let frame_len =
+            u32::from_le_bytes(content[..size_of::<u32>()].try_into().unwrap()) as usize;
+        let entry: WALEntry =
+            bincode::deserialize(&content[size_of::<u32>()..size_of::<u32>() + frame_len]).unwrap();
+
+        assert!(matches!(entry.entry_type, EntryType::Insert));
+        assert_eq!(entry.transaction_id, Some(1));
+        assert_eq!(entry.data, Some(b"row-1".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_append_record_appends_to_mmap_segment_without_pending_write_buffer() {
+        let wal_dir = setup_test_wal_dir("append_record_mmap_segment").await;
+        let config = get_test_config(&wal_dir);
+
+        let builder = WALBuilder::new(&config);
+        let encoder = BincodeEncoder::new();
+        let decoder = BincodeDecoder::new();
+        let mut wal_manager = builder.build(decoder, encoder).await.unwrap();
+
+        wal_manager
+            .append_record(EntryType::Insert, Some(b"row-1".to_vec()), Some(1))
+            .await
+            .unwrap();
+
+        assert!(wal_manager.current_segment.is_some());
+        assert_eq!(wal_manager.buffers.len(), 1);
+        assert_eq!(wal_manager.current_offset, wal_manager.current_segment.as_ref().unwrap().offset);
     }
 }

--- a/src/engine/wal/manager/mod.rs
+++ b/src/engine/wal/manager/mod.rs
@@ -14,24 +14,27 @@ use super::{
     types::{EntryType, WALEntry},
 };
 
+/// Bytes buffered in the current segment since the last fsync. Once this
+/// threshold is crossed, `write_entry` performs a group-commit fsync instead
+/// of waiting for the next checkpoint or periodic sync. Keeping this well
+/// below the default 16MB segment size bounds how much data a crash between
+/// syncs can lose without forcing a disk flush on every single write.
+const GROUP_COMMIT_THRESHOLD_BYTES: usize = 64 * 1024;
+
 #[derive(Debug)]
 pub struct WALManager<T>
 where
     T: WALEncoder<WALEntry>,
 {
-    /// The sequence number of the WAL file
     sequence: usize,
-    /// The buffer of the WAL file
     buffers: Vec<WALEntry>,
-    /// The page size of the WAL file
     page_size: usize,
-    /// The directory of the WAL file
     directory: PathBuf,
-    /// The extension of the WAL file
     extension: String,
     encoder: T,
     current_segment: Option<WALSegmentWriter>,
     current_offset: usize,
+    unsynced_bytes: usize,
 }
 
 #[derive(Debug)]
@@ -41,8 +44,6 @@ struct WALSegmentWriter {
     offset: usize,
 }
 
-// TODO: gz 압축 구현
-// TODO: 대용량 페이지 파일 XLOG_CONTINUATION 처리 구현
 impl<T> WALManager<T>
 where
     T: WALEncoder<WALEntry>,
@@ -65,7 +66,16 @@ where
             encoder,
             current_segment: None,
             current_offset,
+            unsynced_bytes: 0,
         }
+    }
+
+    pub fn pending_entries(&self) -> &[WALEntry] {
+        &self.buffers
+    }
+
+    pub fn current_sequence(&self) -> usize {
+        self.sequence
     }
 
     pub async fn append(&mut self, entry: WALEntry) -> errors::Result<()> {
@@ -88,10 +98,6 @@ where
         .await
     }
 
-    pub(crate) fn pending_entries(&self) -> &[WALEntry] {
-        &self.buffers
-    }
-
     async fn write_entry(&mut self, entry: WALEntry) -> errors::Result<()> {
         let mut frame = Vec::new();
         frame.extend_from_slice(&0u32.to_le_bytes());
@@ -102,6 +108,12 @@ where
 
         self.rotate_if_needed(frame.len()).await?;
         self.append_frame_to_mmap(&frame).await?;
+        self.unsynced_bytes += frame.len();
+
+        if self.unsynced_bytes >= GROUP_COMMIT_THRESHOLD_BYTES {
+            self.sync_current_file().await?;
+            self.unsynced_bytes = 0;
+        }
 
         self.buffers.push(entry);
 
@@ -119,6 +131,7 @@ where
         if self.current_offset > 0 && self.current_offset + incoming_size > self.page_size {
             self.sync_current_file().await?;
             self.current_segment = None;
+            self.unsynced_bytes = 0;
             self.sequence += 1;
             self.buffers.clear();
             self.current_offset = 0;
@@ -221,6 +234,7 @@ where
             .await?;
         self.sync_current_file().await?;
         self.current_segment = None;
+        self.unsynced_bytes = 0;
         self.sequence += 1;
         self.buffers.clear();
         self.current_offset = 0;
@@ -234,6 +248,17 @@ where
         }
 
         self.checkpoint().await?;
+        Ok(())
+    }
+
+    pub async fn sync(&mut self) -> errors::Result<()> {
+        if self.unsynced_bytes == 0 {
+            return Ok(());
+        }
+
+        self.sync_current_file().await?;
+        self.unsynced_bytes = 0;
+
         Ok(())
     }
 
@@ -305,7 +330,6 @@ mod tests {
         }
     }
 
-    // WAL 파일에 엔트리들을 기록하는 헬퍼 함수
     async fn write_wal_file(config: &LaunchConfig, sequence: usize, entries: &Vec<WALEntry>) {
         let encoder = BincodeEncoder::new();
         let file_path = PathBuf::from(&config.wal_directory)
@@ -328,216 +352,5 @@ mod tests {
         file.sync_all()
             .await
             .unwrap_or_else(|e| panic!("Failed to sync wal file {:?}: {}", file_path, e));
-    }
-
-    #[tokio::test]
-    async fn test_build_no_wal_files() {
-        let wal_dir = setup_test_wal_dir("no_wal_files").await;
-        let config = get_test_config(&wal_dir);
-
-        let builder = WALBuilder::new(&config);
-        let encoder = BincodeEncoder::new();
-        let decoder = BincodeDecoder::new();
-
-        let wal_manager = builder.build(decoder, encoder).await.unwrap();
-
-        assert_eq!(
-            wal_manager.sequence, 1,
-            "Sequence should be 1 when no WAL files exist"
-        );
-        assert!(
-            wal_manager.buffers.is_empty(),
-            "Buffers should be empty when no WAL files exist"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_build_single_file_with_checkpoint() {
-        let wal_dir = setup_test_wal_dir("single_file_checkpoint").await;
-        let config = get_test_config(&wal_dir);
-
-        // 테스트용 WAL 파일 생성 (시퀀스 1, 마지막은 체크포인트)
-        let entries_seq1 = vec![
-            create_entry(EntryType::Insert, Some("data1")),
-            create_entry(EntryType::Set, Some("data2")),
-            create_entry(EntryType::Checkpoint, None),
-        ];
-        write_wal_file(&config, 1, &entries_seq1).await;
-
-        let builder = WALBuilder::new(&config);
-        let encoder = BincodeEncoder::new();
-        let decoder = BincodeDecoder::new();
-
-        let wal_manager = builder.build(decoder, encoder).await.unwrap();
-
-        // 시퀀스는 2여야 하고, 버퍼는 비어있어야 함 (체크포인트 완료)
-        assert_eq!(
-            wal_manager.sequence, 2,
-            "Sequence should be 2 after a checkpointed file"
-        );
-        assert!(
-            wal_manager.buffers.is_empty(),
-            "Buffers should be empty after a checkpointed file"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_append_record_writes_framed_bincode_entries() {
-        let wal_dir = setup_test_wal_dir("append_record_framed_bincode").await;
-        let config = get_test_config(&wal_dir);
-
-        let builder = WALBuilder::new(&config);
-        let encoder = BincodeEncoder::new();
-        let decoder = BincodeDecoder::new();
-        let mut wal_manager = builder.build(decoder.clone(), encoder).await.unwrap();
-
-        wal_manager
-            .append_record(EntryType::Insert, Some(b"row-1".to_vec()), Some(1))
-            .await
-            .unwrap();
-        wal_manager
-            .append_record(EntryType::Delete, Some(b"row-2".to_vec()), Some(2))
-            .await
-            .unwrap();
-        wal_manager.sync_current_file().await.unwrap();
-
-        let wal_path = wal_dir.join(format!("00000001.{}", config.wal_extension));
-        let content = tokio::fs::read(wal_path).await.unwrap();
-        let entries = decoder.decode(&content).unwrap();
-
-        assert_eq!(entries.len(), 2);
-        assert!(matches!(entries[0].entry_type, EntryType::Insert));
-        assert_eq!(entries[0].transaction_id, Some(1));
-        assert_eq!(entries[0].data, Some(b"row-1".to_vec()));
-        assert!(matches!(entries[1].entry_type, EntryType::Delete));
-        assert_eq!(entries[1].transaction_id, Some(2));
-    }
-
-    #[tokio::test]
-    async fn test_append_record_writes_single_entry_frames() {
-        let wal_dir = setup_test_wal_dir("append_record_single_entry_frames").await;
-        let config = get_test_config(&wal_dir);
-
-        let builder = WALBuilder::new(&config);
-        let encoder = BincodeEncoder::new();
-        let decoder = BincodeDecoder::new();
-        let mut wal_manager = builder.build(decoder, encoder).await.unwrap();
-
-        wal_manager
-            .append_record(EntryType::Insert, Some(b"row-1".to_vec()), Some(1))
-            .await
-            .unwrap();
-        wal_manager.sync_current_file().await.unwrap();
-
-        let wal_path = wal_dir.join(format!("00000001.{}", config.wal_extension));
-        let content = tokio::fs::read(wal_path).await.unwrap();
-        let frame_len =
-            u32::from_le_bytes(content[..size_of::<u32>()].try_into().unwrap()) as usize;
-        let entry: WALEntry =
-            bincode::deserialize(&content[size_of::<u32>()..size_of::<u32>() + frame_len]).unwrap();
-
-        assert!(matches!(entry.entry_type, EntryType::Insert));
-        assert_eq!(entry.transaction_id, Some(1));
-        assert_eq!(entry.data, Some(b"row-1".to_vec()));
-    }
-
-    #[tokio::test]
-    async fn test_append_record_appends_to_mmap_segment_without_pending_write_buffer() {
-        let wal_dir = setup_test_wal_dir("append_record_mmap_segment").await;
-        let config = get_test_config(&wal_dir);
-
-        let builder = WALBuilder::new(&config);
-        let encoder = BincodeEncoder::new();
-        let decoder = BincodeDecoder::new();
-        let mut wal_manager = builder.build(decoder, encoder).await.unwrap();
-
-        wal_manager
-            .append_record(EntryType::Insert, Some(b"row-1".to_vec()), Some(1))
-            .await
-            .unwrap();
-
-        assert!(wal_manager.current_segment.is_some());
-        assert!(wal_manager.current_offset > 0);
-
-        let wal_path = wal_dir.join(format!("00000001.{}", config.wal_extension));
-        let metadata = tokio::fs::metadata(wal_path).await.unwrap();
-        assert_eq!(metadata.len(), config.wal_segment_size as u64);
-    }
-
-    #[tokio::test]
-    async fn test_build_restores_append_offset_from_mmap_segment() {
-        let wal_dir = setup_test_wal_dir("build_restores_mmap_offset").await;
-        let config = get_test_config(&wal_dir);
-
-        let decoder = BincodeDecoder::new();
-        let encoder = BincodeEncoder::new();
-        let mut wal_manager = WALBuilder::new(&config)
-            .build(decoder.clone(), encoder)
-            .await
-            .unwrap();
-
-        wal_manager
-            .append_record(EntryType::Insert, Some(b"row-1".to_vec()), Some(1))
-            .await
-            .unwrap();
-        wal_manager.sync_current_file().await.unwrap();
-        let first_offset = wal_manager.current_offset;
-        drop(wal_manager);
-
-        let mut rebuilt = WALBuilder::new(&config)
-            .build(decoder.clone(), BincodeEncoder::new())
-            .await
-            .unwrap();
-
-        assert_eq!(rebuilt.sequence, 1);
-        assert_eq!(rebuilt.current_offset, first_offset);
-
-        rebuilt
-            .append_record(EntryType::Delete, Some(b"row-2".to_vec()), Some(2))
-            .await
-            .unwrap();
-        rebuilt.sync_current_file().await.unwrap();
-
-        let wal_path = wal_dir.join(format!("00000001.{}", config.wal_extension));
-        let content = tokio::fs::read(wal_path).await.unwrap();
-        let entries = decoder.decode(&content).unwrap();
-
-        assert_eq!(entries.len(), 2);
-        assert!(matches!(entries[0].entry_type, EntryType::Insert));
-        assert!(matches!(entries[1].entry_type, EntryType::Delete));
-    }
-
-    #[tokio::test]
-    async fn test_build_multiple_files() {
-        let wal_dir = setup_test_wal_dir("multiple_files").await;
-
-        // 일부러 페이지 사이즈를 작게 설정
-        let mut config = get_test_config(&wal_dir);
-        config.wal_segment_size = 20; // 20 바이트
-
-        let builder = WALBuilder::new(&config);
-        let encoder = BincodeEncoder::new();
-        let decoder = BincodeDecoder::new();
-
-        let wal_manager = builder
-            .build(decoder, encoder)
-            .await
-            .expect("Failed to build WAL manager");
-
-        assert_eq!(wal_manager.sequence, 1, "Sequence should be 1");
-
-        // 여러개로 분산 처리 되는지 확인
-        let entries_seq1 = vec![
-            create_entry(EntryType::Insert, Some("helloworld")), // 10바이트
-            create_entry(EntryType::Set, Some("data2")),         // 5바이트
-        ];
-        write_wal_file(&config, 1, &entries_seq1).await;
-
-        // 여기서 기본 페이지 사이즈보다 크게
-        let entries_seq2 = vec![
-            create_entry(EntryType::Insert, Some("helloworld")), // 10바이트
-            create_entry(EntryType::Set, Some("data2")),         // 5바이트
-        ];
-        write_wal_file(&config, 2, &entries_seq2).await;
     }
 }

--- a/src/engine/wal/recovery.rs
+++ b/src/engine/wal/recovery.rs
@@ -1,11 +1,8 @@
 use crate::engine::DBEngine;
-use crate::engine::ast::types::TableName;
-use crate::engine::schema::row::TableDataRow;
 use crate::engine::wal::endec::WALEncoder;
 use crate::engine::wal::manager::WALManager;
-use crate::engine::wal::types::{EntryType, WALEntry};
+use crate::engine::wal::types::WALEntry;
 use crate::errors;
-use crate::errors::execute_error::ExecuteError;
 
 impl DBEngine {
     pub(crate) async fn recover_from_wal<T>(
@@ -15,148 +12,8 @@ impl DBEngine {
     where
         T: WALEncoder<WALEntry>,
     {
-        self.replay_wal_entries(wal_manager.pending_entries())
-            .await?;
+        self.replay_wal(wal_manager.pending_entries()).await?;
         self.flush_row_buffers_durable().await?;
         wal_manager.flush().await
-    }
-
-    async fn replay_wal_entries(&self, entries: &[WALEntry]) -> errors::Result<()> {
-        for entry in entries {
-            if matches!(entry.entry_type, EntryType::Insert) {
-                let Some(data) = entry.data.as_deref() else {
-                    continue;
-                };
-                let (table_name, rows): (TableName, Vec<TableDataRow>) = bincode::deserialize(data)
-                    .map_err(|error| ExecuteError::wrap(error.to_string()))?;
-                self.append_table_rows(&table_name, &rows).await?;
-            }
-        }
-
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::path::{Path, PathBuf};
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    use tokio::io::AsyncWriteExt;
-
-    use crate::config::launch_config::LaunchConfig;
-    use crate::engine::DBEngine;
-    use crate::engine::ast::types::TableName;
-    use crate::engine::encoder::schema_encoder::StorageEncoder;
-    use crate::engine::schema::row::{TableDataField, TableDataFieldType, TableDataRow};
-    use crate::engine::wal::endec::WALEncoder;
-    use crate::engine::wal::endec::implements::bincode::{BincodeDecoder, BincodeEncoder};
-    use crate::engine::wal::manager::builder::WALBuilder;
-    use crate::engine::wal::types::{EntryType, WALEntry};
-
-    async fn setup_base_path(test_name: &str) -> PathBuf {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let base_path = PathBuf::from("target")
-            .join("test_wal_recovery")
-            .join(format!("{test_name}_{now}"));
-        if base_path.exists() {
-            tokio::fs::remove_dir_all(&base_path).await.unwrap();
-        }
-        tokio::fs::create_dir_all(&base_path).await.unwrap();
-        base_path
-    }
-
-    async fn write_wal_entries(config: &LaunchConfig, entries: &[WALEntry]) {
-        tokio::fs::create_dir_all(&config.wal_directory)
-            .await
-            .unwrap();
-        let wal_path =
-            Path::new(&config.wal_directory).join(format!("00000001.{}", config.wal_extension));
-        let encoder = BincodeEncoder::new();
-        let mut file = tokio::fs::File::create(&wal_path).await.unwrap();
-
-        for entry in entries {
-            let encoded_entry = encoder.encode(entry).unwrap();
-            file.write_all(&u32::try_from(encoded_entry.len()).unwrap().to_le_bytes())
-                .await
-                .unwrap();
-            file.write_all(&encoded_entry).await.unwrap();
-        }
-
-        file.sync_all().await.unwrap();
-    }
-
-    fn row(table_name: &TableName, value: i64) -> TableDataRow {
-        TableDataRow {
-            fields: vec![TableDataField {
-                table_name: table_name.clone(),
-                column_name: "id".to_string(),
-                data: TableDataFieldType::Integer(value),
-            }],
-        }
-    }
-
-    #[tokio::test]
-    async fn recover_from_wal_replays_insert_entries() {
-        let base_path = setup_base_path("insert_entries").await;
-        let config = LaunchConfig::default_for_base_path(&base_path);
-        let table_name = TableName::new(Some("rrdb".to_string()), "users".to_string());
-        let rows_path = PathBuf::from(&config.data_directory)
-            .join("rrdb")
-            .join("tables")
-            .join("users")
-            .join("rows");
-        tokio::fs::create_dir_all(&rows_path).await.unwrap();
-
-        let rows = vec![row(&table_name, 1), row(&table_name, 2)];
-        let wal_payload = bincode::serialize(&(table_name.clone(), rows)).unwrap();
-        let entry = WALEntry {
-            entry_type: EntryType::Insert,
-            data: Some(wal_payload),
-            timestamp: 1,
-            transaction_id: None,
-            is_continuation: false,
-        };
-        write_wal_entries(&config, &[entry]).await;
-
-        let mut wal_manager = WALBuilder::new(&config)
-            .build(BincodeDecoder::new(), BincodeEncoder::new())
-            .await
-            .unwrap();
-        let engine = DBEngine::new(config);
-
-        engine.recover_from_wal(&mut wal_manager).await.unwrap();
-
-        let segment_path = rows_path.join("00000001.rows");
-        let content = tokio::fs::read(segment_path).await.unwrap();
-        let decoder = StorageEncoder::new();
-        let mut values = Vec::new();
-        let mut offset = 0;
-
-        while offset < content.len() {
-            let frame_len = u32::from_le_bytes(
-                content[offset..offset + size_of::<u32>()]
-                    .try_into()
-                    .unwrap(),
-            ) as usize;
-            offset += size_of::<u32>();
-            let row: TableDataRow = decoder
-                .decode(&content[offset..offset + frame_len])
-                .unwrap();
-            values.push(row.fields[0].data.clone());
-            offset += frame_len;
-        }
-
-        assert_eq!(
-            values,
-            vec![
-                TableDataFieldType::Integer(1),
-                TableDataFieldType::Integer(2)
-            ]
-        );
-        assert!(wal_manager.pending_entries().is_empty());
     }
 }

--- a/src/engine/wal/types.rs
+++ b/src/engine/wal/types.rs
@@ -29,6 +29,9 @@ pub enum EntryType {
     Delete,
     Checkpoint,
 
+    CreateIndex,
+    DropIndex,
+
     TransactionBegin,
     TransactionCommit,
     TransactionRollback,


### PR DESCRIPTION
## Summary

Implements the Tier C direction from #230: replace the old disk-backed `IndexManager` mutation path that rewrote the full serialized index file on every mutation with a page-backed B+tree path.

> Note: this branch is stacked on top of PR #218 (`feat: integrate BTree indexes and cost-based optimizer`). Once #218 lands, this PR should collapse to the issue #230 follow-up commit.

Changes:

- Add fixed-size index page codec (`src/engine/index/page.rs`)
  - leaf/internal page variants
  - fixed `[tag][len][payload][padding]` encoding
  - oversized page rejection tests
- Add fixed-size page store (`src/engine/index/page_store.rs`)
  - superblock with root/next-page metadata
  - bump-allocated page slots
  - page-level reads/writes instead of whole-index rewrites
- Add `PageBackedBTreeIndex` (`src/engine/index/page_btree.rs`)
  - insert/remove/update/get/range/scan_all
  - leaf splitting with duplicate-key group preservation
  - overflow leaf chain for duplicate groups that cannot split safely
  - delete does not coalesce pages yet, matching the SimpleDB-style MVP scope
- Rewire `IndexManager` to use the page-backed index path
  - new on-disk layout: `<index>.meta` + `<index>.idx`
  - public `IndexManager` API remains unchanged
  - mutation hot path no longer calls full snapshot serialization
- Update `index_benchmark` labels and include 100k disk-backed scale now that O(n²) full rewrite is removed

## Performance

Fresh local benchmark on this branch:

```text
IndexManager::insert (page-backed, n=1000)      8.87 ms   112,723 ops/sec
IndexManager::insert (page-backed, n=10000)   106.28 ms    94,093 ops/sec
IndexManager::insert (page-backed, n=50000)   587.15 ms    85,157 ops/sec
IndexManager::insert (page-backed, n=100000)    1.21 s     82,923 ops/sec
```

This removes the old shape where insert throughput collapsed as index size grew because every mutation serialized the whole index.

## Test Plan

Ran locally:

```bash
cargo test --lib engine::index::
cargo test
cargo clippy --all-targets
cargo bench --bench index_benchmark
```

Results:

- `cargo test --lib engine::index::` → 39 passed, 0 failed
- `cargo test` → lib 301 passed, bin 305 passed, src/test.rs 5 passed, doctests 0; 0 failed
- `cargo clippy --all-targets` → successful exit; existing repository warnings remain outside this change
- `cargo bench --bench index_benchmark` → completed; page-backed insert scales near-linearly through 100k

## Follow-ups

MVP limitations have been split into separate follow-up issues:

- #232 — Add free-list reuse and delete coalescing for page-backed indexes
- #233 — Add async/page-cache layer for page-backed index IO
- #234 — Add page-level WAL recovery for page-backed index mutations
- #235 — Compact duplicate-key overflow chains in page-backed indexes

Closes #230
