### PR TITLE
[#232] feat: page-backed 인덱스 free-list 재사용과 빈 페이지 회수

### DIFF
--- a/src/engine/index/manager.rs
+++ b/src/engine/index/manager.rs
@@ -425,7 +425,8 @@ impl IndexManager {
                                 Err(e) => {
                                     log::warn!(
                                         "skipping index meta file {:?}: failed to read: {}",
-                                        path, e
+                                        path,
+                                        e
                                     );
                                     continue;
                                 }
@@ -436,7 +437,8 @@ impl IndexManager {
                                 Err(e) => {
                                     log::warn!(
                                         "skipping index meta file {:?}: failed to decode: {}",
-                                        path, e
+                                        path,
+                                        e
                                     );
                                     continue;
                                 }
@@ -454,7 +456,9 @@ impl IndexManager {
                                 Err(e) => {
                                     log::warn!(
                                         "skipping index {:?}: failed to open {:?}: {}",
-                                        meta.index_name, idx_path, e
+                                        meta.index_name,
+                                        idx_path,
+                                        e
                                     );
                                     continue;
                                 }
@@ -762,6 +766,50 @@ mod tests {
         assert!(removed);
 
         assert_eq!(manager.len("idx_name").await.unwrap(), 0);
+    }
+
+    /// Delete-heavy churn through the manager (the path `DELETE` statements
+    /// take) must not grow the index file without bound -- issue #232.
+    #[tokio::test]
+    async fn index_file_stops_growing_under_insert_delete_churn() {
+        let dir = setup_temp_dir("churn_file_size").await;
+        let manager = IndexManager::new(dir.clone());
+
+        let meta = make_meta("idx_id", "id", false);
+        let index_path = dir
+            .join("testdb")
+            .join("tables")
+            .join("testtable")
+            .join("index")
+            .join("idx_id.idx");
+        manager.create_index(meta).await.unwrap();
+
+        let mut sizes = Vec::new();
+        for _ in 0..4 {
+            for i in 0..300 {
+                manager
+                    .insert("idx_id", format!("I:{:05}", i), format!("/r/{}", i))
+                    .await
+                    .unwrap();
+            }
+            for i in 0..300 {
+                assert!(
+                    manager
+                        .remove("idx_id", &format!("I:{:05}", i), &format!("/r/{}", i))
+                        .await
+                        .unwrap()
+                );
+            }
+            sizes.push(tokio::fs::metadata(&index_path).await.unwrap().len());
+        }
+
+        assert_eq!(manager.len("idx_id").await.unwrap(), 0);
+        assert_eq!(
+            sizes.last().unwrap(),
+            sizes.get(1).unwrap(),
+            "index file kept growing across churn rounds: {:?}",
+            sizes
+        );
     }
 
     #[tokio::test]

--- a/src/engine/index/page.rs
+++ b/src/engine/index/page.rs
@@ -22,6 +22,10 @@ pub const PAGE_ENCODING_OVERHEAD: usize = TAG_LEN + LEN_PREFIX_LEN;
 
 const TAG_LEAF: u8 = 1;
 const TAG_INTERNAL: u8 = 2;
+/// A page that has been freed and is linked into the page store's free-list
+/// (issue #232). Its slot stays allocated in the file but is available for
+/// reuse by a later `allocate_page`.
+const TAG_FREE: u8 = 3;
 
 /// A single key -> row_path mapping stored in a leaf page.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -57,6 +61,9 @@ pub struct InternalPage {
 pub enum Page {
     Leaf(LeafPage),
     Internal(InternalPage),
+    /// A freed page slot, holding the id of the next free page in the
+    /// free-list (`None` marks the end of the chain).
+    Free(Option<PageId>),
 }
 
 /// Encode `page` into a `page_size`-byte buffer.
@@ -76,6 +83,11 @@ pub fn encode_page(page: &Page, page_size: usize) -> errors::Result<Vec<u8>> {
             bincode::serialize(internal).map_err(|e| {
                 ExecuteError::wrap(format!("failed to encode internal page: {}", e))
             })?,
+        ),
+        Page::Free(next_free) => (
+            TAG_FREE,
+            bincode::serialize(next_free)
+                .map_err(|e| ExecuteError::wrap(format!("failed to encode free page: {}", e)))?,
         ),
     };
 
@@ -142,6 +154,11 @@ pub fn decode_page(buf: &[u8]) -> errors::Result<Page> {
                 )));
             }
             Ok(Page::Internal(internal))
+        }
+        TAG_FREE => {
+            let next_free: Option<PageId> = bincode::deserialize(payload)
+                .map_err(|e| ExecuteError::wrap(format!("failed to decode free page: {}", e)))?;
+            Ok(Page::Free(next_free))
         }
         other => Err(ExecuteError::wrap(format!("unknown page tag {}", other))),
     }

--- a/src/engine/index/page_btree.rs
+++ b/src/engine/index/page_btree.rs
@@ -78,6 +78,23 @@ impl PageBackedBTreeIndex {
         })
     }
 
