### PR TITLE
[#237] fix: 토크나이저 EOF 경계 처리 보정

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ path = "./src/test.rs"
 
 [[bench]]
 name = "index_benchmark"
-path = "./benches/index_benchmark.rs"
+path = "./src/benches/index_benchmark.rs"
 harness = false
 
 [features]

--- a/src/engine/lexer/test/eof.rs
+++ b/src/engine/lexer/test/eof.rs
@@ -1,0 +1,176 @@
+//! 입력 끝(EOF) 경계에서의 토크나이저 동작 회귀 테스트.
+//!
+//! 관련 이슈: #237
+#[cfg(test)]
+use crate::engine::lexer::predule::{OperatorToken, Token, Tokenizer};
+
+#[test]
+pub fn test_token_before_eof_is_not_dropped() {
+    struct TestCase {
+        name: String,
+        input: String,
+        expected: Vec<Token>,
+    }
+
+    let test_cases = vec![
+        TestCase {
+            name: "세미콜론 없이 닫는 괄호로 끝나는 입력".to_owned(),
+            input: "create index foo_id_idx on foo (id)".to_owned(),
+            expected: vec![
+                Token::Create,
+                Token::Index,
+                Token::Identifier("foo_id_idx".to_owned()),
+                Token::On,
+                Token::Identifier("foo".to_owned()),
+                Token::LeftParentheses,
+                Token::Identifier("id".to_owned()),
+                Token::RightParentheses,
+            ],
+        },
+        TestCase {
+            name: "닫는 괄호로 끝나는 표현식".to_owned(),
+            input: "select (1)".to_owned(),
+            expected: vec![
+                Token::Select,
+                Token::LeftParentheses,
+                Token::Integer(1),
+                Token::RightParentheses,
+            ],
+        },
+        TestCase {
+            name: "여는 괄호로 끝나는 입력".to_owned(),
+            input: "select (".to_owned(),
+            expected: vec![Token::Select, Token::LeftParentheses],
+        },
+        TestCase {
+            name: "세미콜론으로 끝나는 입력".to_owned(),
+            input: "select 1;".to_owned(),
+            expected: vec![Token::Select, Token::Integer(1), Token::SemiColon],
+        },
+        TestCase {
+            name: "쉼표로 끝나는 입력".to_owned(),
+            input: "select 1,".to_owned(),
+            expected: vec![Token::Select, Token::Integer(1), Token::Comma],
+        },
+        TestCase {
+            name: "마침표로 끝나는 입력".to_owned(),
+            input: "select foo.".to_owned(),
+            expected: vec![
+                Token::Select,
+                Token::Identifier("foo".to_owned()),
+                Token::Period,
+            ],
+        },
+        TestCase {
+            name: "단항 연산자로 끝나는 입력".to_owned(),
+            input: "select 1 <".to_owned(),
+            expected: vec![
+                Token::Select,
+                Token::Integer(1),
+                Token::Operator(OperatorToken::Lt),
+            ],
+        },
+        TestCase {
+            name: "= 연산자로 끝나는 입력".to_owned(),
+            input: "select 1 =".to_owned(),
+            expected: vec![
+                Token::Select,
+                Token::Integer(1),
+                Token::Operator(OperatorToken::Eq),
+            ],
+        },
+        TestCase {
+            name: "! 연산자로 끝나는 입력".to_owned(),
+            input: "select !".to_owned(),
+            expected: vec![Token::Select, Token::Operator(OperatorToken::Not)],
+        },
+        TestCase {
+            name: "- 연산자로 끝나는 입력".to_owned(),
+            input: "select -".to_owned(),
+            expected: vec![Token::Select, Token::Operator(OperatorToken::Minus)],
+        },
+        TestCase {
+            name: "/ 연산자로 끝나는 입력".to_owned(),
+            input: "select 4 /".to_owned(),
+            expected: vec![
+                Token::Select,
+                Token::Integer(4),
+                Token::Operator(OperatorToken::Slash),
+            ],
+        },
+        TestCase {
+            name: "숫자로 끝나는 입력".to_owned(),
+            input: "select 42".to_owned(),
+            expected: vec![Token::Select, Token::Integer(42)],
+        },
+        TestCase {
+            name: "문자열로 끝나는 입력".to_owned(),
+            input: "select 'abc'".to_owned(),
+            expected: vec![Token::Select, Token::String("abc".to_owned())],
+        },
+        TestCase {
+            name: "따옴표 식별자로 끝나는 입력".to_owned(),
+            input: "select \"abc\"".to_owned(),
+            expected: vec![Token::Select, Token::Identifier("abc".to_owned())],
+        },
+        TestCase {
+            name: "백틱 식별자로 끝나는 입력".to_owned(),
+            input: "select `abc`".to_owned(),
+            expected: vec![Token::Select, Token::Identifier("abc".to_owned())],
+        },
+        TestCase {
+            name: "공백으로 끝나는 입력".to_owned(),
+            input: "select (id) ".to_owned(),
+            expected: vec![
+                Token::Select,
+                Token::LeftParentheses,
+                Token::Identifier("id".to_owned()),
+                Token::RightParentheses,
+            ],
+        },
+    ];
+
+    for t in test_cases {
+        let got = Tokenizer::string_to_tokens(t.input.clone());
+
+        assert!(got.is_ok(), "{}: 토큰화 실패: {:?}", t.name, got.err());
+        assert_eq!(got.unwrap(), t.expected, "{}", t.name);
+    }
+}
+
+#[test]
+pub fn test_unterminated_quoted_identifier_returns_error() {
+    // 닫는 큰따옴표가 없는 입력은 무한루프 대신 오류로 처리되어야 합니다.
+    let got = Tokenizer::string_to_tokens("select \"abc".to_owned());
+
+    assert!(got.is_err(), "unterminated quoted identifier: {:?}", got);
+}
+
+#[test]
+pub fn test_comment_at_eof() {
+    // 행 주석이 개행 없이 입력 끝에서 종료되는 경우
+    assert_eq!(
+        Tokenizer::string_to_tokens("select 1 -- comment".to_owned()).unwrap(),
+        vec![
+            Token::Select,
+            Token::Integer(1),
+            Token::CodeComment(" comment".to_owned()),
+        ],
+    );
+
+    // 행 주석 뒤에 개행과 토큰이 이어지는 경우
+    assert_eq!(
+        Tokenizer::string_to_tokens("select -- comment\n1".to_owned()).unwrap(),
+        vec![
+            Token::Select,
+            Token::CodeComment(" comment".to_owned()),
+            Token::Integer(1),
+        ],
+    );
+
+    // 블록 주석이 입력 끝에서 닫히는 경우
+    assert_eq!(
+        Tokenizer::string_to_tokens("select /* comment */".to_owned()).unwrap(),
+        vec![Token::Select, Token::CodeComment(" comment ".to_owned())],
+    );
+}

--- a/src/engine/lexer/test/mod.rs
+++ b/src/engine/lexer/test/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod comment;
+pub(crate) mod eof;
 pub(crate) mod select;

--- a/src/engine/lexer/tokenizer.rs
+++ b/src/engine/lexer/tokenizer.rs
@@ -7,6 +7,9 @@ pub struct Tokenizer {
     buffer: Vec<char>,
     buffer_index: usize,
     last_char: char,
+    // last_char에 아직 토큰으로 소비되지 않은 입력 문자가 들어있는지 여부.
+    // 버퍼 끝을 넘어서 읽은 경우에는 false가 됩니다.
+    has_pending_char: bool,
 }
 
 impl Tokenizer {
@@ -16,6 +19,7 @@ impl Tokenizer {
             last_char: ' ',
             buffer: text.chars().collect(),
             buffer_index: 0,
+            has_pending_char: false,
         }
     }
 
@@ -64,25 +68,47 @@ impl Tokenizer {
     }
 
     pub fn is_eof(&self) -> bool {
-        self.buffer_index >= self.buffer.len()
+        // 버퍼를 모두 읽었더라도 아직 토큰화되지 않은 선행 문자가 남아있다면 EOF가 아닙니다.
+        self.buffer_index >= self.buffer.len() && !self.has_pending_char
+    }
+
+    // 버퍼에 아직 읽지 않은 문자가 남아있는지 확인합니다.
+    fn has_more_char(&self) -> bool {
+        self.buffer_index < self.buffer.len()
     }
 
     // 버퍼에서 문자 하나를 읽어서 last_char에 보관합니다.
     pub fn read_char(&mut self) {
         if self.buffer_index >= self.buffer.len() {
             self.last_char = ' ';
+            self.has_pending_char = false;
         } else {
             self.last_char = self.buffer[self.buffer_index];
             self.buffer_index += 1;
+            self.has_pending_char = true;
         }
     }
 
     // 보관했던 문자 하나를 다시 버퍼에 돌려놓습니다.
     pub fn unread_char(&mut self) {
+        // 버퍼 끝을 넘어서 읽은 경우에는 되돌릴 문자가 없습니다.
+        // 이때 인덱스를 되돌리면 마지막 문자를 중복해서 읽게 됩니다.
+        if !self.has_pending_char {
+            return;
+        }
+
         if self.buffer_index != 0 {
             self.buffer_index -= 1;
             self.last_char = self.buffer[self.buffer_index];
         }
+
+        self.has_pending_char = false;
+    }
+
+    // 보관 중인 문자를 토큰으로 소비 처리합니다.
+    fn consume_last_char(&mut self) {
+        self.last_char = ' ';
+        self.has_pending_char = false;
     }
 
     // 주어진 텍스트에서 토큰을 순서대로 획득해 반환합니다.
@@ -238,7 +264,9 @@ impl Tokenizer {
                     if self.last_char == '-' {
                         let mut comment = vec![];
 
-                        while !self.is_eof() {
+                        // 주석은 개행 또는 입력의 끝까지 읽습니다.
+                        // 버퍼 끝을 넘어 읽으면 공백이 덧붙으므로 버퍼 잔량으로 판단합니다.
+                        while self.has_more_char() {
                             self.read_char();
 
                             if self.last_char == '\n' {
@@ -249,6 +277,7 @@ impl Tokenizer {
                         }
 
                         let comment: String = comment.into_iter().collect();
+                        self.consume_last_char();
                         Token::CodeComment(comment)
                     } else {
                         self.unread_char();
@@ -264,7 +293,7 @@ impl Tokenizer {
                         let mut comment = vec![];
 
                         self.read_char();
-                        while !self.is_eof() {
+                        while self.has_more_char() {
                             if self.last_char == '*' {
                                 self.read_char();
                                 if self.last_char == '/' {
@@ -278,6 +307,7 @@ impl Tokenizer {
                         }
 
                         let comment: String = comment.into_iter().collect();
+                        self.consume_last_char();
                         Token::CodeComment(comment)
                     } else {
                         self.unread_char();
@@ -341,11 +371,20 @@ impl Tokenizer {
 
                 self.read_char();
                 while self.last_char != '"' {
+                    // 닫는 큰따옴표 없이 입력이 끝난 경우 무한루프에 빠지지 않도록 오류로 처리
+                    if self.is_eof() {
+                        return Err(LexingError::wrap(
+                            "unterminated quoted identifier: missing closing '\"'",
+                        ));
+                    }
+
                     identifier.push(self.last_char);
                     self.read_char();
                 }
 
                 let identifier: String = identifier.into_iter().collect::<String>();
+
+                self.consume_last_char();
 
                 Token::Identifier(identifier)
             } else {
@@ -428,7 +467,8 @@ impl Tokenizer {
             )));
         };
 
-        self.last_char = ' ';
+        // 방금 토큰으로 소비한 문자를 비웁니다.
+        self.consume_last_char();
 
         Ok(token)
     }
@@ -440,7 +480,15 @@ impl Tokenizer {
         let mut tokens = vec![];
 
         while !tokenizer.is_eof() {
-            tokens.push(tokenizer.get_token()?);
+            let token = tokenizer.get_token()?;
+
+            // 입력 끝에 도달했을 때의 EOF 센티널은 목록에 포함하지 않습니다.
+            // (입력 끝 공백 유무에 따라 결과가 달라지지 않도록 정규화)
+            if token.is_eof() {
+                break;
+            }
+
+            tokens.push(token);
         }
 
         Ok(tokens)

--- a/src/engine/parser/test/index.rs
+++ b/src/engine/parser/test/index.rs
@@ -55,8 +55,7 @@ pub fn create_unique_index_if_not_exists() {
 
 #[test]
 pub fn create_index_without_semicolon() {
-    // 입력 끝의 공백: 토크나이저가 EOF 직전의 ')'를 소실하는 기존 동작 우회
-    let text = "create index foo_id_idx on foo (id) ".to_owned();
+    let text = "create index foo_id_idx on foo (id)".to_owned();
 
     let mut parser = Parser::with_string(text).unwrap();
 


### PR DESCRIPTION
resolves: #237

## 설명

`#237`에서 지적된 토크나이저 EOF 처리 문제를 수정합니다. 조사 과정에서 같은 원인(EOF 판정과 선행 문자 상태의 불일치)에서 파생된 문제 3건을 추가로 발견해 함께 수정했습니다.

### 근본 원인

`is_eof()`는 `buffer_index`만 확인하는데, `read_char()`는 버퍼에서 문자를 하나 미리 읽어 `last_char`에 보관합니다. 그래서 **마지막 문자를 읽은 직후** `buffer_index == buffer.len()`가 되어, 아직 토큰화되지 않은 문자가 `last_char`에 남아있는데도 EOF로 판정되었습니다. `string_to_tokens()`의 루프가 이 시점에서 종료되면서 마지막 토큰이 소실됩니다.

또한 `unread_char()`는 버퍼 끝을 넘어서 읽은 경우에도 인덱스를 되돌려, 마지막 문자를 중복해서 읽게 만들었습니다.

수정: `has_pending_char` 플래그로 "아직 토큰으로 소비되지 않은 선행 문자"의 존재를 추적하고, EOF 판정과 `unread_char()`가 이를 함께 고려하도록 했습니다.

### 수정 내역

1. **EOF 직전 토큰 소실** (#237 본문)

   ```
   "create index foo_id_idx on foo (id)"
   기존: [..., LeftParentheses, Identifier("id")]   // ')' 소실
   수정: [..., LeftParentheses, Identifier("id"), RightParentheses]
   ```

   `)` 뿐 아니라 `;` `,` `.` `<` `=` `!` 등 입력 끝에 오는 모든 구분자/연산자 토큰에 동일하게 영향이 있었습니다.

2. **무한루프 (버그)** — `select "abc` 처럼 닫는 큰따옴표가 없는 입력에서 `while self.last_char != '"'` 루프가 종료되지 않아 토크나이저가 무한히 돕니다. pgwire 쿼리 경로(`Connection::parse_statement`)로도 도달 가능해, 클라이언트가 보낸 한 줄로 커넥션 처리 스레드를 멈출 수 있었습니다. 이제 렉싱 오류를 반환합니다.

3. **주석 토큰 끝 공백 혼입** — 주석 루프가 버퍼 끝을 넘어 읽으면서 `read_char()`가 채우는 공백이 주석 내용에 덧붙던 문제를 수정했습니다.

4. **EOF 센티널 비일관성** — 입력 끝 공백 유무에 따라 결과에 `Token::EOF`가 붙거나 붙지 않았습니다(`"select (id) "` → 붙음, `"select 1 "` → 안 붙음). `string_to_tokens()`가 EOF 센티널을 포함하지 않도록 정규화했습니다.

5. **파서 우회 주석 제거** — `create_index_without_semicolon` 테스트가 우회용으로 붙여둔 끝 공백과 설명 주석을 제거했습니다(#237 acceptance criteria).

6. **bench 타겟 경로 수정** — `Cargo.toml`의 `[[bench]]`가 `./benches/index_benchmark.rs`를 가리키는데, 92e39aa에서 파일이 `src/benches/`로 이동하면서 경로가 어긋나 `cargo fmt --all`과 `cargo bench`가 실패하고 있었습니다. 경로를 맞췄습니다.

### 테스트

`src/engine/lexer/test/eof.rs`에 회귀 테스트를 추가했습니다.

- 16종 입력에 대한 EOF 직전 토큰 보존 (구분자, 연산자, 숫자, 문자열, 따옴표/백틱 식별자, 끝 공백 포함)
- 닫히지 않은 따옴표 식별자가 무한루프 대신 오류를 반환하는지
- 행/블록 주석의 EOF 종료 동작

### 검증

- `cargo test` — 317 + 321 + 5 통과, 실패 0
- `cargo clippy --all-targets` — 오류 0
- `cargo fmt --all -- --check` — 통과
- `cargo bench --no-run` — 빌드 성공 (기존에는 경로 오류로 실패)

포맷 차이가 있는 무관한 파일들은 리뷰 범위를 좁히기 위해 이 PR에 포함하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * EOF에서 입력이 끝날 때 마지막 토큰이 누락되지 않도록 개선했습니다.
  * 닫히지 않은 큰따옴표 식별자는 무한 반복 대신 오류를 반환하도록 했습니다.
  * EOF에서 종료되는 행/블록 주석 처리 및 토큰화 결과에서 EOF 센티널 포함 여부를 수정했습니다.
* **테스트**
  * EOF 경계, 주석, 따옴표 식별자 관련 회귀 테스트를 추가했습니다.
* **유지보수**
  * 벤치마크 소스 경로를 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->