### PR TITLE
fix(engine): 단항 부정의 오버플로 패닉 차단

### DIFF
--- a/src/engine/expression.rs
+++ b/src/engine/expression.rs
@@ -60,21 +60,27 @@ impl DBEngine {
 
                     match operand {
                         TableDataFieldType::Integer(value) => {
-                            Ok(TableDataFieldType::Integer(-value))
+                            let negated = value.checked_neg().ok_or_else(|| {
+                                TypeError::wrap(format!("integer overflow: -{value}"))
+                            })?;
+                            Ok(TableDataFieldType::Integer(negated))
                         }
                         TableDataFieldType::Float(value) => Ok(TableDataFieldType::Float(-value)),
                         TableDataFieldType::Array(mut array) => {
                             for e in &mut array {
                                 match e {
                                     TableDataFieldType::Integer(value) => {
-                                        *e = TableDataFieldType::Integer(-*value);
+                                        let negated = value.checked_neg().ok_or_else(|| {
+                                            TypeError::wrap(format!("integer overflow: -{value}"))
+                                        })?;
+                                        *e = TableDataFieldType::Integer(negated);
                                     }
                                     TableDataFieldType::Float(value) => {
                                         *e = TableDataFieldType::Float(-*value);
                                     }
                                     _ => {
                                         return Err(TypeError::wrap(
-                                            "unary '!' operator is valid only for integer and float types.",
+                                            "unary '-' operator is valid only for integer and float types.",
                                         ));
                                     }
                                 }
@@ -777,7 +783,8 @@ mod tests {
     }
 
     use crate::engine::ast::dml::expressions::binary::BinaryOperatorExpression;
-    use crate::engine::ast::dml::expressions::operators::BinaryOperator;
+    use crate::engine::ast::dml::expressions::operators::{BinaryOperator, UnaryOperator};
+    use crate::engine::ast::dml::expressions::unary::UnaryOperatorExpression;
 
     async fn reduce_binary(
         operator: BinaryOperator,
@@ -846,6 +853,43 @@ mod tests {
 
         for (operator, lhs, rhs, expected) in cases {
             let result = reduce_binary(operator, lhs, rhs).await.unwrap();
+            assert_eq!(result, TableDataFieldType::Integer(expected));
+        }
+    }
+
+
+    async fn negate(value: i64) -> crate::errors::Result<TableDataFieldType> {
+        let engine = DBEngine::new(LaunchConfig::default());
+        let expression = SQLExpression::Unary(Box::new(UnaryOperatorExpression {
+            operator: UnaryOperator::Neg,
+            operand: SQLExpression::Integer(value),
+        }));
+
+        engine
+            .reduce_expression(expression, ReduceContext::default())
+            .await
+    }
+
+    /// 단항 부정이 `-value`를 그대로 써서 `-i64::MIN`이 패닉했습니다.
+    /// `i64::MIN`의 절댓값은 `i64`로 표현할 수 없습니다. 쿼리를 처리하던
+    /// 연결 태스크가 그대로 죽습니다.
+    #[tokio::test]
+    async fn negating_i64_min_returns_error() {
+        let error = negate(i64::MIN)
+            .await
+            .expect_err("negating i64::MIN must not panic");
+
+        assert!(
+            error.to_string().contains("overflow"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// 경계에 걸리지 않는 부정은 그대로 동작해야 합니다.
+    #[tokio::test]
+    async fn negating_normal_integers_still_works() {
+        for (input, expected) in [(5i64, -5i64), (-5, 5), (0, 0), (i64::MAX, -i64::MAX)] {
+            let result = negate(input).await.unwrap();
             assert_eq!(result, TableDataFieldType::Integer(expected));
         }
     }


### PR DESCRIPTION
#246의 후속입니다. 이항 연산을 checked 계열로 바꾸면서 확인해보니 **단항 부정에 같은 문제가 남아 있었습니다.**

## 문제

```rust
TableDataFieldType::Integer(value) => Ok(TableDataFieldType::Integer(-value))
```

`i64::MIN`의 절댓값(9223372036854775808)은 `i64`로 표현할 수 없어서 `-i64::MIN`이 **패닉**합니다. 쿼리를 처리하던 연결 태스크가 그대로 죽습니다.

```
-i64::MIN  →  panic
-0         →  Ok(0)
-5         →  Ok(-5)
```

`checked_neg`로 바꿔 오버플로 시 `TypeError`를 반환합니다.

배열 원소를 부정하는 분기도 `-*value`로 같은 위험이 있어 함께 고쳤습니다. 참고로 현재 `SQLExpression::List`는 `reduce_expression`에서 문자열로 직렬화되어 이 경로에 실제로 도달하지는 않습니다 — 방어적으로 맞춰둔 것이고, 판단 근거를 남겨두려고 적습니다.

## 덤: 에러 메시지 오타

배열 부정 분기가 타입 오류를 낼 때 이렇게 안내하고 있었습니다:

```
unary '!' operator is valid only for integer and float types.
```

실제로는 `'-'` 연산자 자리라 바로잡았습니다.

## 테스트

| 테스트 | 확인 |
|---|---|
| `negating_i64_min_returns_error` | `-i64::MIN`이 패닉 대신 에러 |
| `negating_normal_integers_still_works` | `5, -5, 0, i64::MAX` 정상 동작 |

`checked_neg`를 되돌리면 첫 테스트가 실제로 패닉하며 실패합니다:

```
panicked at src/engine/expression.rs:63:60
```

## 검증

- `cargo test` — **641 passed / 0 failed**
- `cargo clippy --lib` — 신규 경고 없음
- 변경 파일 1개

#246과 같은 파일을 건드리지만 다른 함수(단항 vs 이항)라, 두 PR은 순서 무관하게 병합됩니다. 하나로 합치는 편이 편하시면 그렇게 하겠습니다.
