### PR TITLE
fix(pgwire): startup 파라미터 파싱을 메시지 경계 안으로 제한

### DIFF
--- a/src/pgwire/protocol/connection_codec.rs
+++ b/src/pgwire/protocol/connection_codec.rs
@@ -329,6 +329,7 @@ mod tests {
     use crate::pgwire::protocol::client::{ClientMessage, Close};
 
     use super::ConnectionCodec;
+    use super::STARTUP_HEADER_SIZE;
 
     fn close_message(target_type: u8, name: &str) -> BytesMut {
         let mut message = BytesMut::new();
@@ -611,5 +612,111 @@ mod tests {
 
         // 뒤따르던 바이트는 그대로 남아 다음 디코딩에 쓰여야 합니다.
         assert_eq!(&message[..], b"INJECTED\0VALUE\0");
+    }
+
+    /// 결정적 xorshift. 실패하면 seed 하나로 그대로 재현됩니다.
+    struct FuzzRng(u64);
+
+    impl FuzzRng {
+        fn next(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            x
+        }
+    }
+
+    /// 구조를 갖춘 퍼징: 헤더(tag + length)는 항상 올바르게 만들어서
+    /// 길이 검사를 통과시킨 뒤 본문 파서까지 도달시킵니다. 순수 랜덤
+    /// 바이트는 유효한 헤더를 거의 만들지 못해 이 경로를 못 건드립니다.
+    #[test]
+    fn decoder_never_panics_on_structured_garbage() {
+        let tags: [u8; 8] = [b'B', b'Q', b'P', b'D', b'E', b'C', b'X', b'F'];
+
+        for seed in 1u64..20000 {
+            let mut rng = FuzzRng(seed);
+            let tag = tags[(rng.next() % 8) as usize];
+            let body_len = (rng.next() % 40) as usize;
+
+            let mut body = Vec::with_capacity(body_len);
+            for _ in 0..body_len {
+                let r = rng.next();
+                body.push(match r % 5 {
+                    0 => 0u8,
+                    1 => 0xff,
+                    2 => 0x80,
+                    3 => (r >> 16) as u8,
+                    _ => b'a',
+                });
+            }
+
+            // 길이 필드 자체도 퍼징 대상입니다. 여기를 항상 올바르게 계산하면
+            // 조작된 길이로 인한 언더플로/거대 할당 경로를 영영 못 건드립니다.
+            let honest = (size_of::<i32>() + body.len()) as i32;
+            let declared = match rng.next() % 8 {
+                0 => 0,
+                1 => -1,
+                2 => i32::MIN,
+                3 => i32::MAX,
+                4 => honest.wrapping_neg(),
+                5 => (rng.next() >> 32) as i32,
+                6 => honest.wrapping_sub((rng.next() % 16) as i32),
+                _ => honest,
+            };
+            let mut buf = BytesMut::new();
+            buf.put_u8(tag);
+            buf.put_i32(declared);
+            buf.put_slice(&body);
+
+            let mut codec = ConnectionCodec::new();
+            codec.startup_received = true;
+            // 패닉하지 않는 것이 조건입니다. Err는 정상적인 거부입니다.
+            let _ = codec.decode(&mut buf);
+        }
+    }
+
+    /// 인증 이전 startup 경로도 같은 방식으로 훑습니다.
+    #[test]
+    fn startup_decoder_never_panics_on_structured_garbage() {
+        for seed in 1u64..20000 {
+            let mut rng = FuzzRng(seed);
+            let body_len = (rng.next() % 40) as usize;
+
+            let mut body = Vec::with_capacity(body_len);
+            for _ in 0..body_len {
+                let r = rng.next();
+                body.push(match r % 4 {
+                    0 => 0u8,
+                    1 => 0xff,
+                    2 => (r >> 16) as u8,
+                    _ => b'k',
+                });
+            }
+
+            let honest = (STARTUP_HEADER_SIZE + body.len()) as i32;
+            let declared = match rng.next() % 8 {
+                0 => 0,
+                1 => -1,
+                2 => i32::MIN,
+                3 => i32::MAX,
+                4 => honest.wrapping_neg(),
+                5 => (rng.next() >> 32) as i32,
+                6 => honest.wrapping_sub((rng.next() % 16) as i32),
+                _ => honest,
+            };
+            let major = (rng.next() % 4) as i16;
+            let minor = (rng.next() % 4) as i16;
+
+            let mut buf = BytesMut::new();
+            buf.put_i32(declared);
+            buf.put_i16(major);
+            buf.put_i16(minor);
+            buf.put_slice(&body);
+
+            let mut codec = ConnectionCodec::new();
+            let _ = codec.decode(&mut buf);
+        }
     }
 }

--- a/src/pgwire/protocol/connection_codec.rs
+++ b/src/pgwire/protocol/connection_codec.rs
@@ -115,9 +115,16 @@ impl Decoder for ConnectionCodec {
             let mut param_str_start_pos = 0;
             let mut current_key = None;
 
-            for (i, &blah) in src.iter().enumerate() {
-                if blah == 0 {
-                    let string_value = String::from_utf8(src[param_str_start_pos..i].to_owned())?;
+            // 파라미터 영역은 이 메시지 안으로 한정해야 합니다. `src`는 아직
+            // 소비되지 않은 스트림 전체라, 뒤에 파이프라이닝된 다음 메시지가
+            // 붙어 있으면 그 바이트까지 파라미터로 읽힙니다.
+            let parameters_len = message_len - STARTUP_HEADER_SIZE;
+            let parameters_buf = &src[..parameters_len];
+
+            for (i, &byte) in parameters_buf.iter().enumerate() {
+                if byte == 0 {
+                    let string_value =
+                        String::from_utf8(parameters_buf[param_str_start_pos..i].to_owned())?;
 
                     param_str_start_pos = i + 1;
 
@@ -131,7 +138,7 @@ impl Decoder for ConnectionCodec {
                 }
             }
 
-            src.advance(message_len - STARTUP_HEADER_SIZE);
+            src.advance(parameters_len);
 
             self.startup_received = true;
             return Ok(Some(ClientMessage::Startup(Startup {
@@ -560,5 +567,49 @@ mod tests {
                 "message length {declared_len} should be rejected"
             );
         }
+    }
+
+    /// startup 파라미터 파싱은 이 메시지의 길이 안에서만 이뤄져야 합니다.
+    ///
+    /// 이전 구현은 아직 소비되지 않은 스트림 전체(`src`)를 순회해서, 클라이언트가
+    /// startup 뒤에 다음 메시지를 곧바로 이어 보내면(파이프라이닝) 그 바이트까지
+    /// 파라미터로 읽었습니다. 결과적으로 보내지도 않은 항목이 파라미터 맵에
+    /// 들어가고, 이어지는 메시지도 일부 소비되어 프레이밍이 어긋납니다.
+    #[test]
+    fn startup_parameters_stop_at_message_boundary() {
+        let mut codec = ConnectionCodec::new();
+
+        let mut body = BytesMut::new();
+        body.put_i16(3);
+        body.put_i16(0);
+        body.put_slice(b"user\0me\0\0");
+
+        let mut message = BytesMut::new();
+        message.put_i32((4 + body.len()) as i32);
+        message.extend_from_slice(&body);
+
+        // startup 직후에 이어지는 바이트. 파라미터로 섞여 들어가면 안 됩니다.
+        message.put_slice(b"INJECTED\0VALUE\0");
+
+        let decoded = codec.decode(&mut message).unwrap().unwrap();
+
+        match decoded {
+            ClientMessage::Startup(startup) => {
+                assert_eq!(
+                    startup.parameters.get("user").map(String::as_str),
+                    Some("me")
+                );
+                assert_eq!(
+                    startup.parameters.len(),
+                    1,
+                    "bytes after the startup message must not become parameters, got {:?}",
+                    startup.parameters
+                );
+            }
+            other => panic!("expected startup, got {other:?}"),
+        }
+
+        // 뒤따르던 바이트는 그대로 남아 다음 디코딩에 쓰여야 합니다.
+        assert_eq!(&message[..], b"INJECTED\0VALUE\0");
     }
 }


### PR DESCRIPTION
**#244 위에 쌓여 있습니다.** #244를 먼저 병합해 주시거나, 원하시면 master로 리베이스하겠습니다. (경계 계산이 #244의 길이 검증에 의존해서 순서를 이렇게 뒀습니다.)

## 문제

startup 파라미터 파싱 루프가 `src` 전체를 순회합니다. `src`는 아직 소비되지 않은 **스트림 전체**라, 클라이언트가 startup 뒤에 다음 메시지를 곧바로 이어 보내면(파이프라이닝) 그 바이트까지 파라미터로 읽힙니다.

```rust
for (i, &blah) in src.iter().enumerate() {   // 메시지 길이와 무관하게 끝까지
```

startup 뒤에 `INJECTED\0VALUE\0`을 붙여 보낸 결과입니다:

```
params: {"": "INJECTED", "user": "me"}
```

보내지도 않은 항목이 파라미터 맵에 들어갔고, 이어지는 메시지도 일부가 소비되어 프레이밍이 어긋납니다. `psql`처럼 startup 후 응답을 기다리는 클라이언트에서는 잘 안 드러나지만, 메시지를 몰아 보내는 드라이버에서는 재현됩니다.

## 해결

파라미터 영역을 `message_len - STARTUP_HEADER_SIZE`로 한정해 순회하고, 소비도 딱 그만큼만 합니다. 뒤따르는 바이트는 다음 디코딩에 그대로 남습니다.

## 테스트

`startup_parameters_stop_at_message_boundary`가 두 가지를 확인합니다:

1. 파라미터가 정확히 1개(`user`)인지
2. 뒤따르던 바이트가 버퍼에 온전히 남는지

경계 제한을 되돌리면 실제로 실패합니다:

```
assertion failed: bytes after the startup message must not become parameters,
got {"": "INJECTED", "user": "me"}
```

## 검증

- `cargo test` — **645 passed / 0 failed**
- `cargo clippy --lib` — 신규 경고 없음
- 변경 파일 1개


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 시작 메시지의 파라미터 처리 범위를 메시지 경계로 정확히 제한해, 다음 메시지 바이트가 섞여 프레이밍이 어긋나는 문제를 방지했습니다.
* **품질 개선**
  * 시작 파라미터가 메시지 경계에서 정확히 종료되는 동작을 검증하는 테스트를 추가했습니다.
  * 구조화된 비정상/무작위 입력에 대해 디코딩이 패닉 없이 동작하는지 퍼징 검증을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->