### PR TITLE
[#236] fix: INSERT WAL replay 멱등성 확보

### DIFF
--- a/src/engine/actions/dml/insert.rs
+++ b/src/engine/actions/dml/insert.rs
@@ -7,7 +7,7 @@ use crate::engine::schema::row::{TableDataField, TableDataRow};
 use crate::engine::types::{
     ExecuteColumn, ExecuteColumnType, ExecuteField, ExecuteResult, ExecuteRow,
 };
-use crate::engine::wal::types::EntryType;
+use crate::engine::wal::types::{EntryType, InsertWALPayload};
 use crate::engine::{DBEngine, SharedWALManager};
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
@@ -26,6 +26,49 @@ impl DBEngine {
     /// operation is already durably recorded in the WAL being replayed).
     pub(crate) async fn insert_replay(&self, query: InsertQuery) -> errors::Result<ExecuteResult> {
         self.insert_internal(query, None).await
+    }
+
+    /// WAL replay용 INSERT.
+    ///
+    /// 행이 durable해진 뒤 WAL 체크포인트 경계가 진행되기 전에 크래시하면,
+    /// 이미 디스크에 있는 행을 replay가 다시 추가할 수 있습니다. unique 인덱스가
+    /// 없는 테이블에서는 값으로 중복을 판별할 수 없으므로(중복 행이 합법),
+    /// WAL에 기록해 둔 start_row_index로 판단합니다: 테이블이 이미 그 위치까지
+    /// 채워져 있다면 이 INSERT는 이미 반영된 것이므로 건너뜁니다 (#236).
+    pub(crate) async fn insert_replay_with_payload(
+        &self,
+        payload: InsertWALPayload,
+    ) -> errors::Result<ExecuteResult> {
+        let Some(into_table) = payload.query.into_table.as_ref() else {
+            return self.insert_replay(payload.query).await;
+        };
+
+        let next_row_index = self.next_row_index(into_table).await?;
+
+        if next_row_index >= payload.start_row_index + payload.row_count {
+            log::debug!(
+                "skipping already-applied INSERT replay for {} (rows {}..{}, table holds {})",
+                into_table.table_name,
+                payload.start_row_index,
+                payload.start_row_index + payload.row_count,
+                next_row_index
+            );
+            return Ok(ExecuteResult::with_affected_rows(
+                vec![ExecuteColumn {
+                    name: "desc".into(),
+                    data_type: ExecuteColumnType::String,
+                }],
+                vec![ExecuteRow {
+                    fields: vec![ExecuteField::String(format!(
+                        "skipped already-applied insert into {}",
+                        into_table.table_name
+                    ))],
+                }],
+                0,
+            ));
+        }
+
+        self.insert_replay(payload.query).await
     }
 
     async fn insert_internal(
@@ -204,18 +247,37 @@ impl DBEngine {
                     }
                 }
 
-                if let Some(wal_manager) = &wal_manager {
-                    let wal_payload = bincode::serialize(&query)
-                        .map_err(|error| ExecuteError::wrap(error.to_string()))?;
-                    wal_manager
-                        .lock()
-                        .await
-                        .append_record(EntryType::Insert, Some(wal_payload), None)
-                        .await?;
-                }
-
                 let affected_rows = rows.len();
-                let start_index = self.append_table_rows(into_table, &rows).await?;
+                let row_count = rows.len();
+
+                // WAL은 행 위치가 확정된 직후, 아직 row storage 락을 쥔 상태에서
+                // 기록합니다. 그래야 기록된 start_row_index가 실제로 이 INSERT가
+                // 차지한 범위와 일치하고, replay가 멱등해집니다 (#236).
+                let start_index = self
+                    .append_table_rows_with_reservation(into_table, &rows, |start_row_index| {
+                        let wal_manager = wal_manager.clone();
+                        let query = query.clone();
+                        async move {
+                            let Some(wal_manager) = wal_manager else {
+                                return Ok(());
+                            };
+
+                            let payload = InsertWALPayload {
+                                query,
+                                start_row_index,
+                                row_count,
+                            };
+                            let wal_payload = bincode::serialize(&payload)
+                                .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+
+                            wal_manager
+                                .lock()
+                                .await
+                                .append_record(EntryType::Insert, Some(wal_payload), None)
+                                .await
+                        }
+                    })
+                    .await?;
 
                 // 인덱스 반영 (#217)
                 // 안전성: append_table_rows가 row_storage_lock으로 직렬화되므로,
@@ -253,7 +315,11 @@ impl DBEngine {
                                 return Err(error);
                             }
 
-                            applied_index_entries.push((meta.index_name.clone(), key, row_path.clone()));
+                            applied_index_entries.push((
+                                meta.index_name.clone(),
+                                key,
+                                row_path.clone(),
+                            ));
                         }
                     }
                 }

