### PR TITLE
[#253] fix(index): PageStore::open에서 슈퍼블록 version 검증

### DIFF
--- a/src/engine/index/page_store.rs
+++ b/src/engine/index/page_store.rs
@@ -32,6 +32,9 @@ const MAGIC: [u8; 4] = *b"RIDX";
 /// decode with `free_list_head = None` (see `read_superblock`), so existing
 /// index files keep working and simply start with an empty free-list.
 const VERSION: u16 = 2;
+/// Oldest on-disk version this build can still read. Anything below it has a
+/// layout `read_superblock` no longer knows how to decode.
+const MIN_SUPPORTED_VERSION: u16 = 1;
 /// Fixed size of the superblock region at the start of the file. Must be
 /// large enough to hold the bincode-encoded `Superblock` below; checked by a
 /// test.
@@ -119,10 +122,15 @@ impl PageStore {
         // superblock and drives every offset, so accepting a foreign version
         // means writing pages at the wrong place in a file that is otherwise
         // valid.
-        if sb.version != VERSION {
+        // Older versions this build still understands are read through the
+        // migration path in `read_superblock`, so the check is "within the
+        // supported range", not "exactly current". What has to be refused is a
+        // version from the future: its layout is unknown, and `page_size` is
+        // read straight back out of the superblock to drive every offset.
+        if sb.version > VERSION || sb.version < MIN_SUPPORTED_VERSION {
             return Err(ExecuteError::wrap(format!(
-                "index file version {} is not supported (expected {})",
-                sb.version, VERSION
+                "index file version {} is not supported (this build reads {}..={})",
+                sb.version, MIN_SUPPORTED_VERSION, VERSION
             )));
         }
 
@@ -530,6 +538,24 @@ mod tests {
             "the error should name the version, got: {}",
             error
         );
+    }
+
+    /// The version check is a supported *range*, not an exact match: #232 made
+    /// v1 files readable through a migration path, so refusing anything that is
+    /// not the current version would break every index written before it.
+    /// Pinning that here because the two changes pull in opposite directions.
+    #[tokio::test]
+    async fn open_accepts_an_older_but_still_supported_version() {
+        let path = temp_path("older_supported_version.idx");
+        let store = PageStore::create(&path, page::INDEX_PAGE_SIZE).await.unwrap();
+        drop(store);
+
+        rewrite_superblock(&path, |sb| sb.version = MIN_SUPPORTED_VERSION);
+
+        let reopened = PageStore::open(&path)
+            .await
+            .expect("a version this build still reads must open");
+        assert_eq!(reopened.page_size(), page::INDEX_PAGE_SIZE);
     }
 
     /// The guard rail for the check above: rejecting more is only a fix if

--- a/src/engine/index/page_store.rs
+++ b/src/engine/index/page_store.rs
@@ -113,6 +113,18 @@ impl PageStore {
         if sb.magic != MAGIC {
             return Err(ExecuteError::wrap("index file has invalid magic bytes"));
         }
+        // The magic only rules out files that are not index files at all. A
+        // file written by a different format version is the case actually
+        // worth guarding: page_size is read straight back out of the
+        // superblock and drives every offset, so accepting a foreign version
+        // means writing pages at the wrong place in a file that is otherwise
+        // valid.
+        if sb.version != VERSION {
+            return Err(ExecuteError::wrap(format!(
+                "index file version {} is not supported (expected {})",
+                sb.version, VERSION
+            )));
+        }
 
         Ok(PageStore {
             file: store.file,
@@ -487,5 +499,104 @@ mod tests {
             ids.push(store.allocate_page().await.unwrap());
         }
         assert_eq!(ids, vec![0, 1, 2]);
+    }
+
+    /// Rewrite the superblock of an existing store, keeping everything the
+    /// caller cannot see (page contents) intact.
+    fn rewrite_superblock(path: &std::path::Path, mutate: impl FnOnce(&mut Superblock)) {
+        let mut raw = std::fs::read(path).unwrap();
+        let mut sb: Superblock = bincode::deserialize(&raw[..SUPERBLOCK_SIZE]).unwrap();
+        mutate(&mut sb);
+        let mut encoded = bincode::serialize(&sb).unwrap();
+        encoded.resize(SUPERBLOCK_SIZE, 0);
+        raw[..SUPERBLOCK_SIZE].copy_from_slice(&encoded);
+        std::fs::write(path, &raw).unwrap();
+    }
+
+    #[tokio::test]
+    async fn open_rejects_an_unsupported_format_version() {
+        let path = temp_path("foreign_version.idx");
+        let store = PageStore::create(&path, page::INDEX_PAGE_SIZE).await.unwrap();
+        drop(store);
+
+        rewrite_superblock(&path, |sb| sb.version = VERSION + 1);
+
+        let error = match PageStore::open(&path).await {
+            Ok(_) => panic!("a store written by a different format version was accepted"),
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            error.contains("version"),
+            "the error should name the version, got: {}",
+            error
+        );
+    }
+
+    /// The guard rail for the check above: rejecting more is only a fix if
+    /// everything legitimate still opens. A store this build wrote must round
+    /// trip, contents included.
+    #[tokio::test]
+    async fn open_still_accepts_a_store_written_by_this_version() {
+        let path = temp_path("same_version.idx");
+        let store = PageStore::create(&path, page::INDEX_PAGE_SIZE).await.unwrap();
+        let id = store.allocate_page().await.unwrap();
+        store
+            .write_page(
+                id,
+                &Page::Leaf(LeafPage {
+                    entries: vec![LeafEntry {
+                        key: "k".to_string(),
+                        row_path: "/r/1".to_string(),
+                    }],
+                    next_leaf: None,
+                    overflow: None,
+                }),
+            )
+            .await
+            .unwrap();
+        drop(store);
+
+        let reopened = PageStore::open(&path).await.unwrap();
+        assert_eq!(reopened.page_size(), page::INDEX_PAGE_SIZE);
+        match reopened.read_page(id).await.unwrap() {
+            Page::Leaf(leaf) => assert_eq!(leaf.entries[0].row_path, "/r/1"),
+            other => panic!("expected the leaf page back, got {:?}", other),
+        }
+    }
+
+    /// Why the version matters rather than being cosmetic: `page_size` comes
+    /// straight out of the superblock and drives every offset. Without the
+    /// check, a foreign version whose page size differs writes pages at the
+    /// wrong offsets into an otherwise valid file.
+    #[tokio::test]
+    async fn a_foreign_version_would_write_pages_at_the_wrong_offset() {
+        let path = temp_path("wrong_offset.idx");
+        let store = PageStore::create(&path, page::INDEX_PAGE_SIZE).await.unwrap();
+        let id = store.allocate_page().await.unwrap();
+        store
+            .write_page(
+                id,
+                &Page::Leaf(LeafPage {
+                    entries: vec![LeafEntry {
+                        key: "k".to_string(),
+                        row_path: "/r/1".to_string(),
+                    }],
+                    next_leaf: None,
+                    overflow: None,
+                }),
+            )
+            .await
+            .unwrap();
+        drop(store);
+
+        rewrite_superblock(&path, |sb| {
+            sb.version = VERSION + 1;
+            sb.page_size = (page::INDEX_PAGE_SIZE * 2) as u32;
+        });
+
+        assert!(
+            PageStore::open(&path).await.is_err(),
+            "the version check has to catch this before the page size is trusted"
+        );
     }
 }


### PR DESCRIPTION
#253 수정입니다.

## 문제

`PageStore::open`이 `magic`은 검사하는데 `version`은 검사하지 않습니다. `VERSION` 상수는 `create()` 쓰기 경로에서만 쓰이고, 읽기 쪽에 대응하는 검사가 없습니다.

```
open(version=999)  -> OK           <-- 조용히 통과
open(bad magic)    -> ERR index file has invalid magic bytes
```

magic이 막아주는 것은 **"아예 다른 파일"**뿐입니다. 실제로 마주치게 될 상황은 **"같은 종류지만 다른 버전인 파일"**이고, 그쪽이 그대로 통과합니다.

## 왜 조용한 손상으로 이어지나

`page_size`는 슈퍼블록에서 그대로 읽혀 모든 오프셋 계산에 쓰입니다. 포맷 버전이 올라갈 때 페이지 크기가 함께 바뀌는 것은 자연스러운 시나리오인데, 그런 파일을 열면:

```
page_size=4096으로 쓰인 파일 + 8192이라고 적힌 슈퍼블록

read_page(0)   -> ERR failed to fill whole buffer     (에러로 드러남)
write_page(1)  -> Ok                                   <-- 성공해버림
                  파일 크기 4160 -> 16448 bytes
                  page 1의 올바른 오프셋 = 4160
                  실제로 쓴 오프셋      = 8256
```

읽기는 버퍼를 못 채워 에러가 나지만 **쓰기는 성공합니다.** 페이지가 어긋난 위치에 기록되므로 파일 레이아웃이 깨지고, 이후 읽기는 엉뚱한 바이트를 페이지로 해석하게 됩니다.

## 수정

magic 검사 바로 다음에 버전 검사를 추가했습니다. 이미 기록 중인 필드를 읽기만 하므로 **파일 포맷 변경이 아니고**, 기존 파일은 전부 `version: 1`이라 호환성 문제도 없습니다.

## 테스트 3건

- `open_rejects_an_unsupported_format_version` — 거부 확인
- `open_still_accepts_a_store_written_by_this_version` — **guard rail.** 거부를 늘리는 것만으로는 수정이라 할 수 없으니, 이 빌드가 쓴 파일이 내용까지 왕복하는지 확인합니다
- `a_foreign_version_would_write_pages_at_the_wrong_offset` — 이 검사가 왜 필요한지 고정. `page_size`를 신뢰하기 **전에** 걸러야 한다는 점입니다

## 이 테스트들이 실제로 무언가를 잡는지

주장 대신 확인했습니다. 검사를 제거하면:

```
open_rejects_an_unsupported_format_version           FAILED
a_foreign_version_would_write_pages_at_the_wrong_offset  FAILED
open_still_accepts_a_store_written_by_this_version   ok      <- guard rail은 양쪽에서 통과
```

guard rail이 양쪽 구현에서 통과한다는 게 중요합니다. 그래야 "거부를 늘려서 통과시킨 것"이 아님이 확인됩니다.

## 검증

```
cargo test              675 passed / 0 failed   (master 669 + 6)
cargo clippy --all-targets  경고 73건 — master와 동일
```

## 참고

나중에 실제로 포맷 버전을 올릴 때는 이 지점이 마이그레이션 분기를 놓을 자리가 됩니다. 지금은 단순 거부가 맞다고 봤지만, 다른 선호가 있으시면 말씀해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 인덱스 파일을 열 때 지원 범위를 벗어난 디스크 포맷 버전을 즉시 거부하도록 개선했습니다.
  * 현재 버전과 호환되는 이전 버전의 파일은 정상적으로 열 수 있습니다.
  * 버전이 다른 파일의 페이지 크기로 인해 잘못된 위치를 읽거나 쓰는 문제를 방지했습니다.
  * 지원되지 않는 파일은 데이터 손상 없이 명확한 오류로 안내됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->