### PR TITLE
[#227] fix: 다중 세그먼트 WAL replay 복구 보정

### DIFF
--- a/docs/superpowers/plans/2026-07-19-wal-filesystem-injection.md
+++ b/docs/superpowers/plans/2026-07-19-wal-filesystem-injection.md
@@ -1,0 +1,46 @@
+# WAL Filesystem Injection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route WAL segment discovery and reads through the common `FileSystem` abstraction.
+
+**Architecture:** Add owned directory-entry and read APIs to `FileSystem`; keep Tokio types in `RealFileSystem`. Give `WALBuilder` a real-filesystem convenience constructor and an explicit injection constructor for mock-driven tests.
+
+**Tech Stack:** Rust 2024, async-trait, mockall, Tokio, existing WAL codecs.
+
+---
+
+### Task 1: Extend the common filesystem abstraction
+
+**Files:**
+- Modify: `src/common/fs.rs`
+
+- [ ] Add `FileSystemEntry { path: PathBuf, is_file: bool }` and async `read_dir`/`read` methods to `FileSystem`.
+- [ ] Implement both methods in `RealFileSystem`, collecting every Tokio directory entry and propagating `next_entry` and `file_type` errors.
+- [ ] Run `cargo test common` to verify compilation and existing behavior.
+
+### Task 2: Inject the filesystem into WALBuilder
+
+**Files:**
+- Modify: `src/engine/wal/manager/builder.rs`
+- Modify: `src/engine/wal/manager/mod.rs`
+
+- [ ] Add a failing mock test whose expected `read_dir` and `read` calls provide two framed segment files without creating files on disk.
+- [ ] Verify RED because `WALBuilder` cannot yet accept the mock.
+- [ ] Store `Arc<dyn FileSystem + Send + Sync>` in `WALBuilder`.
+- [ ] Keep `new(config)` backed by `RealFileSystem`; add `with_file_system(config, file_system)` for dependency injection.
+- [ ] Replace `tokio::fs::read_dir`, `Path::is_file`, and `tokio::fs::read` with trait results.
+- [ ] Add mock error tests for directory and segment reads, preserving segment-path context.
+- [ ] Run `cargo test engine::wal::manager::tests` and confirm all tests pass.
+
+### Task 3: Verify and integrate
+
+**Files:**
+- Verify: `src/common/fs.rs`
+- Verify: `src/engine/wal/manager/builder.rs`
+- Verify: `src/engine/wal/manager/mod.rs`
+
+- [ ] Confirm `rg -n "tokio::fs|std::fs|\.is_file" src/engine/wal/manager/builder.rs` returns no matches.
+- [ ] Run `cargo test`.
+- [ ] Run Clippy and distinguish pre-existing repository warnings from new warnings.
+- [ ] Commit with a `[#227]` message and update the remote branch with `--force-with-lease` only if history was rewritten.

--- a/docs/superpowers/plans/2026-07-19-wal-multi-segment-replay.md
+++ b/docs/superpowers/plans/2026-07-19-wal-multi-segment-replay.md
@@ -1,0 +1,232 @@
+# WAL Multi-Segment Replay Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replay every WAL mutation after the latest checkpoint across all segment files and abort recovery without checkpointing when replay fails.
+
+**Architecture:** `WALBuilder` sorts and decodes every valid WAL segment, clearing its pending-entry suffix whenever it encounters a checkpoint. `DBEngine::replay_wal` propagates the first contextual error, while `recover_from_wal` checkpoints only after replay and durable row flushing succeed.
+
+**Tech Stack:** Rust 2024, Tokio async filesystem/tests, bincode framed WAL encoding, RRDB error types.
+
+---
+
+## File Map
+
+- `src/engine/wal/manager/builder.rs`: ordered segment discovery and recovery-boundary calculation.
+- `src/engine/wal/manager/mod.rs`: loader and corruption regression tests.
+- `src/engine/mod.rs`: fail-fast replay behavior and focused replay test.
+- `src/engine/wal/recovery.rs`: failed-recovery checkpoint regression test.
+
+### Task 1: Multi-segment recovery loading
+
+**Files:**
+- Modify: `src/engine/wal/manager/mod.rs`
+- Modify: `src/engine/wal/manager/builder.rs`
+
+- [ ] **Step 1: Add the failing multi-segment test**
+
+Add a test that writes an `Insert` payload `segment-1` to sequence 1 and a `Delete` payload `segment-2` to sequence 2 using `write_wal_file`. Build the manager and assert exactly these two payloads appear in `pending_entries()` in sequence order, and `current_sequence()` is 2.
+
+```rust
+let payloads: Vec<_> = wal_manager
+    .pending_entries()
+    .iter()
+    .map(|entry| entry.data.clone().unwrap())
+    .collect();
+assert_eq!(payloads, vec![b"segment-1".to_vec(), b"segment-2".to_vec()]);
+assert_eq!(wal_manager.current_sequence(), 2);
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run `cargo test engine::wal::manager::tests::test_build_loads_pending_entries_from_all_segments -- --exact`.
+
+Expected: FAIL because the current builder loads only sequence 2.
+
+- [ ] **Step 3: Add checkpoint-boundary coverage**
+
+Write sequence 1 with `Insert("durable")` followed by `Checkpoint`, and sequence 2 with `Set("pending")`. Assert the manager exposes only the `Set` entry. This test documents that the last checkpoint applies across files.
+
+- [ ] **Step 4: Add the failing corrupt-intermediate-segment test**
+
+Write valid segments 1 and 3. Between them, create sequence 2 with a frame length of 8 but only two body bytes:
+
+```rust
+tokio::fs::write(
+    wal_dir.join(format!("00000002.{}", config.wal_extension)),
+    [8, 0, 0, 0, 1, 2],
+)
+.await
+.unwrap();
+```
+
+Assert `WALBuilder::build` returns an error containing both `00000002` and `truncated wal frame body`. Run `cargo test engine::wal::manager::tests::test_build_rejects_corrupt_intermediate_segment -- --exact` and verify RED because the current loader ignores sequence 2.
+
+- [ ] **Step 5: Implement ordered loading**
+
+Replace the single `max_sequence`/`last_log_path` scan with `Vec<(usize, PathBuf)>`. Include only regular files with the configured extension and a hexadecimal stem, then call:
+
+```rust
+segments.sort_by_key(|(sequence, _)| *sequence);
+```
+
+For every segment in order:
+
+```rust
+let content = tokio::fs::read(&path).await.map_err(|error| {
+    WALError::wrap(format!("failed to read log file {:?}: {}", path, error))
+})?;
+let used_bytes = used_wal_bytes(&content).map_err(|error| {
+    WALError::wrap(format!("failed to inspect log file {:?}: {}", path, error))
+})?;
+let entries = decoder.decode(&content).map_err(|error| {
+    WALError::wrap(format!("failed to decode log file {:?}: {}", path, error))
+})?;
+
+for entry in &entries {
+    if matches!(entry.entry_type, EntryType::Checkpoint) {
+        pending_entries.clear();
+    } else {
+        pending_entries.push(entry.clone());
+    }
+}
+```
+
+Remember the newest segment's decoded entries and `used_bytes`. Return `(1, [], 0)` when no segment exists. If the newest entry is a checkpoint, return `(max_sequence + 1, pending_entries, 0)`; otherwise return `(max_sequence, pending_entries, newest_offset)`. An empty newest segment therefore resumes at its own sequence and offset zero.
+
+- [ ] **Step 6: Verify GREEN**
+
+Run `cargo test engine::wal::manager::tests -- --nocapture`.
+
+Expected: all builder tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/engine/wal/manager/builder.rs src/engine/wal/manager/mod.rs
+git commit -m "fix: replay WAL across segment boundaries"
+```
+
+### Task 2: Abort replay on the first error
+
+**Files:**
+- Modify: `src/engine/mod.rs`
+
+- [ ] **Step 1: Add a failing payload test**
+
+Construct a default `DBEngine` and one `WALEntry` with `EntryType::Insert` and payload `vec![0xff]`. Call `replay_wal`, require `unwrap_err()`, and assert its display contains `entry 0` and `Insert`.
+
+```rust
+let entry = WALEntry {
+    entry_type: EntryType::Insert,
+    data: Some(vec![0xff]),
+    timestamp: 1,
+    transaction_id: None,
+    is_continuation: false,
+};
+let error = engine.replay_wal(&[entry]).await.unwrap_err();
+assert!(error.to_string().contains("entry 0"));
+assert!(error.to_string().contains("Insert"));
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run `cargo test engine::wal_replay_tests::replay_wal_returns_contextual_error_for_invalid_payload -- --exact`.
+
+Expected: FAIL because the current method logs the error and returns success.
+
+- [ ] **Step 3: Implement fail-fast replay**
+
+Enumerate the existing replay loop and preserve its `EntryType` match. Replace the warning-and-continue block with:
+
+```rust
+result.map_err(|error| {
+    ExecuteError::wrap(format!(
+        "WAL replay failed at entry {} ({:?}): {}",
+        index, entry.entry_type, error
+    ))
+})?;
+```
+
+Update the method comment to state that any decode or application failure aborts recovery. Do not change transaction-entry handling in this task.
+
+- [ ] **Step 4: Verify GREEN and existing index replay**
+
+Run:
+
+```bash
+cargo test engine::wal_replay_tests -- --nocapture
+cargo test engine::actions::ddl::create_index::tests -- --nocapture
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/engine/mod.rs
+git commit -m "fix: abort WAL replay on entry failure"
+```
+
+### Task 3: Preserve WAL when recovery fails
+
+**Files:**
+- Modify: `src/engine/wal/recovery.rs`
+
+- [ ] **Step 1: Add a recovery-level regression test**
+
+Create a unique directory below `target/test_wal_recovery`, build a manager, append an invalid `Insert` payload, and call `sync()`. Run `recover_from_wal` and assert it returns an error. Decode `00000001.<extension>` and assert it contains exactly the invalid entry and no `Checkpoint`.
+
+```rust
+assert!(engine.recover_from_wal(&mut wal_manager).await.is_err());
+let entries = BincodeDecoder::new().decode(&content).unwrap();
+assert_eq!(entries.len(), 1);
+assert!(!entries
+    .iter()
+    .any(|entry| matches!(entry.entry_type, EntryType::Checkpoint)));
+```
+
+- [ ] **Step 2: Run the focused test**
+
+Run `cargo test engine::wal::recovery::tests::failed_recovery_does_not_append_checkpoint -- --exact`.
+
+Expected after Task 2: PASS. The existing `?` ordering already prevents `WALManager::flush` after replay failure, so no production change is expected in `recovery.rs`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/engine/wal/recovery.rs
+git commit -m "test: preserve WAL after replay failure"
+```
+
+### Task 4: Full verification
+
+**Files:**
+- Verify: `src/engine/wal/manager/builder.rs`
+- Verify: `src/engine/wal/manager/mod.rs`
+- Verify: `src/engine/mod.rs`
+- Verify: `src/engine/wal/recovery.rs`
+
+- [ ] **Step 1: Format and inspect**
+
+Run `cargo fmt --check` and `git diff --check`.
+
+Expected: both commands succeed.
+
+- [ ] **Step 2: Run all tests**
+
+Run `cargo test`.
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run Clippy**
+
+Run `cargo clippy --all-targets --all-features -- -D warnings`.
+
+Expected: no warnings or errors.
+
+- [ ] **Step 4: Confirm scope**
+
+Run `git status --short` and `git log -5 --oneline`.
+
+Expected: only the intended WAL loader, replay, recovery-test, design, and plan changes are present.

--- a/docs/superpowers/specs/2026-07-19-wal-filesystem-injection-design.md
+++ b/docs/superpowers/specs/2026-07-19-wal-filesystem-injection-design.md
@@ -1,0 +1,44 @@
+# WAL Filesystem Injection Design
+
+## Goal
+
+Remove direct operating-system filesystem access from `WALBuilder` so WAL discovery and loading can be tested through RRDB's shared `FileSystem` abstraction.
+
+## Scope
+
+This change covers read-only filesystem operations needed by WAL loading. WAL segment writing remains in `WALManager`, where mmap and file synchronization require concrete `std::fs::File` handles and are outside this review item.
+
+## Common Filesystem API
+
+Extend `FileSystem` with two asynchronous methods:
+
+- `read_dir(&self, path: &str) -> io::Result<Vec<FileSystemEntry>>`
+- `read(&self, path: &Path) -> io::Result<Vec<u8>>`
+
+`FileSystemEntry` contains an owned `PathBuf` and an `is_file` boolean. This keeps Tokio-specific types and metadata access inside `RealFileSystem` while giving mock implementations a simple owned value. `RealFileSystem` collects the complete Tokio directory stream and propagates iteration and file-type errors.
+
+## WALBuilder Construction
+
+`WALBuilder` stores `Arc<dyn FileSystem + Send + Sync>`.
+
+`WALBuilder::new(config)` remains the production convenience constructor and installs `RealFileSystem`. `WALBuilder::with_file_system(config, file_system)` provides explicit dependency injection for callers and tests. Keeping `new` avoids mechanical changes to every existing call site while still making the dependency replaceable.
+
+## WAL Loading Flow
+
+`load_data` calls `self.file_system.read_dir(&config.wal_directory)` and applies the existing regular-file, extension, hexadecimal sequence, sorting, and checkpoint-boundary logic to the returned entries. Each selected segment is loaded with `self.file_system.read(&path)` while preserving the existing path-aware error messages.
+
+No `tokio::fs` or `std::fs` access remains in `builder.rs`.
+
+## Testing
+
+Add mock-driven tests that:
+
+- Return two segment paths and their framed contents through `MockFileSystem`, then assert both pending entries are loaded in sequence order.
+- Return a directory-read error and assert `WALBuilder::build` propagates it.
+- Return a segment-read error and assert the error retains the affected path.
+
+Existing real-filesystem WAL manager and recovery tests remain integration coverage for `RealFileSystem`.
+
+## Error Handling
+
+Common filesystem methods return `io::Error`. `WALBuilder` maps these into the existing `WALError` messages. Directory iteration errors are no longer hidden inside the concrete implementation, and segment read errors continue to identify the segment path.

--- a/docs/superpowers/specs/2026-07-19-wal-multi-segment-replay-design.md
+++ b/docs/superpowers/specs/2026-07-19-wal-multi-segment-replay-design.md
@@ -1,0 +1,47 @@
+# WAL Multi-Segment Replay Design
+
+## Goal
+
+Prevent recovery data loss by replaying every WAL mutation after the most recent checkpoint, even when those mutations span multiple segment files, and stop recovery without checkpointing when any replay entry fails.
+
+## Scope
+
+This change covers multi-segment WAL discovery and replay failure propagation. Transaction-aware replay and enforcement of the `wal_enabled` configuration remain outside this change.
+
+## WAL Loading
+
+`WALBuilder` discovers every regular file whose extension matches `wal_extension` and whose stem is a valid hexadecimal segment sequence. It sorts those files by numeric sequence and reads them in ascending order.
+
+Every discovered segment is read and decoded with the existing framed WAL decoder. A read error, truncated frame, or invalid encoded entry fails the build. Recovery must not silently skip an unreadable segment because a later segment can depend on mutations recorded in it.
+
+The builder combines decoded entries in sequence order and retains only entries after the last `Checkpoint`. A checkpoint therefore establishes the recovery boundary across segment files rather than only within the newest file.
+
+The writer resumes the highest existing segment when its last decoded entry is not a checkpoint, using that segment's measured frame offset. If the newest segment ends in a checkpoint, it starts at the following sequence with offset zero. An empty highest segment is treated as the current writable segment at offset zero.
+
+## Replay Failure Semantics
+
+`DBEngine::replay_wal` processes pending entries in order. Payload deserialization failures and mutation execution failures are returned immediately. Recovery does not continue past the failed entry because later operations may depend on it.
+
+`recover_from_wal` preserves its ordering:
+
+1. Replay all pending WAL entries.
+2. Flush replay-created row buffers durably.
+3. Write and sync the recovery checkpoint.
+
+An error in either of the first two steps returns before `WALManager::flush`, leaving the WAL recovery boundary intact for diagnosis and a later retry. A successful recovery checkpoints the replayed entries as before.
+
+## Error Handling
+
+Errors identify the segment path when file reading or decoding fails. Replay errors identify the entry type and its position in the pending sequence while retaining the underlying error text. Startup propagates these errors and does not accept client connections with partially recovered state.
+
+## Testing
+
+Tests follow a red-green sequence and cover:
+
+- Loading pending entries from two uncheckpointed segments in sequence order.
+- Excluding entries at and before the last checkpoint when the checkpoint is in an earlier segment.
+- Rejecting a corrupt intermediate segment even when a later valid segment exists.
+- Returning an error for an invalid replay payload instead of skipping it.
+- Verifying that failed recovery does not append a checkpoint.
+
+Existing single-segment loading, WAL append, rotation, durability flush, and replay tests remain regression coverage. The focused WAL tests run first, followed by the complete test suite and Clippy.

--- a/src/common/fs.rs
+++ b/src/common/fs.rs
@@ -1,10 +1,19 @@
 use futures::io;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FileSystemEntry {
+    pub path: PathBuf,
+    pub is_file: bool,
+}
 
 #[mockall::automock]
 #[async_trait::async_trait]
 pub trait FileSystem {
     async fn create_dir(&self, path: &str) -> io::Result<()>;
     async fn write_file(&self, path: &str, content: &[u8]) -> io::Result<()>;
+    async fn read_dir(&self, path: &str) -> io::Result<Vec<FileSystemEntry>>;
+    async fn read(&self, path: &Path) -> io::Result<Vec<u8>>;
 }
 
 pub struct RealFileSystem;
@@ -17,5 +26,23 @@ impl FileSystem for RealFileSystem {
 
     async fn write_file(&self, path: &str, content: &[u8]) -> io::Result<()> {
         tokio::fs::write(path, content).await
+    }
+
+    async fn read_dir(&self, path: &str) -> io::Result<Vec<FileSystemEntry>> {
+        let mut directory = tokio::fs::read_dir(path).await?;
+        let mut entries = Vec::new();
+
+        while let Some(entry) = directory.next_entry().await? {
+            entries.push(FileSystemEntry {
+                path: entry.path(),
+                is_file: entry.file_type().await?.is_file(),
+            });
+        }
+
+        Ok(entries)
+    }
+
+    async fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
+        tokio::fs::read(path).await
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -140,10 +140,10 @@ impl DBEngine {
     /// PostgreSQL's redo phase). A single entry failing to reapply (e.g. a
     /// unique-constraint violation, which -- since WAL is written before the
     /// mutation -- would also have failed the first time around and so never
-    /// actually took effect) is logged and does not abort the rest of
-    /// recovery.
+    /// actually took effect) aborts recovery so that the WAL is preserved for
+    /// diagnosis and a later retry.
     pub async fn replay_wal(&self, entries: &[WALEntry]) -> errors::Result<()> {
-        for entry in entries {
+        for (index, entry) in entries.iter().enumerate() {
             let data = entry.data.as_deref();
 
             let result: errors::Result<()> = async {
@@ -176,13 +176,12 @@ impl DBEngine {
             }
             .await;
 
-            if let Err(error) = result {
-                log::warn!(
-                    "WAL replay: skipping entry {:?} due to error: {}",
-                    entry.entry_type,
-                    error
-                );
-            }
+            result.map_err(|error| {
+                ExecuteError::wrap(format!(
+                    "WAL replay failed at entry {} ({:?}): {}",
+                    index, entry.entry_type, error
+                ))
+            })?;
         }
 
         Ok(())
@@ -278,6 +277,27 @@ mod tests {
     use crate::engine::ast::types::{Column, DataType, TableName};
     use crate::engine::encoder::schema_encoder::StorageEncoder;
     use crate::engine::schema::table::TableSchema;
+    use crate::engine::wal::types::{EntryType, WALEntry};
+
+    #[tokio::test]
+    async fn replay_wal_returns_contextual_error_for_invalid_payload() {
+        let config = LaunchConfig::default_for_base_path(PathBuf::from(
+            "target/test_wal_replay/invalid_payload",
+        ));
+        let engine = DBEngine::new(config);
+        let entry = WALEntry {
+            entry_type: EntryType::Insert,
+            data: Some(vec![0xff]),
+            timestamp: 1,
+            transaction_id: None,
+            is_continuation: false,
+        };
+
+        let error = engine.replay_wal(&[entry]).await.unwrap_err();
+
+        assert!(error.to_string().contains("entry 0"));
+        assert!(error.to_string().contains("Insert"));
+    }
 
     #[tokio::test]
     async fn get_table_config_cached_reuses_loaded_schema() {

--- a/src/engine/wal/manager/builder.rs
+++ b/src/engine/wal/manager/builder.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
+use crate::common::fs::{FileSystem, RealFileSystem};
 use crate::config::launch_config::LaunchConfig;
 use crate::engine::wal::endec::{WALDecoder, WALEncoder};
 use crate::engine::wal::types::{EntryType, WALEntry};
@@ -10,11 +12,22 @@ use super::WALManager;
 
 pub struct WALBuilder<'a> {
     config: &'a LaunchConfig,
+    file_system: Arc<dyn FileSystem + Send + Sync>,
 }
 
 impl<'a> WALBuilder<'a> {
     pub fn new(config: &'a LaunchConfig) -> Self {
-        Self { config }
+        Self::with_file_system(config, Arc::new(RealFileSystem))
+    }
+
+    pub fn with_file_system(
+        config: &'a LaunchConfig,
+        file_system: Arc<dyn FileSystem + Send + Sync>,
+    ) -> Self {
+        Self {
+            config,
+            file_system,
+        }
     }
 
     pub async fn build<T, D>(&self, decoder: T, encoder: D) -> errors::Result<WALManager<D>>
@@ -39,78 +52,75 @@ impl<'a> WALBuilder<'a> {
     where
         T: WALDecoder<Vec<WALEntry>>,
     {
-        let mut max_sequence = 0;
-        let mut last_log_path: Option<PathBuf> = None;
+        let mut segments = Vec::new();
 
-        let mut dir_entries = tokio::fs::read_dir(&self.config.wal_directory)
+        let dir_entries = self
+            .file_system
+            .read_dir(&self.config.wal_directory)
             .await
             .map_err(|e| WALError::wrap(e.to_string()))?;
 
-        while let Ok(Some(entry)) = dir_entries.next_entry().await {
-            let path = entry.path();
-
-            if !path.is_file() {
+        for entry in dir_entries {
+            if !entry.is_file {
                 continue;
             }
+            let path = entry.path;
 
             // 파일 명 16진수로 변환
-            let wrapped_parsed_seq = path
+            let sequence = path
                 .extension()
                 .filter(|ext_osstr| ext_osstr.to_str() == Some(self.config.wal_extension.as_str()))
                 .and_then(|_| path.file_stem())
                 .and_then(|stem_osstr| stem_osstr.to_str())
                 .and_then(|stem_str| usize::from_str_radix(stem_str, 16).ok());
 
-            if let Some(seq) = wrapped_parsed_seq
-                && seq > max_sequence
-            {
-                max_sequence = seq;
-                last_log_path = Some(path);
+            if let Some(sequence) = sequence {
+                segments.push((sequence, path));
             }
         }
 
-        let (current_sequence, entries, current_offset) = match last_log_path {
-            // Case 1: WAL 파일이 하나도 없는 초기 상태
-            None => {
-                // 첫 번째 WAL 파일이므로 시퀀스는 1로 시작하고, 복구할 엔트리는 없음
-                Ok::<(usize, Vec<WALEntry>, usize), errors::Errors>((1, Vec::new(), 0))
+        segments.sort_by_key(|(sequence, _)| *sequence);
+
+        let Some((max_sequence, _)) = segments.last() else {
+            return Ok((1, Vec::new(), 0));
+        };
+        let max_sequence = *max_sequence;
+        let mut pending_entries = Vec::new();
+        let mut newest_ends_with_checkpoint = false;
+        let mut newest_offset = 0;
+
+        for (sequence, path) in segments {
+            let content = self.file_system.read(&path).await.map_err(|e| {
+                WALError::wrap(format!("failed to read log file {:?}: {}", path, e))
+            })?;
+            let used_bytes = used_wal_bytes(&content).map_err(|e| {
+                WALError::wrap(format!("failed to inspect log file {:?}: {}", path, e))
+            })?;
+            let entries: Vec<WALEntry> = decoder.decode(&content).map_err(|e| {
+                WALError::wrap(format!("failed to decode log file {:?}: {}", path, e))
+            })?;
+
+            if sequence == max_sequence {
+                newest_offset = used_bytes;
+                newest_ends_with_checkpoint = entries
+                    .last()
+                    .is_some_and(|entry| matches!(entry.entry_type, EntryType::Checkpoint));
             }
-            // Case 2: 최신 WAL 파일이 존재하는 상태
-            Some(log_path) => {
-                // 최신 WAL 파일의 내용을 읽음
-                let content = tokio::fs::read(&log_path).await.map_err(|e| {
-                    WALError::wrap(format!("failed to read log file {:?}: {}", log_path, e))
-                })?;
 
-                // 파일 내용이 비어있는 경우 복구할 엔트리는 없음
-                if content.is_empty() {
-                    return Ok((max_sequence + 1, Vec::new(), 0));
-                }
-
-                let used_bytes = used_wal_bytes(&content)?;
-                let saved_entries: Vec<WALEntry> = decoder.decode(&content).map_err(|e| {
-                    WALError::wrap(format!(
-                        "failed to decode log file {:?}: {}",
-                        log_path,
-                        e.to_string()
-                    ))
-                })?;
-
-                let last_entry = match saved_entries.last() {
-                    Some(entry) => entry,
-                    None => return Ok((max_sequence + 1, Vec::new(), 0)),
-                };
-
-                if matches!(last_entry.entry_type, EntryType::Checkpoint) {
-                    Ok((max_sequence + 1, Vec::new(), 0))
+            for entry in entries {
+                if matches!(entry.entry_type, EntryType::Checkpoint) {
+                    pending_entries.clear();
                 } else {
-                    // 마지막 엔트리가 체크포인트가 아니면 비정상 종료로 간주
-                    Ok((max_sequence, saved_entries, used_bytes))
+                    pending_entries.push(entry);
                 }
             }
-        }?;
+        }
 
-        Ok((current_sequence, entries, current_offset))
+        if newest_ends_with_checkpoint {
+            Ok((max_sequence + 1, pending_entries, 0))
+        } else {
+            Ok((max_sequence, pending_entries, newest_offset))
+        }
     }
 }
 

--- a/src/engine/wal/manager/mod.rs
+++ b/src/engine/wal/manager/mod.rs
@@ -290,12 +290,14 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::fs::{FileSystemEntry, MockFileSystem};
     use crate::config::launch_config::LaunchConfig;
     use crate::engine::wal::endec::WALDecoder;
     use crate::engine::wal::endec::implements::bincode::{BincodeDecoder, BincodeEncoder};
     use crate::engine::wal::manager::builder::WALBuilder;
     use crate::engine::wal::types::{EntryType, WALEntry};
     use std::path::{Path, PathBuf};
+    use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
     use tokio::io::AsyncWriteExt;
 
@@ -347,6 +349,19 @@ mod tests {
         }
     }
 
+    fn encode_entries(entries: &[WALEntry]) -> Vec<u8> {
+        let encoder = BincodeEncoder::new();
+        let mut content = Vec::new();
+
+        for entry in entries {
+            let encoded = encoder.encode(entry).unwrap();
+            content.extend_from_slice(&u32::try_from(encoded.len()).unwrap().to_le_bytes());
+            content.extend_from_slice(&encoded);
+        }
+
+        content
+    }
+
     async fn write_wal_file(config: &LaunchConfig, sequence: usize, entries: &Vec<WALEntry>) {
         let encoder = BincodeEncoder::new();
         let file_path = PathBuf::from(&config.wal_directory)
@@ -393,6 +408,105 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_build_reads_segments_through_injected_file_system() {
+        let config = get_test_config(Path::new("/virtual/wal"));
+        let segment_1 = PathBuf::from("/virtual/wal/00000001.waltest");
+        let segment_2 = PathBuf::from("/virtual/wal/00000002.waltest");
+        let content_1 = encode_entries(&[create_entry(EntryType::Insert, Some("first"))]);
+        let content_2 = encode_entries(&[create_entry(EntryType::Delete, Some("second"))]);
+        let mut file_system = MockFileSystem::new();
+
+        let listed_segment_1 = segment_1.clone();
+        let listed_segment_2 = segment_2.clone();
+        file_system
+            .expect_read_dir()
+            .with(mockall::predicate::eq(config.wal_directory.clone()))
+            .times(1)
+            .return_once(move |_| {
+                Ok(vec![
+                    FileSystemEntry {
+                        path: listed_segment_2,
+                        is_file: true,
+                    },
+                    FileSystemEntry {
+                        path: listed_segment_1,
+                        is_file: true,
+                    },
+                ])
+            });
+        file_system.expect_read().times(2).returning(move |path| {
+            if path.ends_with("00000001.waltest") {
+                Ok(content_1.clone())
+            } else {
+                Ok(content_2.clone())
+            }
+        });
+
+        let wal_manager = WALBuilder::with_file_system(&config, Arc::new(file_system))
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .unwrap();
+
+        let payloads: Vec<_> = wal_manager
+            .pending_entries()
+            .iter()
+            .map(|entry| entry.data.clone().unwrap())
+            .collect();
+        assert_eq!(payloads, vec![b"first".to_vec(), b"second".to_vec()]);
+    }
+
+    #[tokio::test]
+    async fn test_build_propagates_injected_directory_read_error() {
+        let config = get_test_config(Path::new("/virtual/wal"));
+        let mut file_system = MockFileSystem::new();
+        file_system
+            .expect_read_dir()
+            .times(1)
+            .return_once(|_| Err(std::io::Error::other("directory unavailable")));
+
+        let error = match WALBuilder::with_file_system(&config, Arc::new(file_system))
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+        {
+            Ok(_) => panic!("directory read error was ignored"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("directory unavailable"));
+    }
+
+    #[tokio::test]
+    async fn test_build_preserves_segment_path_for_injected_read_error() {
+        let config = get_test_config(Path::new("/virtual/wal"));
+        let segment = PathBuf::from("/virtual/wal/00000001.waltest");
+        let mut file_system = MockFileSystem::new();
+        file_system.expect_read_dir().times(1).return_once({
+            let segment = segment.clone();
+            move |_| {
+                Ok(vec![FileSystemEntry {
+                    path: segment,
+                    is_file: true,
+                }])
+            }
+        });
+        file_system
+            .expect_read()
+            .times(1)
+            .return_once(|_| Err(std::io::Error::other("segment unavailable")));
+
+        let error = match WALBuilder::with_file_system(&config, Arc::new(file_system))
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+        {
+            Ok(_) => panic!("segment read error was ignored"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("00000001.waltest"));
+        assert!(error.to_string().contains("segment unavailable"));
+    }
+
+    #[tokio::test]
     async fn test_build_single_file_with_checkpoint() {
         let wal_dir = setup_test_wal_dir("single_file_checkpoint").await;
         let config = get_test_config(&wal_dir);
@@ -418,6 +532,108 @@ mod tests {
             wal_manager.buffers.is_empty(),
             "Buffers should be empty after a checkpointed file"
         );
+    }
+
+    #[tokio::test]
+    async fn test_build_loads_pending_entries_from_all_segments() {
+        let wal_dir = setup_test_wal_dir("multi_segment_pending").await;
+        let config = get_test_config(&wal_dir);
+        write_wal_file(
+            &config,
+            1,
+            &vec![create_entry(EntryType::Insert, Some("segment-1"))],
+        )
+        .await;
+        write_wal_file(
+            &config,
+            2,
+            &vec![create_entry(EntryType::Delete, Some("segment-2"))],
+        )
+        .await;
+
+        let wal_manager = WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .unwrap();
+
+        let payloads: Vec<_> = wal_manager
+            .pending_entries()
+            .iter()
+            .map(|entry| entry.data.clone().unwrap())
+            .collect();
+        assert_eq!(payloads, vec![b"segment-1".to_vec(), b"segment-2".to_vec()]);
+        assert_eq!(wal_manager.current_sequence(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_build_keeps_only_entries_after_last_checkpoint_across_segments() {
+        let wal_dir = setup_test_wal_dir("checkpoint_across_segments").await;
+        let config = get_test_config(&wal_dir);
+        write_wal_file(
+            &config,
+            1,
+            &vec![
+                create_entry(EntryType::Insert, Some("durable")),
+                create_entry(EntryType::Checkpoint, None),
+            ],
+        )
+        .await;
+        write_wal_file(
+            &config,
+            2,
+            &vec![create_entry(EntryType::Set, Some("pending"))],
+        )
+        .await;
+
+        let wal_manager = WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .unwrap();
+
+        assert_eq!(wal_manager.pending_entries().len(), 1);
+        assert!(matches!(
+            wal_manager.pending_entries()[0].entry_type,
+            EntryType::Set
+        ));
+        assert_eq!(
+            wal_manager.pending_entries()[0].data,
+            Some(b"pending".to_vec())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_rejects_corrupt_intermediate_segment() {
+        let wal_dir = setup_test_wal_dir("corrupt_intermediate_segment").await;
+        let config = get_test_config(&wal_dir);
+        write_wal_file(
+            &config,
+            1,
+            &vec![create_entry(EntryType::Insert, Some("first"))],
+        )
+        .await;
+        tokio::fs::write(
+            wal_dir.join(format!("00000002.{}", config.wal_extension)),
+            [8, 0, 0, 0, 1, 2],
+        )
+        .await
+        .unwrap();
+        write_wal_file(
+            &config,
+            3,
+            &vec![create_entry(EntryType::Delete, Some("last"))],
+        )
+        .await;
+
+        let error = match WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+        {
+            Ok(_) => panic!("corrupt intermediate WAL segment was accepted"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("00000002"));
+        assert!(error.to_string().contains("truncated wal frame body"));
     }
 
     #[tokio::test]
@@ -497,6 +713,9 @@ mod tests {
 
         assert!(wal_manager.current_segment.is_some());
         assert_eq!(wal_manager.buffers.len(), 1);
-        assert_eq!(wal_manager.current_offset, wal_manager.current_segment.as_ref().unwrap().offset);
+        assert_eq!(
+            wal_manager.current_offset,
+            wal_manager.current_segment.as_ref().unwrap().offset
+        );
     }
 }

--- a/src/engine/wal/recovery.rs
+++ b/src/engine/wal/recovery.rs
@@ -17,3 +17,56 @@ impl DBEngine {
         wal_manager.flush().await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use crate::config::launch_config::LaunchConfig;
+    use crate::engine::wal::endec::WALDecoder;
+    use crate::engine::wal::endec::implements::bincode::{BincodeDecoder, BincodeEncoder};
+    use crate::engine::wal::manager::builder::WALBuilder;
+    use crate::engine::wal::types::EntryType;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn failed_recovery_does_not_append_checkpoint() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let base_path = PathBuf::from("target")
+            .join("test_wal_recovery")
+            .join(format!("failed_recovery_{suffix}"));
+        let config = LaunchConfig::default_for_base_path(&base_path);
+        tokio::fs::create_dir_all(&config.wal_directory)
+            .await
+            .unwrap();
+
+        let mut wal_manager = WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .unwrap();
+        wal_manager
+            .append_record(EntryType::Insert, Some(vec![0xff]), None)
+            .await
+            .unwrap();
+        wal_manager.sync().await.unwrap();
+
+        let engine = DBEngine::new(config.clone());
+        assert!(engine.recover_from_wal(&mut wal_manager).await.is_err());
+
+        let wal_path =
+            PathBuf::from(&config.wal_directory).join(format!("00000001.{}", config.wal_extension));
+        let content = tokio::fs::read(wal_path).await.unwrap();
+        let entries = BincodeDecoder::new().decode(&content).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert!(
+            !entries
+                .iter()
+                .any(|entry| matches!(entry.entry_type, EntryType::Checkpoint))
+        );
+    }
+}


### PR DESCRIPTION
resolves: #227

## 설명
WAL 복구 관련 미비한 부분 처리


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 여러 WAL 세그먼트에 걸친 복구를 지원해 최신 체크포인트 이후의 기록을 순서대로 재생합니다.
  - 손상되거나 읽을 수 없는 중간 세그먼트는 복구 실패로 처리합니다.
  - WAL 재생 중 오류가 발생하면 이후 기록을 건너뛰지 않고 즉시 복구를 중단합니다.
  - 복구 실패 시 불필요한 체크포인트가 WAL에 추가되지 않습니다.

- **문서**
  - 멀티 세그먼트 WAL 복구 동작과 검증 절차를 설명하는 설계 및 구현 계획을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->