--- a/src/engine/actions/dml/scan.rs
+++ b/src/engine/actions/dml/scan.rs
@@ -5,7 +5,6 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 
-
 use crate::engine::DBEngine;
 use crate::engine::ast::dml::plan::select::scan::IndexScanPlan;
 use crate::engine::ast::types::TableName;
@@ -18,7 +17,6 @@ use crate::errors::execute_error::ExecuteError;
 const ROW_SEGMENT_FILENAME: &str = "00000001.rows";
 const ROW_META_FILENAME: &str = "meta.bin";
 const DEFAULT_ROW_WRITE_BUFFER_LIMIT_BYTES: usize = 16 * 1024 * 1024;
-
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct RowLocation {
@@ -59,6 +57,11 @@ impl DBEngine {
     /// 행을 세그먼트 파일 끝에 추가하고 시작 row index를 반환합니다.
     /// 반환된 시작 인덱스는 인덱스 유지보수(key -> row index)에 사용됩니다.
     /// 시작 인덱스는 meta.bin + 버퍼 상태를 사용해 계산하므로 세그먼트 전체 스캔이 필요 없습니다.
+    ///
+    /// 프로덕션 INSERT 경로는 WAL 기록과 위치 확정을 원자적으로 처리해야 하므로
+    /// `append_table_rows_with_reservation`을 사용합니다 (#236). 이 함수는 WAL이
+    /// 필요 없는 테스트/내부 용도로 남겨둡니다.
+    #[cfg(test)]
     pub(crate) async fn append_table_rows(
         &self,
         table_name: &TableName,
@@ -72,12 +75,80 @@ impl DBEngine {
         .await
     }
 
+    /// 행을 추가하되, 추가할 위치를 확정한 직후 `on_reserved`를 호출합니다.
+    ///
+    /// INSERT는 WAL 기록과 행 추가가 같은 row index를 가리켜야 replay가
+    /// 멱등해집니다 (#236). 두 작업을 따로 하면 그 사이에 다른 INSERT가
+    /// 끼어들어 인덱스가 어긋나므로, `row_storage_lock`을 쥔 채로 위치를
+    /// 확정하고 콜백에서 WAL을 기록합니다.
+    pub(crate) async fn append_table_rows_with_reservation<F, Fut>(
+        &self,
+        table_name: &TableName,
+        rows: &[TableDataRow],
+        on_reserved: F,
+    ) -> errors::Result<usize>
+    where
+        F: FnOnce(usize) -> Fut,
+        Fut: std::future::Future<Output = errors::Result<()>>,
+    {
+        self.append_table_rows_inner(
+            table_name,
+            rows,
+            DEFAULT_ROW_WRITE_BUFFER_LIMIT_BYTES,
+            Some(on_reserved),
+        )
+        .await
+    }
+
+    #[cfg(test)]
     async fn append_table_rows_with_buffer_limit(
         &self,
         table_name: &TableName,
         rows: &[TableDataRow],
         buffer_limit_bytes: usize,
     ) -> errors::Result<usize> {
+        self.append_table_rows_inner(
+            table_name,
+            rows,
+            buffer_limit_bytes,
+            None::<fn(usize) -> std::future::Ready<errors::Result<()>>>,
+        )
+        .await
+    }
+
+    /// 현재 테이블의 다음 row index(= 논리적 행 개수)를 반환합니다.
+    ///
+    /// `append_table_rows`와 같은 계산(meta.bin + 버퍼 상태)이라 세그먼트 전체
+    /// 스캔이 필요 없습니다. WAL replay가 이 INSERT를 이미 반영했는지 판단할 때
+    /// 사용합니다 (#236).
+    pub(crate) async fn next_row_index(&self, table_name: &TableName) -> errors::Result<usize> {
+        let _guard = self.row_storage_lock.lock().await;
+
+        let segment_path = self.row_segment_path(table_name)?;
+        if let Some(count) = self
+            .row_buffer_pool
+            .lock()
+            .await
+            .cached_row_count(&segment_path)
+        {
+            return Ok(count);
+        }
+
+        let meta_path = self.row_segment_meta_path(table_name)?;
+        Ok(self.read_segment_meta(&meta_path).await?.next_row_index)
+    }
+
+    async fn append_table_rows_inner<F, Fut>(
+        &self,
+        table_name: &TableName,
+        rows: &[TableDataRow],
+        buffer_limit_bytes: usize,
+        on_reserved: Option<F>,
+    ) -> errors::Result<usize>
+    where
+        F: FnOnce(usize) -> Fut,
+        Fut: std::future::Future<Output = errors::Result<()>>,
+    {
         if rows.is_empty() {
             return Ok(0);
         }
@@ -86,7 +157,12 @@ impl DBEngine {
         let segment_path = self.row_segment_path(table_name)?;
         let meta_path = self.row_segment_meta_path(table_name)?;
 
-        let cached_start_index = { self.row_buffer_pool.lock().await.cached_row_count(&segment_path) };
+        let cached_start_index = {
+            self.row_buffer_pool
+                .lock()
+                .await
+                .cached_row_count(&segment_path)
+        };
         let start_index = match cached_start_index {
             Some(count) => count,
             None => {
@@ -99,6 +175,12 @@ impl DBEngine {
                 start_index
             }
         };
+
+        // 위치가 확정된 뒤, 아직 락을 쥔 상태에서 WAL을 기록합니다. 실패하면
+        // 행을 추가하지 않고 그대로 반환하므로 WAL과 데이터가 어긋나지 않습니다.
+        if let Some(on_reserved) = on_reserved {
+            on_reserved(start_index).await?;
+        }
 
         let frame = encode_live_row_frames(rows)?;
 
@@ -380,11 +462,15 @@ impl DBEngine {
     }
 
     pub(crate) fn row_segment_path(&self, table_name: &TableName) -> errors::Result<PathBuf> {
-        Ok(self.table_rows_directory(table_name)?.join(ROW_SEGMENT_FILENAME))
+        Ok(self
+            .table_rows_directory(table_name)?
+            .join(ROW_SEGMENT_FILENAME))
     }
 
     fn row_segment_meta_path(&self, table_name: &TableName) -> errors::Result<PathBuf> {
-        Ok(self.table_rows_directory(table_name)?.join(ROW_META_FILENAME))
+        Ok(self
+            .table_rows_directory(table_name)?
+            .join(ROW_META_FILENAME))
     }
 
     fn row_segment_meta_path_from_segment_path(&self, segment_path: &Path) -> PathBuf {
@@ -604,13 +690,16 @@ mod tests {
         engine
             .update_table_rows(
                 &table_name_clone,
-                HashMap::from([(0, TableDataRow {
-                    fields: vec![TableDataField {
-                        table_name: table_name.clone(),
-                        column_name: "id".to_string(),
-                        data: TableDataFieldType::Integer(10),
-                    }],
-                })]),
+                HashMap::from([(
+                    0,
+                    TableDataRow {
+                        fields: vec![TableDataField {
+                            table_name: table_name.clone(),
+                            column_name: "id".to_string(),
+                            data: TableDataFieldType::Integer(10),
+                        }],
+                    },
+                )]),
             )
             .await
             .unwrap();
@@ -666,7 +755,10 @@ mod tests {
         assert_eq!(scanned[1].0.row_index, 2);
         assert_eq!(scanned[1].1.fields[0].data, TableDataFieldType::Integer(3));
 
-        let start_index = engine.append_table_rows(&table_name, &[row(4)]).await.unwrap();
+        let start_index = engine
+            .append_table_rows(&table_name, &[row(4)])
+            .await
+            .unwrap();
         assert_eq!(start_index, 3);
 
         let scanned = engine.full_scan(table_name).await.unwrap();

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -37,7 +37,7 @@ use crate::engine::schema::table::TableSchema;
 use crate::engine::types::ExecuteResult;
 use crate::engine::wal::endec::implements::bincode::BincodeEncoder;
 use crate::engine::wal::manager::WALManager;
-use crate::engine::wal::types::{EntryType, WALEntry};
+use crate::engine::wal::types::{EntryType, InsertWALPayload, WALEntry};
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
 use tokio::sync::{Mutex, RwLock};
@@ -149,8 +149,18 @@ impl DBEngine {
             let result: errors::Result<()> = async {
                 match entry.entry_type {
                     EntryType::Insert => {
-                        let query = Self::decode_wal_payload::<InsertQuery>(data)?;
-                        self.insert_replay(query).await.map(|_| ())
+                        // 새 형식은 start_row_index를 포함합니다. 이전 형식(InsertQuery
+                        // 단독)으로 기록된 WAL도 그대로 읽을 수 있어야 하므로,
+                        // 실패 시 이전 형식으로 폴백합니다 (#236).
+                        match Self::decode_wal_payload::<InsertWALPayload>(data) {
+                            Ok(payload) => {
+                                self.insert_replay_with_payload(payload).await.map(|_| ())
+                            }
+                            Err(_) => {
+                                let query = Self::decode_wal_payload::<InsertQuery>(data)?;
+                                self.insert_replay(query).await.map(|_| ())
+                            }
+                        }
                     }
                     EntryType::Set => {
                         let query = Self::decode_wal_payload::<UpdateQuery>(data)?;
@@ -274,10 +284,13 @@ mod tests {
 
     use crate::config::launch_config::LaunchConfig;
     use crate::engine::DBEngine;
+    use crate::engine::ast::dml::insert::{InsertData, InsertQuery};
+    use crate::engine::ast::dml::parts::insert_values::InsertValue;
+    use crate::engine::ast::types::SQLExpression;
     use crate::engine::ast::types::{Column, DataType, TableName};
     use crate::engine::encoder::schema_encoder::StorageEncoder;
     use crate::engine::schema::table::TableSchema;
-    use crate::engine::wal::types::{EntryType, WALEntry};
+    use crate::engine::wal::types::{EntryType, InsertWALPayload, WALEntry};
 
     #[tokio::test]
     async fn replay_wal_returns_contextual_error_for_invalid_payload() {
@@ -345,5 +358,121 @@ mod tests {
 
         assert_eq!(first.columns.len(), 1);
         assert_eq!(second.columns[0].name, "id");
+    }
+
+    /// 행이 durable해진 뒤 WAL 체크포인트 경계가 진행되기 전에 크래시하면,
+    /// 재시작 시 replay가 이미 디스크에 있는 행을 다시 추가할 수 있었습니다.
+    /// unique 인덱스가 없는 테이블에서는 값으로 중복을 판별할 수 없으므로
+    /// (중복 행이 합법) WAL에 남긴 start_row_index로 판단합니다 (#236).
+    #[tokio::test]
+    async fn insert_replay_is_idempotent_for_non_unique_table() {
+        let base_path = PathBuf::from("target/test_wal_replay/idempotent_insert");
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+
+        let engine = build_engine_with_table(&base_path, "events").await;
+        let table_name = TableName::new(Some("rrdb".to_string()), "events".to_string());
+
+        let query = insert_query(&table_name, 1);
+        let payload = InsertWALPayload {
+            query: query.clone(),
+            start_row_index: 0,
+            row_count: 1,
+        };
+
+        // 첫 replay: 행이 아직 없으므로 반영되어야 합니다.
+        engine
+            .insert_replay_with_payload(payload.clone())
+            .await
+            .unwrap();
+        engine.flush_row_buffers().await.unwrap();
+        assert_eq!(engine.next_row_index(&table_name).await.unwrap(), 1);
+
+        // 두 번째 replay: 같은 WAL 엔트리가 다시 재생되어도 중복 삽입되면 안 됩니다.
+        engine.insert_replay_with_payload(payload).await.unwrap();
+        engine.flush_row_buffers().await.unwrap();
+        assert_eq!(
+            engine.next_row_index(&table_name).await.unwrap(),
+            1,
+            "replaying an already-applied INSERT must not duplicate the row"
+        );
+    }
+
+    /// 멱등성 처리가 정상적인 중복 INSERT까지 막으면 안 됩니다. 서로 다른
+    /// start_row_index를 가진 두 INSERT는 값이 같아도 모두 보존되어야 합니다.
+    #[tokio::test]
+    async fn legitimate_duplicate_inserts_are_preserved() {
+        let base_path = PathBuf::from("target/test_wal_replay/duplicate_inserts");
+        if base_path.exists() {
+            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        }
+
+        let engine = build_engine_with_table(&base_path, "events").await;
+        let table_name = TableName::new(Some("rrdb".to_string()), "events".to_string());
+
+        for start_row_index in 0..3 {
+            engine
+                .insert_replay_with_payload(InsertWALPayload {
+                    query: insert_query(&table_name, 7),
+                    start_row_index,
+                    row_count: 1,
+                })
+                .await
+                .unwrap();
+            engine.flush_row_buffers().await.unwrap();
+        }
+
+        assert_eq!(
+            engine.next_row_index(&table_name).await.unwrap(),
+            3,
+            "identical rows inserted by distinct statements must all survive"
+        );
+    }
+
+    fn insert_query(table_name: &TableName, value: i64) -> InsertQuery {
+        InsertQuery {
+            into_table: Some(table_name.clone()),
+            columns: vec!["id".to_string()],
+            data: InsertData::Values(vec![InsertValue {
+                list: vec![Some(SQLExpression::Integer(value))],
+            }]),
+        }
+    }
+
+    async fn build_engine_with_table(base_path: &PathBuf, table: &str) -> DBEngine {
+        let config = LaunchConfig::default_for_base_path(base_path);
+        let table_name = TableName::new(Some("rrdb".to_string()), table.to_string());
+        let table_path = PathBuf::from(&config.data_directory)
+            .join("rrdb")
+            .join("tables")
+            .join(table);
+
+        tokio::fs::create_dir_all(table_path.join("rows"))
+            .await
+            .unwrap();
+
+        let table_config = TableSchema {
+            table: table_name,
+            columns: vec![
+                Column::builder()
+                    .set_name("id".to_string())
+                    .set_data_type(DataType::Int)
+                    .build(),
+            ],
+            primary_key: vec![],
+            foreign_keys: vec![],
+            unique_keys: vec![],
+        };
+
+        let encoder = StorageEncoder::new();
+        tokio::fs::write(
+            table_path.join("table.config"),
+            encoder.encode(table_config),
+        )
+        .await
+        .unwrap();
+
+        DBEngine::new(config)
     }
 }

--- a/src/engine/wal/types.rs
+++ b/src/engine/wal/types.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::engine::ast::dml::insert::InsertQuery;
+
 #[derive(Default, Clone, Debug, Deserialize, Serialize)]
 pub struct WALEntry {
     pub entry_type: EntryType,
@@ -19,6 +21,24 @@ impl WALEntry {
             + size_of::<bool>()
             + data_size
     }
+}
+
+/// Payload for `EntryType::Insert`.
+///
+/// The query alone is not enough to replay an INSERT idempotently. Rows can
+/// become durable before the WAL checkpoint boundary advances, so a crash can
+/// leave the rows on disk while the WAL entry is still replay-pending; replay
+/// would then append them a second time. Deduplicating by row value is not an
+/// option because duplicate rows are legal on tables without a unique index.
+///
+/// `start_row_index` records where this statement's rows were placed, giving
+/// replay a stable identity: if the table already holds rows at that position,
+/// this INSERT is already durable and must be skipped (see issue #236).
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct InsertWALPayload {
+    pub query: InsertQuery,
+    pub start_row_index: usize,
+    pub row_count: usize,
 }
 
 #[derive(Default, Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
resolves: #236

## 문제

행이 durable해진 뒤 WAL 체크포인트 경계가 진행되기 전에 크래시하면, 재시작 replay가 **이미 디스크에 있는 행을 다시 추가**합니다.

unique 인덱스가 없는 테이블에서는 값으로 중복을 판별할 수 없습니다 — 중복 행 자체가 합법이니까요. 그래서 기존 구현에는 이걸 막을 방법이 없었습니다.

## 해결

이슈에서 제안한 "안정적인 replay 식별자" 방향으로, INSERT WAL 페이로드에 이 statement가 차지한 행 범위를 함께 남겼습니다.

```rust
pub struct InsertWALPayload {
    pub query: InsertQuery,
    pub start_row_index: usize,
    pub row_count: usize,
}
```

replay는 테이블이 이미 `start_row_index + row_count`까지 차 있으면 해당 INSERT가 반영된 것으로 보고 건너뜁니다.

### 원자성이 관건이었습니다

`start_row_index`가 실제 기록 위치와 어긋나면 이 방식은 의미가 없습니다. 그래서 WAL 기록을 **행 위치 확정 직후, `row_storage_lock`을 쥔 상태에서** 수행합니다.

`append_table_rows_with_reservation`이 위치를 확정한 뒤 콜백으로 WAL을 기록하고, WAL 기록이 실패하면 행을 추가하지 않고 반환합니다. 두 작업을 분리하면 그 사이에 다른 INSERT가 끼어들어 인덱스가 어긋납니다.

### 하위 호환

이전 형식(`InsertQuery` 단독)으로 기록된 WAL도 읽혀야 하므로, 새 형식 디코딩 실패 시 이전 형식으로 폴백합니다. 기존 WAL 파일을 가진 인스턴스도 그대로 복구됩니다.

## 테스트

수용 기준에 맞춰 두 방향을 모두 검증했습니다.

| 테스트 | 확인 내용 |
|---|---|
| `insert_replay_is_idempotent_for_non_unique_table` | 같은 WAL 엔트리를 두 번 replay해도 행이 늘지 않음 |
| `legitimate_duplicate_inserts_are_preserved` | 서로 다른 `start_row_index`를 가진 동일 값 INSERT 3건은 모두 보존 |

테스트가 실제로 버그를 잡는지 확인하려고 멱등성 검사를 임시로 무력화해봤고, 예상대로 실패했습니다:

```
assertion `left == right` failed: replaying an already-applied INSERT must not duplicate the row
  left: 2
 right: 1
```

## 검증

- `cargo test` — **641 passed / 0 failed**
- `cargo clippy --lib --bins` — 신규 경고 없음
- 기존 WAL replay 테스트 모두 통과

참고로 `append_table_rows` / `append_table_rows_with_buffer_limit`는 이제 프로덕션 경로에서 쓰이지 않아 `#[cfg(test)]`로 표시했습니다. 남겨두는 편이 나을지, 아니면 테스트도 새 API를 쓰도록 바꿀지는 의견 주시면 맞추겠습니다.
