### PR TITLE
fix(select): LIMIT/OFFSET이 행 수를 넘을 때의 패닉 차단

### DIFF
--- a/src/engine/actions/dml/select.rs
+++ b/src/engine/actions/dml/select.rs
@@ -336,12 +336,17 @@ impl DBEngine {
                 SelectPlanItem::LimitOffset(limit_offset) => {
                     let offset = limit_offset.offset.unwrap_or(0) as usize;
 
-                    match limit_offset.limit {
-                        Some(limit) => {
-                            rows = rows.drain(offset..(offset + limit as usize)).collect()
-                        }
-                        None => rows = rows.drain(offset..).collect(),
-                    }
+                    // OFFSET/LIMIT은 사용자가 주는 값이라 행 수를 넘을 수 있습니다.
+                    // `drain`에 범위를 그대로 넘기면 인덱스 초과로 패닉하므로
+                    // (`LIMIT 100`을 3행짜리 테이블에 쓰면 바로 재현됩니다)
+                    // 실제 행 수로 잘라냅니다.
+                    let start = offset.min(rows.len());
+                    let end = match limit_offset.limit {
+                        Some(limit) => start.saturating_add(limit as usize).min(rows.len()),
+                        None => rows.len(),
+                    };
+
+                    rows = rows.drain(start..end).collect();
                 }
                 SelectPlanItem::Order(ref order_by_clause) => {
                     let futures = rows.into_iter().map(|e| {
@@ -721,5 +726,64 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(3));
+    }
+
+    /// `LIMIT`/`OFFSET`은 사용자가 주는 값이라 실제 행 수를 넘을 수 있습니다.
+    /// 이전 구현은 `rows.drain(offset..(offset + limit))`을 그대로 호출해서
+    /// 범위가 행 수를 넘으면 패닉했습니다. 3행짜리 테이블에 `LIMIT 100`이면
+    /// 바로 재현되고, 쿼리를 처리하던 연결 태스크가 죽습니다.
+    #[tokio::test]
+    async fn limit_offset_beyond_row_count_is_clamped() {
+        let (engine, wal) = build_test_engine("test_limit_offset_out_of_range").await;
+
+        execute_sql(&engine, wal.clone(), "create database rrdb;")
+            .await
+            .unwrap();
+        execute_sql(&engine, wal.clone(), "create table key_value (id integer);")
+            .await
+            .unwrap();
+        for value in 1..=3 {
+            insert_id(&engine, wal.clone(), value).await;
+        }
+
+        let cases = [
+            ("select id from key_value limit 100;", 3),
+            ("select id from key_value offset 10;", 0),
+            ("select id from key_value limit 5 offset 10;", 0),
+            ("select id from key_value limit 5 offset 2;", 1),
+        ];
+
+        for (sql, expected) in cases {
+            let result = execute_sql(&engine, wal.clone(), sql)
+                .await
+                .unwrap_or_else(|error| panic!("{sql} failed: {error}"));
+
+            assert_eq!(result.rows.len(), expected, "unexpected row count for {sql}");
+        }
+    }
+
+    /// 범위 안에 들어오는 일반적인 조합은 그대로 동작해야 합니다.
+    #[tokio::test]
+    async fn limit_offset_within_range_still_works() {
+        let (engine, wal) = build_test_engine("test_limit_offset_in_range").await;
+
+        execute_sql(&engine, wal.clone(), "create database rrdb;")
+            .await
+            .unwrap();
+        execute_sql(&engine, wal.clone(), "create table key_value (id integer);")
+            .await
+            .unwrap();
+        for value in 1..=3 {
+            insert_id(&engine, wal.clone(), value).await;
+        }
+
+        for (sql, expected) in [
+            ("select id from key_value limit 2;", 2),
+            ("select id from key_value limit 2 offset 1;", 2),
+            ("select id from key_value offset 1;", 2),
+        ] {
+            let result = execute_sql(&engine, wal.clone(), sql).await.unwrap();
+            assert_eq!(result.rows.len(), expected, "unexpected row count for {sql}");
+        }
     }
 }


### PR DESCRIPTION
## 문제

`LIMIT`/`OFFSET`은 사용자가 주는 값이라 실제 행 수를 넘을 수 있는데, 범위를 그대로 `drain`에 넘기고 있었습니다.

```rust
rows.drain(offset..(offset + limit as usize))   // 행 수 초과 시 패닉
rows.drain(offset..)                            // offset 초과 시 패닉
```

3행짜리 테이블에 이 쿼리면 바로 재현됩니다:

```sql
SELECT id FROM key_value LIMIT 100;
```

아주 평범한 쿼리이고, 쿼리를 처리하던 연결 태스크가 그대로 죽습니다. 페이지네이션에서 마지막 페이지를 넘겨 조회하는 것만으로도 걸립니다.

## 해결

시작/끝 인덱스를 실제 행 수로 잘라냅니다. `saturating_add`로 인덱스 계산 자체의 오버플로도 막았습니다.

동작은 SQL 표준과 일치합니다 (3행 테이블 기준):

| 쿼리 | 이전 | 이후 |
|---|---|---|
| `LIMIT 100` | **panic** | 3행 |
| `OFFSET 10` | **panic** | 0행 |
| `LIMIT 5 OFFSET 10` | **panic** | 0행 |
| `LIMIT 5 OFFSET 2` | **panic** | 1행 |
| `LIMIT 2 OFFSET 1` | 2행 | 2행 (변화 없음) |

## 테스트

| 테스트 | 확인 |
|---|---|
| `limit_offset_beyond_row_count_is_clamped` | 위 경계 조합 4종 |
| `limit_offset_within_range_still_works` | 범위 내 일반 조합 회귀 방지 |

수정을 되돌리면 첫 테스트가 실제로 패닉하며 실패합니다 (`slice/index.rs:1020`).

## 검증

- `cargo test` — **641 passed / 0 failed**
- `cargo clippy --lib` — 신규 경고 없음
- 변경 파일 1개

## 다른 PR과의 관계

master 위에 제 오픈 PR 7건(#242~#247 + 이 PR)을 전부 머지해서 확인했습니다. **충돌 없이 모두 적용되고 685 tests 통과**합니다. 이 PR은 다른 PR과 파일이 겹치지 않아 순서 무관하게 병합 가능합니다.
