### PR TITLE
[#208] chore: 로그 정돈 — stdout 오염 제거, 관측 공백 보충

### DIFF
--- a/src/engine/initialize.rs
+++ b/src/engine/initialize.rs
@@ -75,9 +75,9 @@ impl DBEngine {
         if let Err(error) = self.file_system.create_dir(base_path).await
             && error.kind() != std::io::ErrorKind::AlreadyExists
         {
-            println!("path {:?}", base_path);
-            println!("error: {:?}", error.to_string());
-            return Err(ExecuteError::wrap(error.to_string()));
+            return Err(ExecuteError::wrap(format!(
+                "failed to create data directory {base_path}: {error}"
+            )));
         }
 
         Ok(())

--- a/src/engine/server/mod.rs
+++ b/src/engine/server/mod.rs
@@ -94,6 +94,9 @@ impl Server {
         if pending_entry_count > 0 {
             log::info!("replaying {} pending WAL entries", pending_entry_count);
             engine.recover_from_wal(&mut wal_manager).await?;
+            log::info!("WAL replay complete ({} entries)", pending_entry_count);
+        } else {
+            log::debug!("no pending WAL entries to replay");
         }
 
         let wal_manager = Arc::new(Mutex::new(wal_manager));
@@ -109,6 +112,12 @@ impl Server {
             .await
             .map_err(|error| ExecuteError::wrap(error.to_string()))?;
 
+        log::info!(
+            "server listening on {}:{}",
+            self.config.host,
+            self.config.port
+        );
+
         let connection_task = tokio::spawn(async move {
             loop {
                 let accepted = listener.accept().await;
@@ -116,7 +125,7 @@ impl Server {
                 let (stream, address) = match accepted {
                     Ok((stream, address)) => (stream, address),
                     Err(error) => {
-                        log::error!("socket error {:?}", error);
+                        log::error!("failed to accept connection: {}", error);
                         continue;
                     }
                 };
@@ -127,6 +136,12 @@ impl Server {
                     database: "None".into(),
                 };
 
+                log::debug!(
+                    "connection accepted from {} (connection_id: {})",
+                    address,
+                    client_info.connection_id
+                );
+
                 let shared_state = SharedState {
                     engine: engine.clone(),
                     wal_manager: wal_manager.clone(),
@@ -134,23 +149,20 @@ impl Server {
                 };
 
                 tokio::spawn(async move {
+                    let connection_id = shared_state.client_info.connection_id.clone();
                     let mut conn = Connection::new(shared_state);
                     if let Err(error) = conn.run(stream).await {
                         if is_expected_disconnect(&error) {
-                            log::debug!("connection closed");
+                            log::debug!("connection {} closed", connection_id);
                         } else {
-                            log::error!("connection error {:?}", error);
+                            log::error!("connection {} failed: {}", connection_id, error);
                         }
+                    } else {
+                        log::debug!("connection {} closed", connection_id);
                     }
                 });
             }
         });
-
-        log::info!(
-            "Server is running on {}:{}",
-            self.config.host,
-            self.config.port
-        );
 
         connection_task
             .await

--- a/src/engine/wal/manager/mod.rs
+++ b/src/engine/wal/manager/mod.rs
@@ -243,6 +243,9 @@ where
     }
 
     async fn checkpoint(&mut self) -> errors::Result<()> {
+        let entry_count = self.buffers.len();
+        let sequence = self.sequence;
+
         self.append_record(EntryType::Checkpoint, None, None)
             .await?;
         self.sync_current_file().await?;
@@ -251,6 +254,13 @@ where
         self.sequence += 1;
         self.buffers.clear();
         self.current_offset = 0;
+
+        log::debug!(
+            "WAL checkpoint written for segment {} ({} buffered entries); rotating to segment {}",
+            sequence,
+            entry_count,
+            self.sequence
+        );
 
         Ok(())
     }


### PR DESCRIPTION
resolves: #208

## 설명

이슈의 세 항목(레벨 조정 / 이상하게 찍는 로그 정리 / 부족한 로그 보충)에 맞춰 정리했습니다. 동작 변경은 없고 로그와 에러 메시지만 손봤습니다.

### 1. 이상하게 찍는 로그 정리

`create_top_level_directory_if_not_exists`가 실패할 때 `println!`로 경로와 에러를 **stdout에** 찍은 뒤 같은 에러를 반환하고 있었습니다.

```rust
println!("path {:?}", base_path);
println!("error: {:?}", error.to_string());
return Err(ExecuteError::wrap(error.to_string()));
```

서버 로그가 stdout으로 새고, 호출자는 같은 내용을 두 번 보게 됩니다. 같은 파일의 다른 실패 경로(config/data/wal 디렉터리 생성)는 모두 조용히 에러만 반환하므로 그쪽에 맞췄고, 진단에 필요한 경로 정보는 에러 메시지에 담아 잃지 않게 했습니다.

### 2. 로그 문구 정리

| 이전 | 이후 | 이유 |
|---|---|---|
| `socket error {:?}` | `failed to accept connection: {}` | Debug 포매팅된 `io::Error` 대신 Display, 그리고 무엇이 실패했는지 명시 |
| `connection error {:?}` | `connection {id} failed: {}` | 동시 접속 시 어느 연결인지 구분 불가능했음 |

### 3. 부족한 로그 보충

- **`server listening`을 bind 직후로 이동** — 기존에는 accept 루프를 spawn한 *뒤* 찍혀서, bind는 성공했는데 아직 안 뜬 것처럼 보이는 구간이 있었습니다.
- **연결 수립 로그 추가** (debug) — 지금까지 연결은 **실패했을 때만** 로그에 남았습니다.
- **정상 종료도 로그로** — `is_expected_disconnect`인 경우만 찍혀서, 에러 없이 끝난 연결은 흔적이 없었습니다.
- **WAL replay 완료 로그** — 시작만 있고 완료가 없어, 복구가 끝났는지 중간에 멈췄는지 로그만으로 판단할 수 없었습니다.
- **WAL checkpoint 로그** (debug) — `src/engine/wal/` 전체에 로그가 **한 줄도 없었습니다**. 세그먼트 회전은 내구성의 핵심 경계라 관측이 필요하다고 봤습니다.

## 레벨 기준

새로 넣은 로그는 연결마다/체크포인트마다 반복되는 것은 `debug`, 서버 수명주기에 한 번씩 찍히는 것은 `info`로 뒀습니다. 기본 필터가 `info`라 평상시 출력량은 늘지 않습니다.

## 검증

- `cargo test` — **637 passed / 0 failed**
- `cargo clippy --lib --bins` — 신규 경고 없음 (기존 8건은 이 PR과 무관한 파일)
- `cargo fmt --check` — 수정한 3개 파일 clean (master에 이미 66건의 fmt 차이가 있어 전체 실행은 기존에도 실패합니다)

로그 레벨 판단은 취향이 갈릴 수 있는 부분이라, 조정하고 싶은 항목 있으면 말씀해 주세요.
