### PR TITLE
[#251] test: WAL 프레임 본문 손상이 감지되지 않는 현재 동작 고정

### DIFF
--- a/src/engine/wal/manager/mod.rs
+++ b/src/engine/wal/manager/mod.rs
@@ -646,6 +646,118 @@ mod tests {
         assert!(error.to_string().contains("truncated wal frame body"));
     }
 
+    /// Pins the gap reported in #251: framing catches a *length* that no
+    /// longer matches, but nothing checks the frame *body*. A payload that
+    /// is corrupted in place — the length header still correct — is accepted
+    /// and replayed as if it were the value that was written.
+    ///
+    /// This test asserts today's behaviour so the eventual integrity check
+    /// has something concrete to flip. When frame checksums land, the
+    /// decode below must fail instead, and this test changes with it.
+    #[tokio::test]
+    async fn test_decode_currently_accepts_a_corrupted_frame_body() {
+        let wal_dir = setup_test_wal_dir("corrupt_frame_body").await;
+        let config = get_test_config(&wal_dir);
+
+        let mut wal_manager = WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .unwrap();
+        wal_manager
+            .append_record(EntryType::Insert, Some(b"ORIGINAL-PAYLOAD".to_vec()), None)
+            .await
+            .unwrap();
+        wal_manager.sync_current_file().await.unwrap();
+        drop(wal_manager);
+
+        let path = wal_dir.join(format!("00000001.{}", config.wal_extension));
+        let intact = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(
+            BincodeDecoder::new().decode(&intact).unwrap()[0].data,
+            Some(b"ORIGINAL-PAYLOAD".to_vec()),
+            "guard rail: the payload must round-trip before it is corrupted"
+        );
+
+        // Overwrite bytes *inside* the payload, leaving the length header and
+        // the frame boundary untouched: exactly what a torn write looks like.
+        let start = intact
+            .windows(8)
+            .position(|window| window == b"ORIGINAL")
+            .expect("payload should be present in the encoded frame");
+        let mut corrupted = intact.clone();
+        corrupted[start..start + 8].copy_from_slice(b"CORRUPT!");
+
+        let decoded = BincodeDecoder::new()
+            .decode(&corrupted)
+            .expect("current behaviour: a corrupted body decodes without error");
+        assert_eq!(
+            decoded[0].data,
+            Some(b"CORRUPT!-PAYLOAD".to_vec()),
+            "the corrupted bytes are returned verbatim, with no error raised"
+        );
+
+        // And the corruption survives a restart: build() accepts the segment,
+        // so recover_from_wal would replay the altered entry.
+        tokio::fs::write(&path, &corrupted).await.unwrap();
+        let reopened = WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .expect("current behaviour: the corrupted segment is accepted at startup");
+        assert_eq!(
+            reopened.pending_entries()[0].data,
+            Some(b"CORRUPT!-PAYLOAD".to_vec()),
+            "the altered entry is queued for replay"
+        );
+    }
+
+    /// The same gap seen from the other side: zeroing the tail of a frame
+    /// body — a partial flush of the last write — is not detected either.
+    #[tokio::test]
+    async fn test_decode_currently_accepts_a_zeroed_frame_tail() {
+        let wal_dir = setup_test_wal_dir("zeroed_frame_tail").await;
+        let config = get_test_config(&wal_dir);
+
+        let mut wal_manager = WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .unwrap();
+        for index in 0..3 {
+            wal_manager
+                .append_record(EntryType::Insert, Some(vec![b'a' + index; 32]), None)
+                .await
+                .unwrap();
+        }
+        wal_manager.sync_current_file().await.unwrap();
+        drop(wal_manager);
+
+        let path = wal_dir.join(format!("00000001.{}", config.wal_extension));
+        let intact = tokio::fs::read(&path).await.unwrap();
+        let used = intact
+            .iter()
+            .rposition(|byte| *byte != 0)
+            .map(|index| index + 1)
+            .expect("segment should contain data");
+
+        for cut in [1usize, 5, 17] {
+            let mut torn = intact.clone();
+            torn[used - cut..used].fill(0);
+            tokio::fs::write(&path, &torn).await.unwrap();
+
+            let reopened = WALBuilder::new(&config)
+                .build(BincodeDecoder::new(), BincodeEncoder::new())
+                .await
+                .unwrap_or_else(|error| {
+                    panic!("current behaviour: cut={} was expected to be accepted, got {}", cut, error)
+                });
+            assert_eq!(
+                reopened.pending_entries().len(),
+                3,
+                "cut={}: all three entries are still reported as replayable",
+                cut
+            );
+        }
+    }
+
     #[tokio::test]
     async fn test_append_record_writes_framed_bincode_entries() {
         let wal_dir = setup_test_wal_dir("append_record_framed_bincode").await;

--- a/src/engine/wal/manager/mod.rs
+++ b/src/engine/wal/manager/mod.rs
@@ -732,6 +732,12 @@ mod tests {
 
         let path = wal_dir.join(format!("00000001.{}", config.wal_extension));
         let intact = tokio::fs::read(&path).await.unwrap();
+        let baseline = BincodeDecoder::new().decode(&intact).unwrap();
+        assert_eq!(
+            baseline.last().unwrap().data,
+            Some(vec![b'c'; 32]),
+            "guard rail: the last entry must round-trip before it is damaged"
+        );
         let used = intact
             .iter()
             .rposition(|byte| *byte != 0)
@@ -743,6 +749,24 @@ mod tests {
             torn[used - cut..used].fill(0);
             tokio::fs::write(&path, &torn).await.unwrap();
 
+            // The damage must actually change the decoded value; otherwise the
+            // assertions below would hold for reasons unrelated to corruption.
+            // The damage must actually change the decoded entry; otherwise the
+            // assertions below would hold for reasons unrelated to corruption.
+            // Note the zeroed tail lands on the fields serialized after `data`
+            // (timestamp, transaction_id, is_continuation), so the payload can
+            // survive while the entry as a whole does not.
+            let damaged = BincodeDecoder::new().decode(&torn).unwrap();
+            let baseline_last = baseline.last().unwrap();
+            let damaged_last = damaged.last().unwrap();
+            assert!(
+                damaged_last.timestamp != baseline_last.timestamp
+                    || damaged_last.data != baseline_last.data
+                    || damaged_last.transaction_id != baseline_last.transaction_id,
+                "cut={}: the zeroed bytes should have altered the last entry",
+                cut
+            );
+
             let reopened = WALBuilder::new(&config)
                 .build(BincodeDecoder::new(), BincodeEncoder::new())
                 .await
@@ -753,6 +777,17 @@ mod tests {
                 reopened.pending_entries().len(),
                 3,
                 "cut={}: all three entries are still reported as replayable",
+                cut
+            );
+            let replayed = reopened.pending_entries().last().unwrap();
+            assert_eq!(
+                (replayed.timestamp, &replayed.data, replayed.transaction_id),
+                (
+                    damaged_last.timestamp,
+                    &damaged_last.data,
+                    damaged_last.transaction_id
+                ),
+                "cut={}: the damaged entry itself is what would be replayed",
                 cut
             );
         }


### PR DESCRIPTION
#251에서 보고한 공백을 테스트로 고정합니다. **동작을 바꾸지 않고**, 현재 동작이 무엇인지만 코드로 남깁니다.

## 문제

프레이밍은 길이가 맞지 않는 경우를 잡습니다. 하지만 본문은 아무도 검사하지 않아서, 길이 헤더가 온전한 채 페이로드만 훼손되면 오류 없이 통과합니다:

```
before: Some("ORIGINAL-PAYLOAD")
after:  Some("CORRUPT!-PAYLOAD")   <-- 오류 없이 통과
```

`WALBuilder::build`도 이 세그먼트를 받아들이므로, `recover_from_wal`이 변조된 엔트리를 그대로 재생합니다.

## 이 PR이 하는 것

두 방향을 각각 고정했습니다.

1. **제자리 변조** — 페이로드 8바이트를 뒤집습니다. 길이 헤더와 프레임 경계는 건드리지 않습니다. 디코딩이 통과하고, 재시작 후 `pending_entries()`에 변조된 값이 올라오는 것까지 확인합니다.
2. **꼬리 0으로 덮어쓰기** — 부분 flush의 형태입니다. 마지막 프레임 본문을 1/5/17바이트씩 0으로 만들어도 3건 모두 정상으로 판정되는 것을 확인합니다.

두 테스트 모두 **현재 동작을 단언**합니다. 즉 지금은 통과하고, 무결성 검사가 들어오는 순간 실패합니다.

## 이 테스트가 실제로 무언가를 잡는지

주장만 하지 않고 확인했습니다. `decode`가 모든 프레임을 거부하도록 임시로 바꾸면 둘 다 뒤집힙니다:

```
test_decode_currently_accepts_a_corrupted_frame_body ... FAILED
test_decode_currently_accepts_a_zeroed_frame_tail ... FAILED
```

손상시키기 **전에** 페이로드가 정상적으로 라운드트립하는지 확인하는 단언도 함께 뒀습니다. 인코딩 쪽이 깨져서 애초에 `ORIGINAL-PAYLOAD`가 안 써지는 경우, 테스트가 조용히 통과해버리는 것을 막기 위해서입니다.

## 검증

```
cargo test    673 passed / 0 failed   (master 669 + 4)
cargo clippy  경고 73건 — master와 동일, 새로 추가한 경고 없음
```

## 남은 것

실제 수정(프레임 체크섬)은 **파일 포맷 변경**이라 #251에서 방향을 여쭤봤습니다. 세 가지 선택지를 적어뒀고 1번(프레임 헤더에 CRC32 추가)이 맞다고 보지만, 포맷 결정은 메인테이너 몫이라 생각해 이 PR에는 넣지 않았습니다.

정해주시면 이 테스트들을 "거부해야 한다"로 뒤집는 형태로 후속 PR 올리겠습니다. 그때 이 커밋이 diff의 기준선 역할을 합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 손상되거나 일부가 잘린 WAL 데이터에 대한 디코딩 및 복구 동작 검증을 추가했습니다.
  * 비정상적인 세그먼트에서도 데이터 재생 대기 상태가 안정적으로 유지되는지 확인합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->