### PR TITLE
fix(pgwire): 조작된 길이 필드로 인한 원격 패닉 차단

### DIFF
--- a/src/pgwire/protocol/connection_codec.rs
+++ b/src/pgwire/protocol/connection_codec.rs
@@ -79,7 +79,7 @@ impl Decoder for ConnectionCodec {
             }
 
             let mut header_buf = src.clone();
-            let message_len = header_buf.get_i32() as usize;
+            let declared_len = header_buf.get_i32();
             let protocol_version_major = header_buf.get_i16();
             let protocol_version_minor = header_buf.get_i16();
 
@@ -92,6 +92,16 @@ impl Decoder for ConnectionCodec {
                 src.advance(STARTUP_HEADER_SIZE);
                 return Ok(Some(ClientMessage::GSSENCRequest));
             }
+
+            // 길이는 클라이언트가 보낸 값이므로 신뢰할 수 없습니다. 헤더보다 짧으면
+            // 아래 `message_len - STARTUP_HEADER_SIZE`가 언더플로해 패닉하고,
+            // 음수면 usize 캐스팅 후 거대한 값이 되어 `reserve`가 할당에 실패합니다.
+            // 둘 다 인증 이전 단계라 누구나 서버를 죽일 수 있습니다.
+            if declared_len < STARTUP_HEADER_SIZE as i32 {
+                return Err(ProtocolError::ParserError);
+            }
+
+            let message_len = declared_len as usize;
 
             if src.len() < message_len {
                 src.reserve(message_len - src.len());
@@ -137,11 +147,15 @@ impl Decoder for ConnectionCodec {
 
         let mut header_buf = src.clone();
         let message_tag = header_buf.get_u8();
-        let message_len = header_buf.get_i32() as usize;
+        let declared_len = header_buf.get_i32();
 
-        if message_len < size_of::<i32>() {
+        // 음수 길이는 usize 캐스팅 시 거대한 값이 되어 `reserve`가 할당에
+        // 실패하며 패닉합니다. 캐스팅 전에 걸러냅니다.
+        if declared_len < size_of::<i32>() as i32 {
             return Err(ProtocolError::ParserError);
         }
+
+        let message_len = declared_len as usize;
 
         let total_message_len = 1 + message_len;
 
@@ -475,5 +489,76 @@ mod tests {
         let decoded = codec.decode(&mut message);
 
         assert!(decoded.is_err());
+    }
+
+    /// 길이 필드는 클라이언트가 보낸 값이라 신뢰할 수 없습니다. 헤더 크기보다
+    /// 작거나 음수인 길이는 `usize` 캐스팅 전에 걸러야 합니다. 그러지 않으면
+    /// `message_len - STARTUP_HEADER_SIZE`가 언더플로해 패닉하거나, 음수가
+    /// 거대한 `usize`가 되어 `reserve`가 할당에 실패합니다.
+    ///
+    /// startup 메시지는 인증 이전 단계라 아무나 보낼 수 있어, 이 패닉은 원격에서
+    /// 연결 태스크를 죽이는 데 쓰일 수 있었습니다.
+    #[test]
+    fn malformed_startup_length_is_rejected_without_panicking() {
+        for declared_len in [0i32, 1, 4, 7, -1, i32::MIN] {
+            let mut codec = ConnectionCodec::new();
+            let mut message = BytesMut::new();
+            message.put_i32(declared_len);
+            message.put_i16(3);
+            message.put_i16(0);
+            message.put_slice(b"user\0me\0\0");
+
+            assert!(
+                codec.decode(&mut message).is_err(),
+                "startup length {declared_len} should be rejected"
+            );
+        }
+    }
+
+    /// 정상적인 startup 메시지는 그대로 처리되어야 합니다.
+    #[test]
+    fn well_formed_startup_message_still_decodes() {
+        let mut codec = ConnectionCodec::new();
+        let mut body = BytesMut::new();
+        body.put_i16(3);
+        body.put_i16(0);
+        body.put_slice(b"user\0me\0\0");
+
+        let mut message = BytesMut::new();
+        message.put_i32((4 + body.len()) as i32);
+        message.extend_from_slice(&body);
+
+        let decoded = codec.decode(&mut message).unwrap().unwrap();
+
+        match decoded {
+            ClientMessage::Startup(startup) => {
+                assert_eq!(startup.requested_protocol_version, (3, 0));
+                assert_eq!(
+                    startup.parameters.get("user").map(String::as_str),
+                    Some("me")
+                );
+            }
+            other => panic!("expected startup, got {other:?}"),
+        }
+        assert!(codec.startup_received);
+    }
+
+    /// 일반 메시지 경로도 같은 이유로 음수 길이를 캐스팅 전에 걸러야 합니다.
+    #[test]
+    fn negative_regular_message_length_is_rejected_without_panicking() {
+        for declared_len in [-1i32, i32::MIN] {
+            let mut codec = ConnectionCodec {
+                startup_received: true,
+            };
+            let mut message = BytesMut::new();
+            message.put_u8(b'Q');
+            message.put_i32(declared_len);
+            message.put_slice(b"select 1\0");
+
+            assert!(
+                codec.decode(&mut message).is_err(),
+                "message length {declared_len} should be rejected"
+            );
+        }
     }
 }


### PR DESCRIPTION
## 문제

pgwire 디코더가 클라이언트가 보낸 길이 필드를 검증 없이 `usize`로 캐스팅해서, **조작된 메시지 하나로 연결 태스크를 패닉**시킬 수 있었습니다.

### startup 메시지 (인증 이전)

```rust
let message_len = header_buf.get_i32() as usize;
...
src.advance(message_len - STARTUP_HEADER_SIZE);   // 언더플로
```

| 보낸 길이 | 결과 |
|---|---|
| `0, 1, 4, 7` (헤더 8보다 작음) | 뺄셈 언더플로 → 패닉 |
| `-1`, `i32::MIN` | `usize` 캐스팅 후 거대한 값 → `reserve` 할당 실패로 패닉 |

startup은 **인증 이전** 단계라, 포트에 접속만 할 수 있으면 누구나 보낼 수 있습니다.

### 일반 메시지

```rust
let message_len = header_buf.get_i32() as usize;
if message_len < size_of::<i32>() { ... }   // 캐스팅 뒤라 음수를 못 거름
```

하한 검사는 있었지만 `as usize` **뒤에** 있어서, 음수는 이미 거대한 값이 된 채로 검사를 통과합니다.

## 해결

두 경로 모두 `i32` 상태에서 하한을 검사한 뒤 캐스팅하도록 바꿨습니다. 동작 변경은 없고, 지금까지 패닉하던 입력이 `ProtocolError::ParserError`로 돌아옵니다.

## 테스트

| 테스트 | 확인 |
|---|---|
| `malformed_startup_length_is_rejected_without_panicking` | `0, 1, 4, 7, -1, i32::MIN` 모두 에러 |
| `negative_regular_message_length_is_rejected_without_panicking` | `-1, i32::MIN` 에러 |
| `well_formed_startup_message_still_decodes` | 정상 startup은 그대로 (파라미터 파싱, `startup_received` 전이 포함) |

수정을 무력화하면 앞의 두 테스트가 실제로 패닉하며 실패하는 것을 확인했습니다:

```
panicked at src/pgwire/protocol/connection_codec.rs:134:25
panicked at src/pgwire/protocol/connection_codec.rs:160:33
```

## 검증

- `cargo test` — **643 passed / 0 failed**
- `cargo clippy --lib` — 신규 경고 없음
- 변경 파일 1개 (`connection_codec.rs`)

이슈 없이 올렸는데, 필요하시면 이슈 먼저 만들고 연결하겠습니다. #182(pgwire 구조 개선)와도 맞닿아 있지만 그 범위와는 독립적인 수정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 잘못된 메시지 길이로 인해 발생할 수 있는 패닉과 비정상적인 메모리 요청을 방지했습니다.
  * 손상되거나 유효하지 않은 Startup 및 일반 메시지는 안전하게 오류로 거부됩니다.
  * 정상적인 Startup 메시지는 기존과 동일하게 처리됩니다.
  * 다양한 경계값과 음수 길이에 대한 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->