### PR TITLE
fix(ci): cargo-tarpaulin 설치에 --force 추가 (캐시 경합 해소)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,14 @@ jobs:
 
       - name: Install cargo-tarpaulin
         if: steps.cache-tarpaulin.outputs.cache-hit != 'true'
-        run: cargo install cargo-tarpaulin --locked
+        # `--force` because the two cache steps above overlap: the Cargo
+        # directory cache restores all of `~/.cargo/bin/` (which contains
+        # cargo-tarpaulin) via `restore-keys`, while this step's own cache
+        # needs an exact key match. When that key has been evicted but the
+        # directory cache still hit, the binary is already present and a
+        # plain `cargo install` aborts with
+        # `error: binary \`cargo-tarpaulin\` already exists in destination`.
+        run: cargo install cargo-tarpaulin --locked --force
 
       - name: Run cargo-tarpaulin
         run: |


### PR DESCRIPTION
resolves: #249

`coverage.yml`의 `Rust project` 잡이 간헐적으로 실패하는 문제입니다. 지금도 제 #247에서 재현되고 있습니다.

```
Run cargo install cargo-tarpaulin --locked
error: binary `cargo-tarpaulin` already exists in destination
Process completed with exit code 101
```

## 원인

캐시 스텝 두 개가 같은 경로를 두고 겹칩니다.

```yaml
- name: Cache Cargo's directories
  restore-keys: ${{ runner.os }}-cargo-      # 느슨하게 매칭
  path: ~/.cargo/bin/                        # ← cargo-tarpaulin 포함

- name: Cache cargo-tarpaulin
  key: ${{ runner.os }}-tarpaulin-v0.30      # 정확히 일치해야 함
  path: ~/.cargo/bin/cargo-tarpaulin
```

첫 캐시가 `restore-keys` 덕분에 `~/.cargo/bin/` 전체를 복원하면서 `cargo-tarpaulin`도 함께 가져옵니다. 두 번째 캐시는 키가 정확히 맞아야 하므로 `Linux-tarpaulin-v0.30`이 축출되면 미스가 나고, `cache-hit != 'true'` 조건이 성립해 설치를 시도합니다. 바이너리는 이미 있으니 죽습니다.

실패한 실행의 로그가 그 순서 그대로입니다:

```
Cache Cargo's directories  Cache restored from key: Linux-cargo-
Cache cargo-tarpaulin      Cache not found for input keys: Linux-tarpaulin-v0.30
Install cargo-tarpaulin    error: binary `cargo-tarpaulin` already exists
```

tarpaulin 캐시가 살아 있으면 통과하고 없으면 실패하므로, PR마다 결과가 갈립니다. 실제로 지금 #241/#242/#246은 SUCCESS인데 #247만 FAILURE입니다.

## 수정

```diff
-run: cargo install cargo-tarpaulin --locked
+run: cargo install cargo-tarpaulin --locked --force
```

이미 있으면 덮어쓰므로 두 캐시가 어떻게 엇갈리든 안전합니다.

## 검증

로컬에 이미 설치된 크레이트로 두 경로를 모두 확인했습니다:

```
$ cargo install cargo-audit --locked
     Ignored package `cargo-audit v0.22.2` is already installed, use --force to override

$ cargo install cargo-audit --locked --force
   Replacing /Users/lee/.cargo/bin/cargo-audit
    Replaced package `cargo-audit v0.22.2` (executable `cargo-audit`)
```

cargo 자신이 `--force`를 안내하고, 실제로 성공합니다.

## 대안

`Cache cargo-tarpaulin` 스텝을 아예 없애는 방법도 있습니다 — 첫 캐시가 이미 `~/.cargo/bin/`을 통째로 다루고 있어 사실상 중복입니다. 다만 캐시 키 정책을 바꾸는 일이라 의도를 모른 채 건드리지 않았고, 원하시면 그 방향으로 바꾸겠습니다.

#249에서 먼저 여쭤봤는데 답이 없어서, 지금 CI를 막고 있는 상태라 일단 최소 수정으로 올립니다. 방향이 다르면 닫겠습니다.