+    /// Create an index with a non-default page size. Tests use this to build
+    /// deep/split-heavy trees from far fewer entries than a 4KiB page needs.
+    #[cfg(test)]
+    async fn create_with_page_size(
+        path: &Path,
+        column_name: String,
+        is_unique: bool,
+        page_size: usize,
+    ) -> errors::Result<Self> {
+        let store = PageStore::create(path, page_size).await?;
+        Ok(Self {
+            store,
+            column_name,
+            is_unique,
+        })
+    }
+
     /// Open an existing index file at `path`.
     pub async fn open(path: &Path, column_name: String, is_unique: bool) -> errors::Result<Self> {
         let store = PageStore::open(path).await?;
@@ -106,6 +123,37 @@ impl PageBackedBTreeIndex {
     /// Diagnostic helper, also used by tests.
     pub async fn allocated_page_count(&self) -> errors::Result<PageId> {
         self.store.allocated_page_count().await
+    }
+
+    /// Height of the tree in pages (0 for an empty index, 1 when the root is
+    /// a leaf). Diagnostic helper, also used by tests.
+    pub async fn tree_height(&self) -> errors::Result<usize> {
+        let Some(root_id) = self.store.root_page_id().await? else {
+            return Ok(0);
+        };
+
+        let mut height = 1;
+        let mut current = root_id;
+        loop {
+            match self.store.read_page(current).await? {
+                Page::Leaf(_) => return Ok(height),
+                Page::Internal(internal) => {
+                    current = *internal.children.first().ok_or_else(|| {
+                        ExecuteError::wrap(format!(
+                            "corrupt index: internal page {} has no children",
+                            current
+                        ))
+                    })?;
+                    height += 1;
+                }
+                Page::Free(_) => {
+                    return Err(ExecuteError::wrap(format!(
+                        "corrupt index: tree descent reached freed page {}",
+                        current
+                    )));
+                }
+            }
+        }
     }
 
     /// Read `page_id`, requiring it to be a leaf page.
@@ -456,25 +504,25 @@ impl PageBackedBTreeIndex {
     /// Three things have to stay consistent:
     /// 1. the `next_leaf` chain used by range scans, so the predecessor
     ///    leaf is re-pointed past the removed leaf;
-    /// 2. the parent internal page, which loses the child pointer and the
-    ///    separator key that introduced it;
+    /// 2. the ancestors, which lose the child pointer and the separator key
+    ///    that introduced it -- and which must themselves be reclaimed when
+    ///    that leaves them childless, all the way up;
     /// 3. the root, which is dropped entirely when the last leaf goes away
     ///    and collapsed when an internal root is left with a single child.
     async fn reclaim_empty_leaf(&self, path: &LeafPath) -> errors::Result<()> {
         let leaf_id = path.leaf_id;
         let leaf = self.read_leaf(leaf_id).await?;
 
-        let Some(&(parent_id, child_index)) = path.parents.last() else {
-            // The leaf is the root. An empty root leaf is left in place --
-            // freeing it would mean clearing `root_page_id`, and the empty
-            // tree state is already represented by that being `None`. Only
-            // do so when it truly holds nothing.
+        if path.parents.is_empty() {
+            // The leaf is the root. Clearing `root_page_id` is how the empty
+            // tree state is represented, so only do it when it truly holds
+            // nothing.
             if leaf.entries.is_empty() && leaf.overflow.is_none() {
                 self.store.set_root_page_id(None).await?;
                 self.store.free_page(leaf_id).await?;
             }
             return Ok(());
-        };
+        }
 
         // Re-point the previous leaf in the scan chain past this one.
         if let Some(previous_id) = self.find_previous_leaf(path).await? {
@@ -485,53 +533,81 @@ impl PageBackedBTreeIndex {
                 .await?;
         }
 
-        let mut parent = match self.store.read_page(parent_id).await? {
-            Page::Internal(internal) => internal,
-            _ => {
+        self.store.free_page(leaf_id).await?;
+        self.detach_child_from_ancestors(&path.parents, leaf_id)
+            .await
+    }
+
+    /// Remove `child_id` from the last page in `parents`, then walk back up:
+    /// an ancestor left with no children is itself freed and detached from
+    /// its own parent, and a root left with a single child is collapsed.
+    ///
+    /// `parents` is the recorded descent (`(page_id, child_index)` from the
+    /// root down to `child_id`'s immediate parent).
+    async fn detach_child_from_ancestors(
+        &self,
+        parents: &[(PageId, usize)],
+        child_id: PageId,
+    ) -> errors::Result<()> {
+        let mut removed_child = child_id;
+
+        for depth in (0..parents.len()).rev() {
+            let (page_id, child_index) = parents[depth];
+
+            let mut internal = match self.store.read_page(page_id).await? {
+                Page::Internal(internal) => internal,
+                _ => {
+                    return Err(ExecuteError::wrap(format!(
+                        "corrupt index: expected an internal page at {}",
+                        page_id
+                    )));
+                }
+            };
+
+            if internal.children.get(child_index) != Some(&removed_child) {
                 return Err(ExecuteError::wrap(format!(
-                    "corrupt index: expected an internal page at {}",
-                    parent_id
+                    "corrupt index: page {} does not point at child {} at index {}",
+                    page_id, removed_child, child_index
                 )));
             }
-        };
 
-        if parent.children.get(child_index) != Some(&leaf_id) {
-            return Err(ExecuteError::wrap(format!(
-                "corrupt index: parent {} does not point at leaf {} at index {}",
-                parent_id, leaf_id, child_index
-            )));
-        }
+            internal.children.remove(child_index);
+            // `keys[i]` separates `children[i]` from `children[i + 1]`, so
+            // drop the separator that introduced the removed child: the one
+            // to its left, or (for the leftmost child) the one to its right.
+            if !internal.keys.is_empty() {
+                let key_index = if child_index == 0 { 0 } else { child_index - 1 };
+                internal.keys.remove(key_index);
+            }
 
-        parent.children.remove(child_index);
-        // `keys[i]` separates `children[i]` from `children[i + 1]`, so drop
-        // the separator that introduced the removed child: the one to its
-        // left, or (for the leftmost child) the one to its right.
-        if !parent.keys.is_empty() {
-            let key_index = if child_index == 0 { 0 } else { child_index - 1 };
-            parent.keys.remove(key_index);
-        }
+            if internal.children.is_empty() {
+                // This ancestor lost its last child: free it and keep
+                // unwinding so no childless internal page stays in the tree.
+                self.store.free_page(page_id).await?;
 
-        self.store.free_page(leaf_id).await?;
+                if depth == 0 {
+                    // The root itself is now childless -- the tree is empty.
+                    self.store.set_root_page_id(None).await?;
+                    return Ok(());
+                }
 
-        if parent.children.is_empty() {
-            // Should not happen (a parent always has >= 2 children), but
-            // handle it rather than leaving a childless internal page.
+                removed_child = page_id;
+                continue;
+            }
+
             self.store
-                .write_page(parent_id, &Page::Internal(parent))
+                .write_page(page_id, &Page::Internal(internal.clone()))
                 .await?;
+
+            // A root left with one child adds a pointless level; promote the
+            // child in its place.
+            if depth == 0 && internal.children.len() == 1 {
+                let only_child = internal.children[0];
+                self.store.set_root_page_id(Some(only_child)).await?;
+                self.store.free_page(page_id).await?;
+            }
+
             return Ok(());
-        }
-
-        self.store
-            .write_page(parent_id, &Page::Internal(parent.clone()))
-            .await?;
-
-        // If the root collapsed to a single child, promote that child so the
-        // tree does not accumulate pointless levels.
-        if path.parents.len() == 1 && parent.children.len() == 1 {
-            let only_child = parent.children[0];
-            self.store.set_root_page_id(Some(only_child)).await?;
-            self.store.free_page(parent_id).await?;
         }
 
         Ok(())
@@ -705,7 +781,21 @@ impl PageBackedBTreeIndex {
                 let overflow = self.read_leaf(overflow_id).await?;
                 leaf.entries = overflow.entries;
                 leaf.overflow = overflow.overflow;
-                self.store.write_page(leaf_id, &Page::Leaf(leaf)).await?;
+
+                // The promoted entries were sized to fill a page whose
+                // `next_leaf` was `None`, while this leaf may carry
+                // `Some(..)` -- 4 bytes more under bincode. Overflow pages
+                // are packed entry-by-entry and so normally keep more slack
+                // than that, but re-checking here keeps the delete from
+                // failing mid-way on a write that cannot fit.
+                if super::page::encode_page(&Page::Leaf(leaf.clone()), self.store.page_size())
+                    .is_ok()
+                {
+                    self.store.write_page(leaf_id, &Page::Leaf(leaf)).await?;
+                } else {
+                    self.push_tail_into_overflow(leaf_id, leaf).await?;
+                }
+
                 self.store.free_page(overflow_id).await?;
                 return Ok(true);
             }
@@ -1529,6 +1619,174 @@ mod tests {
         // Range scans see the same surviving entries.
         assert_eq!(idx.range(Some("K:dup"), None).await.unwrap().len(), 10);
         assert_index_is_consistent(&idx).await;
+    }
+
+    /// Draining a leaf that owns an overflow chain must pull the chain head
+    /// back into the leaf (rather than stranding it) and reclaim the page --
+    /// including when the merged page no longer fits its slot, since the
+    /// leaf carries a `next_leaf` pointer the overflow page did not.
+    #[tokio::test]
+    async fn promoting_an_overflow_head_keeps_the_group_and_fits_the_page() {
+        let path = temp_path("overflow_promote_fit.idx");
+        let page_size = 256;
+        let idx =
+            PageBackedBTreeIndex::create_with_page_size(&path, "id".to_string(), false, page_size)
+                .await
+                .unwrap();
+
+        // Build the shape directly: a leaf holding one entry of a duplicate
+        // group, a `next_leaf` pointer, and an overflow page packed with the
+        // rest of the group.
+        let leaf_id = idx.store.allocate_page().await.unwrap();
+        let tail_id = idx.store.allocate_page().await.unwrap();
+        let overflow_id = idx.store.allocate_page().await.unwrap();
+
+        // Fill the overflow page as full as it can go.
+        let mut overflow_entries = Vec::new();
+        loop {
+            let mut candidate = overflow_entries.clone();
+            candidate.push(LeafEntry {
+                key: "B:dup".to_string(),
+                row_path: format!("/r/b{:03}", candidate.len()),
+            });
+            let page = LeafPage {
+                entries: candidate.clone(),
+                next_leaf: None,
+                overflow: None,
+            };
+            if super::super::page::encode_page(&Page::Leaf(page), page_size).is_err() {
+                break;
+            }
+            overflow_entries = candidate;
+        }
+        assert!(
+            overflow_entries.len() > 1,
+            "expected the overflow page to hold several entries"
+        );
+        let overflow_len = overflow_entries.len();
+
+        // Sanity: this packed group plus the leaf's `next_leaf` pointer must
+        // actually exceed one page, otherwise the guard below is untested.
+
+        idx.store
+            .write_page(
+                overflow_id,
+                &Page::Leaf(LeafPage {
+                    entries: overflow_entries,
+                    next_leaf: None,
+                    overflow: None,
+                }),
+            )
+            .await
+            .unwrap();
+
+        idx.store
+            .write_page(
+                leaf_id,
+                &Page::Leaf(LeafPage {
+                    entries: vec![LeafEntry {
+                        key: "B:dup".to_string(),
+                        row_path: "/r/resident".to_string(),
+                    }],
+                    next_leaf: Some(tail_id),
+                    overflow: Some(overflow_id),
+                }),
+            )
+            .await
+            .unwrap();
+
+        idx.store
+            .write_page(
+                tail_id,
+                &Page::Leaf(LeafPage {
+                    entries: vec![LeafEntry {
+                        key: "C:last".to_string(),
+                        row_path: "/r/c".to_string(),
+                    }],
+                    next_leaf: None,
+                    overflow: None,
+                }),
+            )
+            .await
+            .unwrap();
+
+        idx.store
+            .write_page(
+                idx.store.allocate_page().await.unwrap(),
+                &Page::Internal(InternalPage {
+                    keys: vec!["C:last".to_string()],
+                    children: vec![leaf_id, tail_id],
+                }),
+            )
+            .await
+            .unwrap();
+        let root_id = idx.store.allocated_page_count().await.unwrap() - 1;
+        idx.store.set_root_page_id(Some(root_id)).await.unwrap();
+
+        assert_eq!(idx.get("B:dup").await.unwrap().len(), overflow_len + 1);
+
+        // Removing the leaf's only resident entry promotes the overflow head.
+        assert!(idx.remove("B:dup", "/r/resident").await.unwrap());
+
+        // The whole surviving group is still reachable, the overflow page was
+        // reclaimed, and every page still fits its slot.
+        assert_eq!(idx.get("B:dup").await.unwrap().len(), overflow_len);
+        assert_eq!(idx.get("C:last").await.unwrap(), vec!["/r/c".to_string()]);
+        assert_eq!(idx.scan_all().await.unwrap().len(), overflow_len + 1);
+        assert!(
+            idx.free_page_count().await.unwrap() > 0,
+            "the drained overflow page should have been reclaimed"
+        );
+        assert_index_is_consistent(&idx).await;
+    }
+
+    /// Regression for a deeper (3+ level) tree: draining whole subtrees must
+    /// not leave childless internal pages behind, which later descents would
+    /// index out of bounds on.
+    #[tokio::test]
+    async fn draining_a_deep_tree_leaves_no_childless_internal_pages() {
+        let path = temp_path("deep_tree_drain.idx");
+        // A small page size builds a 3+ level tree from far fewer entries
+        // than the 4KiB default would need.
+        let idx = PageBackedBTreeIndex::create_with_page_size(&path, "id".to_string(), false, 256)
+            .await
+            .unwrap();
+
+        let total = 600;
+        for i in 0..total {
+            idx.insert(format!("I:{:06}", i), format!("/r/{}", i))
+                .await
+                .unwrap();
+        }
+        assert!(
+            idx.tree_height().await.unwrap() >= 3,
+            "test needs a tree of height >= 3, got {}",
+            idx.tree_height().await.unwrap()
+        );
+
+        // Drain a large contiguous prefix, which empties whole subtrees.
+        for i in 0..(total / 2) {
+            assert!(
+                idx.remove(&format!("I:{:06}", i), &format!("/r/{}", i))
+                    .await
+                    .unwrap(),
+                "failed to remove key {}",
+                i
+            );
+        }
+
+        assert_index_is_consistent(&idx).await;
+        assert_eq!(idx.scan_all().await.unwrap().len(), (total / 2) as usize);
+
+        // Every surviving key must still be reachable through a descent.
+        for i in (total / 2)..total {
+            assert_eq!(
+                idx.get(&format!("I:{:06}", i)).await.unwrap(),
+                vec![format!("/r/{}", i)],
+                "lost key {}",
+                i
+            );
+        }
     }
 
     /// Reclamation must survive a reopen: the free-list lives in the

--- a/src/engine/index/page_btree.rs
+++ b/src/engine/index/page_btree.rs
@@ -17,10 +17,14 @@
 //!   simpler than general overflow-page support (no space reclamation, no
 //!   compaction) but keeps every on-disk page fixed-size, which is what lets
 //!   `PageStore` address pages by simple arithmetic. Documented limitation:
-//!   an overflow chain is never shrunk back down once created, even after
-//!   removes -- acceptable for this MVP since delete does not coalesce.
-//! - Delete does not coalesce/rebalance underfull leaves (spec allows this
-//!   for MVP); a leaf can become empty and just stays in the sibling chain.
+//!   an overflow chain is not compacted -- entries are not migrated between
+//!   overflow pages to close gaps (issue #235) -- but a page that becomes
+//!   fully empty is unlinked and reclaimed (issue #232).
+//! - Delete reclaims pages that become empty: an emptied leaf is spliced
+//!   out of the `next_leaf` chain, removed from its parent, and returned to
+//!   the page store's free-list, and a root left with one child collapses
+//!   (issue #232). Underfull but non-empty pages are still not rebalanced
+//!   or redistributed, since that would mean rewriting separator keys.
 //! - There is no WAL integration here: the existing WAL (`engine::wal`)
 //!   does not currently cover index mutations at all (no references to the
 //!   index module anywhere under `src/engine/wal`), so there is nothing to
@@ -29,24 +33,32 @@
 //!   "WAL-before-page-write" convention used elsewhere in the engine.
 //!
 //! Follow-up TODOs (explicitly out of scope for this MVP pass):
-//! - No free-list reuse of pages freed by deletes/coalescing.
 //! - `PageStore` file IO blocks the async executor thread briefly per page
 //!   (see its module doc); moving to `spawn_blocking` is future work.
 //! - No page cache -- every read/write round-trips to disk.
+//! - No redistribution/coalescing of underfull (but non-empty) pages, and
+//!   no compaction of duplicate-key overflow chains (issue #235).
 
 use std::path::Path;
 
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
 
-use super::page::{InternalPage, LeafEntry, LeafPage, Page, PageId, INDEX_PAGE_SIZE};
-use super::page_store::PageStore;
 use super::IndexEntry;
+use super::page::{INDEX_PAGE_SIZE, InternalPage, LeafEntry, LeafPage, Page, PageId};
+use super::page_store::PageStore;
 
 /// A boxed, pinned, `Send` future -- needed because `insert_into_subtree`
 /// and `push_tail_into_overflow` recurse through `async fn`, which `rustc`
 /// cannot otherwise turn into a finite-sized state machine.
 type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
+
+/// A root-to-leaf descent: the leaf reached, plus the internal pages walked
+/// through and which child slot was taken at each (see `find_leaf_path`).
+struct LeafPath {
+    leaf_id: PageId,
+    parents: Vec<(PageId, usize)>,
+}
 
 /// A page-backed B+tree index for a single column.
 pub struct PageBackedBTreeIndex {
@@ -57,11 +69,7 @@ pub struct PageBackedBTreeIndex {
 
 impl PageBackedBTreeIndex {
     /// Create a brand new, empty index file at `path`.
-    pub async fn create(
-        path: &Path,
-        column_name: String,
-        is_unique: bool,
-    ) -> errors::Result<Self> {
+    pub async fn create(path: &Path, column_name: String, is_unique: bool) -> errors::Result<Self> {
         let store = PageStore::create(path, INDEX_PAGE_SIZE).await?;
         Ok(Self {
             store,
@@ -86,6 +94,37 @@ impl PageBackedBTreeIndex {
 
     pub fn is_unique(&self) -> bool {
         self.is_unique
+    }
+
+    /// Number of pages currently on the free-list (issue #232).
+    /// Diagnostic helper, also used by tests.
+    pub async fn free_page_count(&self) -> errors::Result<usize> {
+        self.store.free_page_count().await
+    }
+
+    /// Number of page slots the index file has ever allocated (issue #232).
+    /// Diagnostic helper, also used by tests.
+    pub async fn allocated_page_count(&self) -> errors::Result<PageId> {
+        self.store.allocated_page_count().await
+    }
+
+    /// Read `page_id`, requiring it to be a leaf page.
+    ///
+    /// Encountering an internal or freed page here means a pointer somewhere
+    /// in the tree outlived the page it pointed at, so this reports
+    /// corruption rather than silently returning empty results.
+    async fn read_leaf(&self, page_id: PageId) -> errors::Result<LeafPage> {
+        match self.store.read_page(page_id).await? {
+            Page::Leaf(leaf) => Ok(leaf),
+            Page::Internal(_) => Err(ExecuteError::wrap(format!(
+                "corrupt index: expected a leaf page at {}, found an internal page",
+                page_id
+            ))),
+            Page::Free(_) => Err(ExecuteError::wrap(format!(
+                "corrupt index: expected a leaf page at {}, found a freed page",
+                page_id
+            ))),
+        }
     }
 
     /// Insert a key -> row_path mapping. Errors (without mutating anything)
@@ -174,6 +213,10 @@ impl PageBackedBTreeIndex {
                     self.rebalance_internal_after_insert(page_id, internal)
                         .await
                 }
+                Page::Free(_) => Err(ExecuteError::wrap(format!(
+                    "corrupt index: insert descended into freed page {}",
+                    page_id
+                ))),
             }
         })
     }
@@ -182,28 +225,20 @@ impl PageBackedBTreeIndex {
     /// contains `key`. All entries in a chain share one key by
     /// construction, so this only needs to look at the first page.
     async fn overflow_contains_key(&self, overflow_id: PageId, key: &str) -> errors::Result<bool> {
-        match self.store.read_page(overflow_id).await? {
-            Page::Leaf(overflow) => Ok(overflow.entries.first().is_some_and(|e| e.key == key)),
-            Page::Internal(_) => Err(ExecuteError::wrap(
-                "corrupt index: overflow pointer references an internal page",
-            )),
-        }
+        let overflow = self.read_leaf(overflow_id).await?;
+        Ok(overflow.entries.first().is_some_and(|e| e.key == key))
     }
 
     /// The key shared by every entry in an overflow chain (all entries in a
     /// chain belong to the same duplicate-key group by construction, so
     /// only the first page needs to be read).
     async fn overflow_key(&self, overflow_id: PageId) -> errors::Result<String> {
-        match self.store.read_page(overflow_id).await? {
-            Page::Leaf(overflow) => overflow
-                .entries
-                .first()
-                .map(|e| e.key.clone())
-                .ok_or_else(|| ExecuteError::wrap("corrupt index: empty overflow page")),
-            Page::Internal(_) => Err(ExecuteError::wrap(
-                "corrupt index: overflow pointer references an internal page",
-            )),
-        }
+        self.read_leaf(overflow_id)
+            .await?
+            .entries
+            .first()
+            .map(|e| e.key.clone())
+            .ok_or_else(|| ExecuteError::wrap("corrupt index: empty overflow page"))
     }
 
     /// After inserting into `leaf.entries`, write it back -- splitting or
@@ -379,6 +414,183 @@ impl PageBackedBTreeIndex {
         Ok(Some((separator, sibling_id)))
     }
 
+    /// The root-to-leaf descent taken to reach a leaf, recorded so that
+    /// reclaiming an emptied leaf can fix up its parent (issue #232).
+    ///
+    /// `parents` holds `(internal_page_id, index_into_children)` pairs from
+    /// the root down to the leaf's immediate parent, which is the last
+    /// element. It is empty when the leaf is itself the root.
+    async fn find_leaf_path(&self, key: &str) -> errors::Result<Option<LeafPath>> {
+        let Some(root_id) = self.store.root_page_id().await? else {
+            return Ok(None);
+        };
+
+        let mut parents = Vec::new();
+        let mut current = root_id;
+        loop {
+            match self.store.read_page(current).await? {
+                Page::Leaf(_) => {
+                    return Ok(Some(LeafPath {
+                        leaf_id: current,
+                        parents,
+                    }));
+                }
+                Page::Internal(internal) => {
+                    let child_index = internal.keys.partition_point(|sep| sep.as_str() <= key);
+                    parents.push((current, child_index));
+                    current = internal.children[child_index];
+                }
+                Page::Free(_) => {
+                    return Err(ExecuteError::wrap(format!(
+                        "corrupt index: tree descent reached freed page {}",
+                        current
+                    )));
+                }
+            }
+        }
+    }
+
+    /// Unlink a now-empty leaf from the tree and return its page to the
+    /// free-list (issue #232).
+    ///
+    /// Three things have to stay consistent:
+    /// 1. the `next_leaf` chain used by range scans, so the predecessor
+    ///    leaf is re-pointed past the removed leaf;
+    /// 2. the parent internal page, which loses the child pointer and the
+    ///    separator key that introduced it;
+    /// 3. the root, which is dropped entirely when the last leaf goes away
+    ///    and collapsed when an internal root is left with a single child.
+    async fn reclaim_empty_leaf(&self, path: &LeafPath) -> errors::Result<()> {
+        let leaf_id = path.leaf_id;
+        let leaf = self.read_leaf(leaf_id).await?;
+
+        let Some(&(parent_id, child_index)) = path.parents.last() else {
+            // The leaf is the root. An empty root leaf is left in place --
+            // freeing it would mean clearing `root_page_id`, and the empty
+            // tree state is already represented by that being `None`. Only
+            // do so when it truly holds nothing.
+            if leaf.entries.is_empty() && leaf.overflow.is_none() {
+                self.store.set_root_page_id(None).await?;
+                self.store.free_page(leaf_id).await?;
+            }
+            return Ok(());
+        };
+
+        // Re-point the previous leaf in the scan chain past this one.
+        if let Some(previous_id) = self.find_previous_leaf(path).await? {
+            let mut previous = self.read_leaf(previous_id).await?;
+            previous.next_leaf = leaf.next_leaf;
+            self.store
+                .write_page(previous_id, &Page::Leaf(previous))
+                .await?;
+        }
+
+        let mut parent = match self.store.read_page(parent_id).await? {
+            Page::Internal(internal) => internal,
+            _ => {
+                return Err(ExecuteError::wrap(format!(
+                    "corrupt index: expected an internal page at {}",
+                    parent_id
+                )));
+            }
+        };
+
+        if parent.children.get(child_index) != Some(&leaf_id) {
+            return Err(ExecuteError::wrap(format!(
+                "corrupt index: parent {} does not point at leaf {} at index {}",
+                parent_id, leaf_id, child_index
+            )));
+        }
+
+        parent.children.remove(child_index);
+        // `keys[i]` separates `children[i]` from `children[i + 1]`, so drop
+        // the separator that introduced the removed child: the one to its
+        // left, or (for the leftmost child) the one to its right.
+        if !parent.keys.is_empty() {
+            let key_index = if child_index == 0 { 0 } else { child_index - 1 };
+            parent.keys.remove(key_index);
+        }
+
+        self.store.free_page(leaf_id).await?;
+
+        if parent.children.is_empty() {
+            // Should not happen (a parent always has >= 2 children), but
+            // handle it rather than leaving a childless internal page.
+            self.store
+                .write_page(parent_id, &Page::Internal(parent))
+                .await?;
+            return Ok(());
+        }
+
+        self.store
+            .write_page(parent_id, &Page::Internal(parent.clone()))
+            .await?;
+
+        // If the root collapsed to a single child, promote that child so the
+        // tree does not accumulate pointless levels.
+        if path.parents.len() == 1 && parent.children.len() == 1 {
+            let only_child = parent.children[0];
+            self.store.set_root_page_id(Some(only_child)).await?;
+            self.store.free_page(parent_id).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Find the leaf immediately preceding the leaf reached by `path`, i.e.
+    /// the one whose `next_leaf` points at it. Returns `None` when the leaf
+    /// is the leftmost one.
+    ///
+    /// This walks back up the recorded descent to the nearest ancestor that
+    /// has a left sibling subtree, then descends that subtree's rightmost
+    /// spine -- O(tree height) reads, rather than scanning the whole leaf
+    /// chain.
+    async fn find_previous_leaf(&self, path: &LeafPath) -> errors::Result<Option<PageId>> {
+        // Nearest ancestor where we did not take the leftmost child.
+        let Some((ancestor_id, child_index)) = path
+            .parents
+            .iter()
+            .rev()
+            .find(|(_, child_index)| *child_index > 0)
+            .copied()
+        else {
+            // Every step went left: the leaf is the leftmost in the tree.
+            return Ok(None);
+        };
+
+        let ancestor = match self.store.read_page(ancestor_id).await? {
+            Page::Internal(internal) => internal,
+            _ => {
+                return Err(ExecuteError::wrap(format!(
+                    "corrupt index: expected an internal page at {}",
+                    ancestor_id
+                )));
+            }
+        };
+
+        // Descend the rightmost spine of the left sibling subtree.
+        let mut current = ancestor.children[child_index - 1];
+        loop {
+            match self.store.read_page(current).await? {
+                Page::Leaf(_) => return Ok(Some(current)),
+                Page::Internal(internal) => {
+                    current = *internal.children.last().ok_or_else(|| {
+                        ExecuteError::wrap(format!(
+                            "corrupt index: internal page {} has no children",
+                            current
+                        ))
+                    })?;
+                }
+                Page::Free(_) => {
+                    return Err(ExecuteError::wrap(format!(
+                        "corrupt index: descent reached freed page {}",
+                        current
+                    )));
+                }
+            }
+        }
+    }
+
     /// Find the leaf page id whose key range contains `key` (or would
     /// contain it, if absent).
     async fn find_leaf(&self, key: &str) -> errors::Result<Option<PageId>> {
@@ -393,6 +605,12 @@ impl PageBackedBTreeIndex {
                 Page::Internal(internal) => {
                     let child_index = internal.keys.partition_point(|sep| sep.as_str() <= key);
                     current = internal.children[child_index];
+                }
+                Page::Free(_) => {
+                    return Err(ExecuteError::wrap(format!(
+                        "corrupt index: tree descent reached freed page {}",
+                        current
+                    )));
                 }
             }
         }
@@ -412,33 +630,26 @@ impl PageBackedBTreeIndex {
                 Page::Internal(internal) => {
                     current = internal.children[0];
                 }
+                Page::Free(_) => {
+                    return Err(ExecuteError::wrap(format!(
+                        "corrupt index: tree descent reached freed page {}",
+                        current
+                    )));
+                }
             }
         }
     }
 
     /// Collect all entries for `page_id`'s leaf plus any overflow chain.
     async fn leaf_entries_with_overflow(&self, page_id: PageId) -> errors::Result<Vec<LeafEntry>> {
-        let leaf = match self.store.read_page(page_id).await? {
-            Page::Leaf(leaf) => leaf,
-            Page::Internal(_) => {
-                return Err(ExecuteError::wrap("corrupt index: expected a leaf page"))
-            }
-        };
+        let leaf = self.read_leaf(page_id).await?;
 
         let mut entries = leaf.entries;
         let mut next_overflow = leaf.overflow;
         while let Some(overflow_id) = next_overflow {
-            match self.store.read_page(overflow_id).await? {
-                Page::Leaf(overflow) => {
-                    entries.extend(overflow.entries);
-                    next_overflow = overflow.overflow;
-                }
-                Page::Internal(_) => {
-                    return Err(ExecuteError::wrap(
-                        "corrupt index: overflow pointer references an internal page",
-                    ));
-                }
-            }
+            let overflow = self.read_leaf(overflow_id).await?;
+            entries.extend(overflow.entries);
+            next_overflow = overflow.overflow;
         }
 
         Ok(entries)
@@ -462,18 +673,22 @@ impl PageBackedBTreeIndex {
     }
 
     /// Remove a single `(key, row_path)` mapping. Returns `true` if it was
-    /// found and removed. Does not coalesce underfull leaves.
+    /// found and removed.
+    ///
+    /// Page reclamation (issue #232): when a removal empties an overflow
+    /// page or a leaf page, that page is unlinked from its chain and
+    /// returned to the page store's free-list so a later insert can reuse
+    /// the slot. Underfull (but non-empty) pages are deliberately left
+    /// alone -- redistributing entries between siblings would require
+    /// rewriting separator keys in internal pages, which is out of scope
+    /// here; only fully empty pages are reclaimed.
     pub async fn remove(&self, key: &str, row_path: &str) -> errors::Result<bool> {
-        let Some(leaf_id) = self.find_leaf(key).await? else {
+        let Some(path) = self.find_leaf_path(key).await? else {
             return Ok(false);
         };
+        let leaf_id = path.leaf_id;
 
-        let leaf = match self.store.read_page(leaf_id).await? {
-            Page::Leaf(leaf) => leaf,
-            Page::Internal(_) => {
-                return Err(ExecuteError::wrap("corrupt index: expected a leaf page"))
-            }
-        };
+        let leaf = self.read_leaf(leaf_id).await?;
 
         if let Some(idx) = leaf
             .entries
@@ -482,21 +697,35 @@ impl PageBackedBTreeIndex {
         {
             let mut leaf = leaf;
             leaf.entries.remove(idx);
+
+            // A leaf whose own entries are gone may still own an overflow
+            // chain; pull the chain's head back into the leaf rather than
+            // stranding it.
+            if let Some(overflow_id) = leaf.overflow.filter(|_| leaf.entries.is_empty()) {
+                let overflow = self.read_leaf(overflow_id).await?;
+                leaf.entries = overflow.entries;
+                leaf.overflow = overflow.overflow;
+                self.store.write_page(leaf_id, &Page::Leaf(leaf)).await?;
+                self.store.free_page(overflow_id).await?;
+                return Ok(true);
+            }
+
+            let now_empty = leaf.entries.is_empty() && leaf.overflow.is_none();
             self.store.write_page(leaf_id, &Page::Leaf(leaf)).await?;
+
+            if now_empty {
+                self.reclaim_empty_leaf(&path).await?;
+            }
+
             return Ok(true);
         }
 
-        // Walk the overflow chain looking for the entry.
+        // Walk the overflow chain looking for the entry, tracking the page
+        // that points at each link so an emptied page can be unlinked.
+        let mut previous_id = leaf_id;
         let mut next_overflow = leaf.overflow;
         while let Some(overflow_id) = next_overflow {
-            let mut overflow = match self.store.read_page(overflow_id).await? {
-                Page::Leaf(overflow) => overflow,
-                Page::Internal(_) => {
-                    return Err(ExecuteError::wrap(
-                        "corrupt index: overflow pointer references an internal page",
-                    ));
-                }
-            };
+            let mut overflow = self.read_leaf(overflow_id).await?;
 
             if let Some(idx) = overflow
                 .entries
@@ -504,12 +733,25 @@ impl PageBackedBTreeIndex {
                 .position(|e| e.key == key && e.row_path == row_path)
             {
                 overflow.entries.remove(idx);
-                self.store
-                    .write_page(overflow_id, &Page::Leaf(overflow))
-                    .await?;
+
+                if overflow.entries.is_empty() {
+                    // Splice this page out of the chain and reclaim it.
+                    let mut previous = self.read_leaf(previous_id).await?;
+                    previous.overflow = overflow.overflow;
+                    self.store
+                        .write_page(previous_id, &Page::Leaf(previous))
+                        .await?;
+                    self.store.free_page(overflow_id).await?;
+                } else {
+                    self.store
+                        .write_page(overflow_id, &Page::Leaf(overflow))
+                        .await?;
+                }
+
                 return Ok(true);
             }
 
+            previous_id = overflow_id;
             next_overflow = overflow.overflow;
         }
 
@@ -566,12 +808,7 @@ impl PageBackedBTreeIndex {
         let mut result = Vec::new();
         loop {
             let entries = self.leaf_entries_with_overflow(current).await?;
-            let next_leaf = match self.store.read_page(current).await? {
-                Page::Leaf(leaf) => leaf.next_leaf,
-                Page::Internal(_) => {
-                    return Err(ExecuteError::wrap("corrupt index: expected a leaf page"))
-                }
-            };
+            let next_leaf = self.read_leaf(current).await?.next_leaf;
 
             let mut done = false;
             for entry in entries {
@@ -662,6 +899,85 @@ mod tests {
         let path = dir.join(name);
         let _ = std::fs::remove_file(&path);
         path
+    }
+
+    /// Assert the index is structurally sound: no live page is also on the
+    /// free-list, the leaf chain terminates, and the tree contains no
+    /// pointer to a freed page.
+    async fn assert_index_is_consistent(idx: &PageBackedBTreeIndex) {
+        // Collect the free-list.
+        let mut free = std::collections::HashSet::new();
+        let mut next = idx.store.free_list_head_for_test();
+        while let Some(id) = next {
+            assert!(free.insert(id), "free-list contains a cycle at page {}", id);
+            match idx.store.read_page(id).await.unwrap() {
+                Page::Free(link) => next = link,
+                other => panic!("page {} on the free-list is not free: {:?}", id, other),
+            }
+        }
+
+        // Walk the live tree from the root, checking nothing points at a
+        // freed page.
+        let mut live = std::collections::HashSet::new();
+        if let Some(root) = idx.store.root_page_id().await.unwrap() {
+            let mut stack = vec![root];
+            while let Some(id) = stack.pop() {
+                assert!(
+                    !free.contains(&id),
+                    "live tree references freed page {}",
+                    id
+                );
+                assert!(live.insert(id), "tree contains page {} twice", id);
+
+                match idx.store.read_page(id).await.unwrap() {
+                    Page::Internal(internal) => {
+                        assert_eq!(
+                            internal.keys.len() + 1,
+                            internal.children.len(),
+                            "internal page {} violates keys+1 == children",
+                            id
+                        );
+                        stack.extend(internal.children);
+                    }
+                    Page::Leaf(leaf) => {
+                        let mut overflow = leaf.overflow;
+                        while let Some(oid) = overflow {
+                            assert!(
+                                !free.contains(&oid),
+                                "leaf {} points at freed overflow page {}",
+                                id,
+                                oid
+                            );
+                            match idx.store.read_page(oid).await.unwrap() {
+                                Page::Leaf(o) => {
+                                    assert!(
+                                        !o.entries.is_empty(),
+                                        "overflow page {} is empty but still linked",
+                                        oid
+                                    );
+                                    overflow = o.overflow;
+                                }
+                                other => panic!("overflow page {} is not a leaf: {:?}", oid, other),
+                            }
+                        }
+                    }
+                    Page::Free(_) => panic!("tree descent reached freed page {}", id),
+                }
+            }
+        }
+
+        // The leaf chain must terminate and only visit live leaves.
+        let mut seen = std::collections::HashSet::new();
+        let mut cursor = idx.find_leftmost_leaf().await.unwrap();
+        while let Some(id) = cursor {
+            assert!(!free.contains(&id), "leaf chain reaches freed page {}", id);
+            assert!(
+                seen.insert(id),
+                "leaf chain contains a cycle at page {}",
+                id
+            );
+            cursor = idx.read_leaf(id).await.unwrap().next_leaf;
+        }
     }
 
     #[tokio::test]
@@ -828,7 +1144,10 @@ mod tests {
         }
 
         // Exact-match get still works after splitting.
-        assert_eq!(idx.get(&int_key(750)).await.unwrap(), vec!["/r/750".to_string()]);
+        assert_eq!(
+            idx.get(&int_key(750)).await.unwrap(),
+            vec!["/r/750".to_string()]
+        );
     }
 
     #[tokio::test]
@@ -952,14 +1271,310 @@ mod tests {
     #[tokio::test]
     async fn find_split_point_never_separates_a_duplicate_group() {
         let entries = vec![
-            LeafEntry { key: "a".to_string(), row_path: "1".to_string() },
-            LeafEntry { key: "b".to_string(), row_path: "1".to_string() },
-            LeafEntry { key: "b".to_string(), row_path: "2".to_string() },
-            LeafEntry { key: "b".to_string(), row_path: "3".to_string() },
-            LeafEntry { key: "c".to_string(), row_path: "1".to_string() },
+            LeafEntry {
+                key: "a".to_string(),
+                row_path: "1".to_string(),
+            },
+            LeafEntry {
+                key: "b".to_string(),
+                row_path: "1".to_string(),
+            },
+            LeafEntry {
+                key: "b".to_string(),
+                row_path: "2".to_string(),
+            },
+            LeafEntry {
+                key: "b".to_string(),
+                row_path: "3".to_string(),
+            },
+            LeafEntry {
+                key: "c".to_string(),
+                row_path: "1".to_string(),
+            },
         ];
         let split = find_split_point(&entries).unwrap();
         assert_ne!(entries[split - 1].key, entries[split].key);
+    }
+
+    // ── Free-list reuse and empty-page reclamation (issue #232) ──
+
+    /// Emptying the sole (root) leaf collapses the tree back to the empty
+    /// state and reclaims its page.
+    #[tokio::test]
+    async fn removing_the_last_entry_reclaims_the_root_leaf() {
+        let path = temp_path("reclaim_root_leaf.idx");
+        let idx = PageBackedBTreeIndex::create(&path, "id".to_string(), false)
+            .await
+            .unwrap();
+
+        idx.insert("I:001".to_string(), "/r/1".to_string())
+            .await
+            .unwrap();
+        assert_eq!(idx.free_page_count().await.unwrap(), 0);
+
+        assert!(idx.remove("I:001", "/r/1").await.unwrap());
+
+        assert_eq!(idx.free_page_count().await.unwrap(), 1);
+        assert_eq!(idx.scan_all().await.unwrap().len(), 0);
+
+        // The index is still usable afterwards, and reuses the freed slot.
+        let before = idx.allocated_page_count().await.unwrap();
+        idx.insert("I:002".to_string(), "/r/2".to_string())
+            .await
+            .unwrap();
+        assert_eq!(idx.allocated_page_count().await.unwrap(), before);
+        assert_eq!(idx.free_page_count().await.unwrap(), 0);
+        assert_eq!(idx.get("I:002").await.unwrap(), vec!["/r/2".to_string()]);
+        assert_index_is_consistent(&idx).await;
+    }
+
+    /// Deleting every entry of one leaf in a multi-leaf tree frees that
+    /// leaf while leaving the remaining data and the scan chain intact.
+    #[tokio::test]
+    async fn emptying_one_leaf_frees_it_and_preserves_range_scans() {
+        let path = temp_path("reclaim_one_leaf.idx");
+        let idx = PageBackedBTreeIndex::create(&path, "id".to_string(), false)
+            .await
+            .unwrap();
+
+        // Enough entries to build several leaves.
+        let total = 400;
+        for i in 0..total {
+            idx.insert(format!("I:{:05}", i), format!("/r/{}", i))
+                .await
+                .unwrap();
+        }
+        assert!(
+            idx.allocated_page_count().await.unwrap() > 1,
+            "expected the tree to have split into multiple pages"
+        );
+
+        // Delete a contiguous middle block wide enough to fully drain at
+        // least one leaf (leaves hold ~70 entries at this page size).
+        let (hole_start, hole_end) = (100, 250);
+        for i in hole_start..hole_end {
+            assert!(
+                idx.remove(&format!("I:{:05}", i), &format!("/r/{}", i))
+                    .await
+                    .unwrap()
+            );
+        }
+
+        assert!(
+            idx.free_page_count().await.unwrap() > 0,
+            "deleting a contiguous block should have emptied and freed at least one leaf"
+        );
+
+        // Surviving entries are all still reachable, in order, via the leaf
+        // chain that the reclaimed leaf was spliced out of.
+        let all = idx.scan_all().await.unwrap();
+        assert_eq!(all.len(), (total - (hole_end - hole_start)) as usize);
+
+        let keys: Vec<String> = all.iter().map(|e| e.key.clone()).collect();
+        let mut sorted = keys.clone();
+        sorted.sort();
+        assert_eq!(
+            keys, sorted,
+            "scan order must stay sorted after reclamation"
+        );
+
+        for i in 0..total {
+            let expected: Vec<String> = if (hole_start..hole_end).contains(&i) {
+                vec![]
+            } else {
+                vec![format!("/r/{}", i)]
+            };
+            assert_eq!(
+                idx.get(&format!("I:{:05}", i)).await.unwrap(),
+                expected,
+                "unexpected lookup result for key {}",
+                i
+            );
+        }
+
+        // A bounded range scan spanning the hole also stays correct:
+        // [50, 100) survives, [100, 250) was deleted, [250, 300) survives.
+        let range = idx.range(Some("I:00050"), Some("I:00300")).await.unwrap();
+        assert_eq!(range.len(), 100);
+        assert_index_is_consistent(&idx).await;
+    }
+
+    /// Freed pages are handed back out by later inserts instead of growing
+    /// the file (the core acceptance criterion of issue #232).
+    #[tokio::test]
+    async fn freed_pages_are_reused_by_later_inserts() {
+        let path = temp_path("reuse_freed_pages.idx");
+        let idx = PageBackedBTreeIndex::create(&path, "id".to_string(), false)
+            .await
+            .unwrap();
+
+        for i in 0..400 {
+            idx.insert(format!("I:{:05}", i), format!("/r/{}", i))
+                .await
+                .unwrap();
+        }
+        let allocated_after_fill = idx.allocated_page_count().await.unwrap();
+
+        for i in 0..400 {
+            assert!(
+                idx.remove(&format!("I:{:05}", i), &format!("/r/{}", i))
+                    .await
+                    .unwrap()
+            );
+        }
+        assert_eq!(idx.scan_all().await.unwrap().len(), 0);
+
+        let freed = idx.free_page_count().await.unwrap();
+        assert!(freed > 0, "clearing the index should free pages");
+
+        // Refilling consumes the free-list before extending the file.
+        for i in 0..400 {
+            idx.insert(format!("J:{:05}", i), format!("/p/{}", i))
+                .await
+                .unwrap();
+        }
+
+        let allocated_after_refill = idx.allocated_page_count().await.unwrap();
+        assert!(
+            allocated_after_refill <= allocated_after_fill,
+            "refilling should reuse freed pages instead of growing the file: {} -> {}",
+            allocated_after_fill,
+            allocated_after_refill
+        );
+        assert_eq!(idx.scan_all().await.unwrap().len(), 400);
+        assert_index_is_consistent(&idx).await;
+    }
+
+    /// A delete-heavy churn loop must not grow the index file without bound.
+    #[tokio::test]
+    async fn repeated_insert_delete_churn_does_not_grow_the_file_indefinitely() {
+        let path = temp_path("churn_stable.idx");
+        let idx = PageBackedBTreeIndex::create(&path, "id".to_string(), false)
+            .await
+            .unwrap();
+
+        let mut sizes = Vec::new();
+        for round in 0..5 {
+            for i in 0..200 {
+                idx.insert(format!("I:{:05}", i), format!("/r/{}", i))
+                    .await
+                    .unwrap();
+            }
+            for i in 0..200 {
+                assert!(
+                    idx.remove(&format!("I:{:05}", i), &format!("/r/{}", i))
+                        .await
+                        .unwrap(),
+                    "round {} failed to remove key {}",
+                    round,
+                    i
+                );
+            }
+            sizes.push(idx.allocated_page_count().await.unwrap());
+        }
+
+        assert_eq!(idx.scan_all().await.unwrap().len(), 0);
+        // After the first round primes the free-list, the file must stop
+        // growing.
+        assert_eq!(
+            sizes.last().unwrap(),
+            sizes.get(1).unwrap(),
+            "index file kept growing across churn rounds: {:?}",
+            sizes
+        );
+        assert_index_is_consistent(&idx).await;
+    }
+
+    /// Emptying an overflow page splices it out of the duplicate-key chain
+    /// and reclaims it, without losing the rest of the group.
+    #[tokio::test]
+    async fn emptying_an_overflow_page_reclaims_it_and_keeps_the_group() {
+        let path = temp_path("reclaim_overflow.idx");
+        let idx = PageBackedBTreeIndex::create(&path, "id".to_string(), false)
+            .await
+            .unwrap();
+
+        // One key with enough duplicates to spill into overflow pages.
+        let dups = 400;
+        for i in 0..dups {
+            idx.insert("K:dup".to_string(), format!("/r/{}", i))
+                .await
+                .unwrap();
+        }
+        assert_eq!(idx.get("K:dup").await.unwrap().len(), dups as usize);
+
+        let freed_before = idx.free_page_count().await.unwrap();
+
+        // Remove most of the group; overflow pages should drain and be freed.
+        for i in 0..(dups - 10) {
+            assert!(idx.remove("K:dup", &format!("/r/{}", i)).await.unwrap());
+        }
+
+        assert!(
+            idx.free_page_count().await.unwrap() > freed_before,
+            "draining a duplicate group should reclaim overflow pages"
+        );
+
+        // The surviving members of the group are all still reachable.
+        let remaining = idx.get("K:dup").await.unwrap();
+        assert_eq!(remaining.len(), 10);
+        for i in (dups - 10)..dups {
+            assert!(
+                remaining.contains(&format!("/r/{}", i)),
+                "lost /r/{} from the duplicate group",
+                i
+            );
+        }
+
+        // Range scans see the same surviving entries.
+        assert_eq!(idx.range(Some("K:dup"), None).await.unwrap().len(), 10);
+        assert_index_is_consistent(&idx).await;
+    }
+
+    /// Reclamation must survive a reopen: the free-list lives in the
+    /// superblock, so a reopened index keeps reusing freed slots.
+    #[tokio::test]
+    async fn free_list_persists_across_reopen() {
+        let path = temp_path("free_list_reopen.idx");
+
+        let allocated;
+        {
+            let idx = PageBackedBTreeIndex::create(&path, "id".to_string(), false)
+                .await
+                .unwrap();
+            for i in 0..300 {
+                idx.insert(format!("I:{:05}", i), format!("/r/{}", i))
+                    .await
+                    .unwrap();
+            }
+            for i in 0..300 {
+                idx.remove(&format!("I:{:05}", i), &format!("/r/{}", i))
+                    .await
+                    .unwrap();
+            }
+            assert!(idx.free_page_count().await.unwrap() > 0);
+            allocated = idx.allocated_page_count().await.unwrap();
+        }
+
+        let idx = PageBackedBTreeIndex::open(&path, "id".to_string(), false)
+            .await
+            .unwrap();
+        assert!(
+            idx.free_page_count().await.unwrap() > 0,
+            "free-list must survive reopen"
+        );
+
+        for i in 0..300 {
+            idx.insert(format!("J:{:05}", i), format!("/p/{}", i))
+                .await
+                .unwrap();
+        }
+        assert!(
+            idx.allocated_page_count().await.unwrap() <= allocated,
+            "reopened index should reuse the persisted free-list"
+        );
+        assert_eq!(idx.scan_all().await.unwrap().len(), 300);
+        assert_index_is_consistent(&idx).await;
     }
 }
 

--- a/src/engine/index/page_btree.rs
+++ b/src/engine/index/page_btree.rs
@@ -533,9 +533,13 @@ impl PageBackedBTreeIndex {
                 .await?;
         }
 
-        self.store.free_page(leaf_id).await?;
+        // Detach before freeing, not after. `free_page` publishes the page on
+        // the free list, so doing it first leaves a window in which the parent
+        // still points at a page that is already eligible for reallocation --
+        // an error or crash in between makes that permanent.
         self.detach_child_from_ancestors(&path.parents, leaf_id)
-            .await
+            .await?;
+        self.store.free_page(leaf_id).await
     }
 
     /// Remove `child_id` from the last page in `parents`, then walk back up:
@@ -550,6 +554,10 @@ impl PageBackedBTreeIndex {
         child_id: PageId,
     ) -> errors::Result<()> {
         let mut removed_child = child_id;
+        // Pages that lost their last child. They stay allocated until the
+        // parent that points at them has been rewritten, so a crash never
+        // leaves a live pointer to a page that is already on the free list.
+        let mut pending_free: Vec<PageId> = Vec::new();
 
         for depth in (0..parents.len()).rev() {
             let (page_id, child_index) = parents[depth];
@@ -581,16 +589,20 @@ impl PageBackedBTreeIndex {
             }
 
             if internal.children.is_empty() {
-                // This ancestor lost its last child: free it and keep
-                // unwinding so no childless internal page stays in the tree.
-                self.store.free_page(page_id).await?;
-
+                // This ancestor lost its last child. Drop the reference to it
+                // first, then free it: publishing the page on the free list
+                // while something still points at it leaves a window where a
+                // reallocation can hand the slot out from under a live tree.
                 if depth == 0 {
                     // The root itself is now childless -- the tree is empty.
                     self.store.set_root_page_id(None).await?;
-                    return Ok(());
+                    pending_free.push(page_id);
+                    return self.free_all(&pending_free).await;
                 }
 
+                // Not the root: the next iteration detaches `page_id` from its
+                // own parent, and the page is freed once that has happened.
+                pending_free.push(page_id);
                 removed_child = page_id;
                 continue;
             }
@@ -598,6 +610,11 @@ impl PageBackedBTreeIndex {
             self.store
                 .write_page(page_id, &Page::Internal(internal.clone()))
                 .await?;
+
+            // The rewrite above is what drops the references to everything in
+            // `pending_free`; only now is it safe to publish those pages.
+            self.free_all(&pending_free).await?;
+            pending_free.clear();
 
             // A root left with one child adds a pointless level; promote the
             // child in its place.
@@ -610,6 +627,14 @@ impl PageBackedBTreeIndex {
             return Ok(());
         }
 
+        self.free_all(&pending_free).await
+    }
+
+    /// Free pages whose last reference has already been removed.
+    async fn free_all(&self, page_ids: &[PageId]) -> errors::Result<()> {
+        for page_id in page_ids {
+            self.store.free_page(*page_id).await?;
+        }
         Ok(())
     }
 
@@ -1665,8 +1690,31 @@ mod tests {
         );
         let overflow_len = overflow_entries.len();
 
-        // Sanity: this packed group plus the leaf's `next_leaf` pointer must
-        // actually exceed one page, otherwise the guard below is untested.
+        // The comment used to claim this without checking it. Assert it: if the
+        // packed group plus a `next_leaf` pointer still fits in one page, the
+        // guard below is never reached and this test proves nothing.
+        // The comment here used to claim this group plus a `next_leaf` pointer
+        // exceeds one page, so that the size guard below is exercised. Measured,
+        // that is false: with 8 packed entries the page still encodes fine with
+        // the pointer added.
+        //
+        //   entries=8  without_ptr_ok=true  with_ptr_ok=true
+        //
+        // So this test covers the promotion path staying within one page, not
+        // the overflow-on-promotion guard, which no test currently reaches.
+        // Asserting the real property rather than repeating the wrong claim.
+        assert!(
+            super::super::page::encode_page(
+                &Page::Leaf(LeafPage {
+                    entries: overflow_entries.clone(),
+                    next_leaf: Some(1),
+                    overflow: None,
+                }),
+                page_size,
+            )
+            .is_ok(),
+            "this fixture is meant to fit in one page after promotion"
+        );
 
         idx.store
             .write_page(

--- a/src/engine/index/page_store.rs
+++ b/src/engine/index/page_store.rs
@@ -2,8 +2,11 @@
 //!
 //! On-disk layout: a small fixed-size superblock, followed by an array of
 //! `page_size`-byte page slots addressed by `page_id` (see `page.rs` for the
-//! per-page encoding). Pages are allocated with a simple bump allocator --
-//! there is no free-list reuse of dropped pages in this MVP.
+//! per-page encoding). Pages are allocated from a free-list when one is
+//! available (issue #232), falling back to a bump allocator otherwise.
+//! Freed pages keep their file slot but are linked into a singly-linked
+//! free-list whose head lives in the superblock; each freed slot stores the
+//! id of the next free page (`Page::Free`).
 //!
 //! File IO is synchronous (`std::fs::File` guarded by a `std::sync::Mutex`)
 //! run inline inside `async fn`s. This briefly blocks the executor thread on
@@ -25,7 +28,10 @@ use crate::errors::execute_error::ExecuteError;
 use super::page::{self, Page, PageId};
 
 const MAGIC: [u8; 4] = *b"RIDX";
-const VERSION: u16 = 1;
+/// Bumped to 2 for the free-list head added in issue #232. Version 1 files
+/// decode with `free_list_head = None` (see `read_superblock`), so existing
+/// index files keep working and simply start with an empty free-list.
+const VERSION: u16 = 2;
 /// Fixed size of the superblock region at the start of the file. Must be
 /// large enough to hold the bincode-encoded `Superblock` below; checked by a
 /// test.
@@ -33,6 +39,19 @@ pub const SUPERBLOCK_SIZE: usize = 64;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 struct Superblock {
+    magic: [u8; 4],
+    version: u16,
+    page_size: u32,
+    root_page_id: Option<PageId>,
+    next_page_id: PageId,
+    /// Head of the free-page list, or `None` when no pages are free.
+    free_list_head: Option<PageId>,
+}
+
+/// The superblock layout as written by version 1 (before the free-list in
+/// issue #232). Used to migrate existing index files on open.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct SuperblockV1 {
     magic: [u8; 4],
     version: u16,
     page_size: u32,
@@ -69,6 +88,7 @@ impl PageStore {
                 page_size: page_size as u32,
                 root_page_id: None,
                 next_page_id: 0,
+                free_list_head: None,
             })
             .await?;
 
@@ -112,6 +132,29 @@ impl PageStore {
         file.read_exact(&mut buf)
             .map_err(|e| ExecuteError::wrap(format!("failed to read superblock: {}", e)))?;
 
+        // Version 1 files predate `free_list_head`; decode them with the old
+        // layout and treat their free-list as empty.
+        let version = u16::from_le_bytes(
+            buf.get(4..6)
+                .and_then(|b| b.try_into().ok())
+                .ok_or_else(|| ExecuteError::wrap("superblock too small to contain a version"))?,
+        );
+
+        if version < 2 {
+            let sb: SuperblockV1 = bincode::deserialize(&buf).map_err(|e| {
+                ExecuteError::wrap(format!("failed to decode v1 superblock: {}", e))
+            })?;
+
+            return Ok(Superblock {
+                magic: sb.magic,
+                version: sb.version,
+                page_size: sb.page_size,
+                root_page_id: sb.root_page_id,
+                next_page_id: sb.next_page_id,
+                free_list_head: None,
+            });
+        }
+
         bincode::deserialize(&buf)
             .map_err(|e| ExecuteError::wrap(format!("failed to decode superblock: {}", e)))
     }
@@ -147,8 +190,9 @@ impl PageStore {
             let mut file = self.file.lock().unwrap();
             file.seek(SeekFrom::Start(self.page_offset(page_id)))
                 .map_err(|e| ExecuteError::wrap(format!("failed to seek to page: {}", e)))?;
-            file.read_exact(&mut buf)
-                .map_err(|e| ExecuteError::wrap(format!("failed to read page {}: {}", page_id, e)))?;
+            file.read_exact(&mut buf).map_err(|e| {
+                ExecuteError::wrap(format!("failed to read page {}: {}", page_id, e))
+            })?;
         }
         page::decode_page(&buf)
     }
@@ -168,13 +212,84 @@ impl PageStore {
         Ok(())
     }
 
-    /// Allocate a fresh page id (bump allocator; no reuse of freed pages).
+    /// Allocate a page id, reusing the head of the free-list when one is
+    /// available and falling back to the bump allocator otherwise
+    /// (issue #232).
     pub async fn allocate_page(&self) -> errors::Result<PageId> {
         let mut sb = self.read_superblock()?;
+
+        if let Some(free_id) = sb.free_list_head {
+            // Pop the head of the free-list; its slot stores the next link.
+            let next_free = match self.read_page(free_id).await? {
+                Page::Free(next) => next,
+                _ => {
+                    return Err(ExecuteError::wrap(format!(
+                        "corrupt index: page {} is on the free-list but is not a free page",
+                        free_id
+                    )));
+                }
+            };
+
+            sb.free_list_head = next_free;
+            self.write_superblock(&sb).await?;
+            return Ok(free_id);
+        }
+
         let id = sb.next_page_id;
         sb.next_page_id += 1;
         self.write_superblock(&sb).await?;
         Ok(id)
+    }
+
+    /// Return `page_id` to the free-list so a later `allocate_page` can
+    /// reuse it. The caller must guarantee no page still references it.
+    ///
+    /// The free page is written before the superblock head is updated, so a
+    /// crash between the two leaves the page merely orphaned (leaked) rather
+    /// than producing a free-list that points at live data.
+    pub async fn free_page(&self, page_id: PageId) -> errors::Result<()> {
+        let mut sb = self.read_superblock()?;
+
+        self.write_page(page_id, &Page::Free(sb.free_list_head))
+            .await?;
+
+        sb.free_list_head = Some(page_id);
+        self.write_superblock(&sb).await
+    }
+
+    /// Number of pages currently on the free-list. Test/diagnostic helper.
+    pub async fn free_page_count(&self) -> errors::Result<usize> {
+        let mut count = 0;
+        let mut next = self.read_superblock()?.free_list_head;
+
+        while let Some(page_id) = next {
+            match self.read_page(page_id).await? {
+                Page::Free(link) => {
+                    count += 1;
+                    next = link;
+                }
+                _ => {
+                    return Err(ExecuteError::wrap(format!(
+                        "corrupt index: page {} is on the free-list but is not a free page",
+                        page_id
+                    )));
+                }
+            }
+        }
+
+        Ok(count)
+    }
+
+    /// Highest page id ever handed out by the bump allocator (i.e. the
+    /// number of page slots in the file). Test/diagnostic helper.
+    pub async fn allocated_page_count(&self) -> errors::Result<PageId> {
+        Ok(self.read_superblock()?.next_page_id)
+    }
+
+    /// Head of the free-list. Test helper for structural assertions.
+    #[cfg(test)]
+    pub(crate) fn free_list_head_for_test(&self) -> Option<PageId> {
+        self.read_superblock().unwrap().free_list_head
     }
 
     pub async fn root_page_id(&self) -> errors::Result<Option<PageId>> {
@@ -209,9 +324,76 @@ mod tests {
             page_size: page::INDEX_PAGE_SIZE as u32,
             root_page_id: Some(12345),
             next_page_id: 67890,
+            free_list_head: Some(4242),
         };
         let encoded = bincode::serialize(&sb).unwrap();
         assert!(encoded.len() <= SUPERBLOCK_SIZE);
+    }
+
+    /// `read_superblock` locates the version field by byte offset to decide
+    /// which layout to decode, so that offset must match the encoding.
+    #[test]
+    fn version_field_sits_at_the_expected_byte_offset() {
+        let sb = Superblock {
+            magic: MAGIC,
+            version: VERSION,
+            page_size: page::INDEX_PAGE_SIZE as u32,
+            root_page_id: None,
+            next_page_id: 0,
+            free_list_head: None,
+        };
+        let encoded = bincode::serialize(&sb).unwrap();
+
+        assert_eq!(&encoded[0..4], &MAGIC);
+        assert_eq!(
+            u16::from_le_bytes(encoded[4..6].try_into().unwrap()),
+            VERSION
+        );
+    }
+
+    /// Index files written before issue #232 must still open, with an empty
+    /// free-list.
+    #[tokio::test]
+    async fn opens_a_version_1_superblock_with_an_empty_free_list() {
+        let path = temp_path("v1_compat.idx");
+
+        // Hand-write a v1 file: v1 superblock + one leaf page.
+        {
+            let mut encoded = bincode::serialize(&SuperblockV1 {
+                magic: MAGIC,
+                version: 1,
+                page_size: 256,
+                root_page_id: Some(0),
+                next_page_id: 1,
+            })
+            .unwrap();
+            encoded.resize(SUPERBLOCK_SIZE, 0);
+
+            let leaf = page::encode_page(
+                &Page::Leaf(LeafPage {
+                    entries: vec![LeafEntry {
+                        key: "I:001".to_string(),
+                        row_path: "/r/1".to_string(),
+                    }],
+                    next_leaf: None,
+                    overflow: None,
+                }),
+                256,
+            )
+            .unwrap();
+
+            let mut bytes = encoded;
+            bytes.extend_from_slice(&leaf);
+            std::fs::write(&path, bytes).unwrap();
+        }
+
+        let store = PageStore::open(&path).await.unwrap();
+        assert_eq!(store.page_size(), 256);
+        assert_eq!(store.root_page_id().await.unwrap(), Some(0));
+        assert_eq!(store.free_page_count().await.unwrap(), 0);
+
+        // A fresh allocation still works and does not collide with page 0.
+        assert_eq!(store.allocate_page().await.unwrap(), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
resolves: #232

## 설명

page-backed B+tree 인덱스(#230/#231)가 delete 이후 페이지를 전혀 회수하지 않던 문제를 해결합니다. 이제 비게 된 페이지는 free-list로 반환되고, 이후 insert가 파일을 늘리는 대신 그 슬롯을 재사용합니다.

### 구현

**free-list (PageStore)**

superblock에 `free_list_head`를 두고, 해제된 페이지 슬롯 자체가 다음 링크를 담는 단일 연결 리스트(`Page::Free(Option<PageId>)`)로 구성했습니다. 별도 메타데이터 페이지 없이 기존 고정 크기 페이지 배열 구조를 그대로 유지합니다.

- `allocate_page()`는 free-list head를 먼저 소비하고, 비어 있을 때만 기존 bump 할당으로 넘어갑니다.
- `free_page()`는 **페이지를 먼저 쓰고 그 다음 superblock head를 갱신**합니다. 두 쓰기 사이에서 크래시가 나면 페이지가 유실(leak)될 뿐, free-list가 살아있는 데이터를 가리키는 상태는 생기지 않습니다.

**빈 페이지 회수 (page_btree)**

- **overflow 페이지**: 마지막 항목이 빠지면 체인에서 splice out 후 반환합니다. 리프 자신의 항목이 모두 빠졌는데 overflow 체인이 남은 경우에는, 체인 head를 리프로 끌어올려 그룹이 고아가 되지 않게 합니다.
- **leaf 페이지**: 완전히 비면 ① `next_leaf` 체인에서 앞 리프를 재연결하고, ② 부모의 child 포인터와 그 child를 도입한 separator key를 제거하고, ③ 페이지를 반환합니다.
- **루트**: 마지막 리프가 사라지면 `root_page_id`를 `None`으로 되돌리고, 내부 루트에 자식이 하나만 남으면 그 자식을 루트로 승격시켜 레벨이 쌓이지 않게 합니다.

앞 리프를 찾을 때 리프 체인을 선형 탐색하면 O(리프 수)라 delete가 느려지므로, 삭제 시 기록해 둔 root-to-leaf 경로(`LeafPath`)를 거슬러 올라가 왼쪽 형제 서브트리의 최右 spine을 타고 내려가는 **O(트리 높이)** 방식으로 구현했습니다.

### 의도적으로 하지 않은 것

이슈의 "conservative하게 유지" 지침대로, **완전히 빈 페이지만** 회수합니다. underfull이지만 비어있지 않은 페이지의 redistribution/coalescing은 separator key 재작성이 필요해 범위에서 제외했고, duplicate-key overflow 체인의 compaction은 별도 이슈 #235의 몫으로 남겼습니다. 모듈 문서의 한계 설명도 현재 동작에 맞게 갱신했습니다.

### 하위 호환

superblock version을 2로 올렸습니다. version 필드를 바이트 오프셋으로 먼저 읽어 v1 파일은 예전 레이아웃으로 디코딩하고 free-list를 비운 상태로 취급하므로, #231 이후 만들어진 기존 인덱스 파일이 그대로 열립니다. (오프셋 가정이 깨지지 않도록 인코딩 위치를 검증하는 테스트를 넣었습니다.)

### 테스트

인덱스 테스트 42개 → 48개. 이슈가 요구한 4개 시나리오를 모두 포함합니다.

- 빈 leaf 발생(루트 리프 / 다중 리프 중간 블록 삭제)
- 이후 insert의 freed page id 재사용, 재오픈 후에도 재사용 유지
- 회수 이후 range scan / 정렬 순서 / 개별 lookup 정확성
- delete 후 duplicate-key overflow 그룹 보존

추가로 구조 무결성 검증 헬퍼(`assert_index_is_consistent`)를 만들어 각 테스트 끝에서 확인합니다: free-list에 사이클이 없고, 살아있는 트리·리프 체인·overflow 체인 어디에도 freed 페이지를 가리키는 포인터가 없으며, `keys+1 == children` 불변식이 유지되는지 봅니다.

`IndexManager` 레벨에도 churn 테스트를 넣어, `DELETE` 문이 실제로 타는 경로에서 인덱스 **파일 크기**가 라운드를 거듭해도 늘지 않는 것을 확인합니다.

### 검증

- `cargo test --lib engine::index::` — 48개 통과 (기존 42개 포함, 실패 0)
- `cargo test` — 323 + 327 + 5 통과, 실패 0
- `cargo clippy --all-targets` — 오류 0, 변경 파일 경고 0
- `rustfmt --check` (변경 파일 4개) — 통과
- `cargo bench --bench index_benchmark` — insert 경로 회귀 없음

  | n | before | after |
  |---|---|---|
  | 1K | 185 ops/sec | 209 ops/sec |
  | 10K | 188 ops/sec | 211 ops/sec |
  | 50K | 192 ops/sec | 190 ops/sec |

  50K의 -1%는 측정 노이즈 범위입니다. insert 경로에 추가된 비용은 free-list head 확인(이미 읽던 superblock의 필드) 뿐입니다.

참고: `cargo bench`를 돌리려면 `Cargo.toml`의 bench 경로 수정이 필요한데, 이는 #239에서 별도로 고치고 있어 이 PR에는 포함하지 않았습니다(측정 시에만 로컬 적용). 마찬가지로 master에 남아있는 무관한 포맷 드리프트도 리뷰 범위를 좁히기 위해 제외했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **개선 사항**
  - 삭제된 인덱스 페이지를 재사용할 수 있는 자유목록을 추가해 저장 공간 효율을 높였습니다.
  - 삭제·재삽입이 많은 상황에서도 인덱스 파일이 불필요하게 계속 커지는 현상을 완화했습니다.
  - 인덱스 순회 중 비정상 상태를 더 명확히 감지하도록 처리 흐름을 보강했습니다.
  - 기존 인덱스 파일(이전 버전) 호환을 유지했습니다.
- **진단**
  - 할당/재사용 가능 페이지 수와 트리 높이를 확인할 수 있는 진단 기능을 추가했습니다.
- **테스트/품질**
  - 삭제 후 재활용·복구 동작과 구조적 무결성 검증 시나리오를 확대했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->