### PR TITLE
[#255] fix: 경로 요소가 되는 식별자 검증

### DIFF
--- a/src/engine/actions/ddl/alter_table.rs
+++ b/src/engine/actions/ddl/alter_table.rs
@@ -33,6 +33,12 @@ impl DBEngine {
         match query.action {
             AlterTableAction::AlterTableRenameTo(action) => {
                 let change_name = action.name;
+                // Renaming moves the table directory, so the new name is a
+                // path component too (#255).
+                crate::engine::path_identifier::validate_path_identifier(
+                    &change_name,
+                    "table name",
+                )?;
                 let change_path = database_path.clone().join(&change_name);
 
                 // table 디렉터리명 변경

--- a/src/engine/actions/ddl/create_database.rs
+++ b/src/engine/actions/ddl/create_database.rs
@@ -25,6 +25,10 @@ impl DBEngine {
             .clone()
             .ok_or_else(|| ExecuteError::wrap("no database name".to_string()))?;
 
+        // The name is about to become a directory under the data directory,
+        // so it has to be a single, contained path component (#255).
+        crate::engine::path_identifier::validate_path_identifier(&database_name, "database name")?;
+
         let database_path = base_path.clone().join(&database_name);
 
         if let Err(error) = tokio::fs::create_dir(database_path.clone()).await {

--- a/src/engine/actions/ddl/create_table.rs
+++ b/src/engine/actions/ddl/create_table.rs
@@ -19,6 +19,10 @@ impl DBEngine {
         let database_name = query.table.clone().unwrap().database_name.unwrap();
         let table_name = query.table.clone().unwrap().table_name;
 
+        // Both names become directories under the data directory (#255).
+        crate::engine::path_identifier::validate_path_identifier(&database_name, "database name")?;
+        crate::engine::path_identifier::validate_path_identifier(&table_name, "table name")?;
+
         let base_path = self.get_data_directory();
         let database_path = base_path.clone().join(&database_name);
 

--- a/src/engine/index/manager.rs
+++ b/src/engine/index/manager.rs
@@ -90,6 +90,21 @@ impl IndexManager {
         let _guard = self.create_lock.lock().await;
         let index_name = meta.index_name.clone();
 
+        // index_file_path joins all three names onto the data directory, so
+        // each has to be a single contained component (#255). Checked here,
+        // before anything is created on disk.
+        crate::engine::path_identifier::validate_path_identifier(&index_name, "index name")?;
+        crate::engine::path_identifier::validate_path_identifier(
+            &meta.table_name.table_name,
+            "table name",
+        )?;
+        if let Some(database_name) = meta.table_name.database_name.as_deref() {
+            crate::engine::path_identifier::validate_path_identifier(
+                database_name,
+                "database name",
+            )?;
+        }
+
         // Check if already exists (under the exclusive lock)
         {
             let metas = self.metas.read().await;
@@ -532,6 +547,97 @@ mod tests {
             column.to_string(),
             unique,
         )
+    }
+
+    /// #255: an index name is joined onto the data directory, so a traversing
+    /// name used to create files outside it. Asserted on the filesystem, not
+    /// on the error alone -- the point of the check is where bytes land.
+    ///
+    /// The depth matters. The name sits at
+    /// `<base>/<db>/tables/<table>/index/<name>.idx`, so it takes five `../`
+    /// to clear `<base>`; with three it would still land inside, and the test
+    /// would pass against the vulnerable code too.
+    #[tokio::test]
+    async fn create_index_rejects_a_traversing_index_name() {
+        let dir = setup_temp_dir("traversal_index_name").await;
+        let escaped = dir
+            .parent()
+            .unwrap()
+            .join("escaped_by_index_name.idx");
+        let _ = tokio::fs::remove_file(&escaped).await;
+
+        let manager = IndexManager::new(dir.clone());
+        let error = manager
+            .create_index(make_meta(
+                "../../../../../escaped_by_index_name",
+                "name",
+                false,
+            ))
+            .await
+            .expect_err("a traversing index name must be rejected");
+
+        assert!(
+            error.to_string().contains("index name"),
+            "the error should name the offending identifier, got: {}",
+            error
+        );
+        assert!(
+            !escaped.exists(),
+            "nothing may be written outside the data directory: {}",
+            escaped.display()
+        );
+    }
+
+    /// The same escape through the table name half of the path. The table sits
+    /// one level shallower, so three `../` is what clears `<base>` here.
+    #[tokio::test]
+    async fn create_index_rejects_a_traversing_table_name() {
+        let dir = setup_temp_dir("traversal_table_name").await;
+        let escaped = dir.parent().unwrap().join("escaped_by_table_name");
+        let _ = tokio::fs::remove_dir_all(&escaped).await;
+
+        let manager = IndexManager::new(dir.clone());
+        let meta = IndexMeta::new(
+            "idx".to_string(),
+            TableName {
+                database_name: Some("testdb".to_string()),
+                table_name: "../../../escaped_by_table_name".to_string(),
+            },
+            "name".to_string(),
+            false,
+        );
+        let error = manager
+            .create_index(meta)
+            .await
+            .expect_err("a traversing table name must be rejected");
+
+        assert!(error.to_string().contains("table name"), "got: {}", error);
+        assert!(
+            !escaped.exists(),
+            "nothing may be created outside the data directory: {}",
+            escaped.display()
+        );
+    }
+
+    /// Guard rail for the two above: refusing more is only a fix while every
+    /// ordinary name still works end to end, contents included.
+    #[tokio::test]
+    async fn create_index_still_accepts_an_ordinary_name() {
+        let dir = setup_temp_dir("traversal_guard_rail").await;
+        let manager = IndexManager::new(dir);
+
+        manager
+            .create_index(make_meta("idx_ordinary", "name", false))
+            .await
+            .expect("an ordinary index name must still be accepted");
+        manager
+            .insert("idx_ordinary", "k".to_string(), "/r/1".to_string())
+            .await
+            .expect("the created index must be usable");
+        assert_eq!(
+            manager.get("idx_ordinary", "k").await.unwrap(),
+            vec!["/r/1".to_string()]
+        );
     }
 
     #[tokio::test]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -4,6 +4,7 @@ pub mod index;
 pub mod lexer;
 pub mod optimizer;
 pub mod parser;
+pub mod path_identifier;
 pub mod row_buffer;
 pub mod schema;
 pub mod server;

--- a/src/engine/path_identifier.rs
+++ b/src/engine/path_identifier.rs
@@ -1,0 +1,124 @@
+//! Validation for SQL identifiers that become filesystem path components.
+//!
+//! Database, table and index names are joined onto the data directory to form
+//! real paths. A quoted identifier may legally contain any character, so
+//! without a check `CREATE INDEX "../../../evil"` resolves outside the data
+//! directory and `PathBuf::join` will happily build that path (see #255).
+//!
+//! The check rejects rather than rewrites. Sanitising -- stripping separators
+//! or collapsing `..` -- would silently fold distinct identifiers onto the same
+//! file, so two different tables could end up sharing storage.
+//!
+//! Note the platform difference behind the colon rule. On Windows,
+//! `Path::join` treats a drive-relative name as absolute and discards the base
+//! entirely -- `base_dir.join("C:escape")` is `C:escape`, not
+//! `base_dir\C:escape`. Verified on CI rather than assumed: a probe asserting
+//! the opposite passed on macOS and Linux and failed on windows-latest.
+
+use crate::errors;
+use crate::errors::execute_error::ExecuteError;
+
+/// Reject an identifier that cannot safely be used as a single path component.
+///
+/// `kind` names the identifier in the error message ("database name", ...).
+pub fn validate_path_identifier(name: &str, kind: &str) -> errors::Result<()> {
+    let reason = if name.is_empty() {
+        "it is empty"
+    } else if name == "." || name == ".." {
+        "it refers to a directory rather than a name"
+    } else if name.contains('/') || name.contains('\\') {
+        "it contains a path separator"
+    } else if name.contains(':') {
+        // Windows reads this as a drive-relative path and drops the base.
+        "it contains a drive separator"
+    } else if name.contains('\0') {
+        "it contains a null byte"
+    } else {
+        return Ok(());
+    };
+
+    Err(ExecuteError::wrap(format!(
+        "invalid {}: {:?} cannot be used as a path component because {}",
+        kind, name, reason
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_ordinary_identifiers() {
+        // The guard rail: rejecting more is only a fix if everything
+        // legitimate still passes. `..` is only refused on its own, so names
+        // that merely contain dots stay usable.
+        for name in [
+            "foo",
+            "rrdb",
+            "my_table",
+            "Table1",
+            "테이블",
+            "a.b",
+            "..leading",
+            "trailing..",
+            "a..b",
+            "-",
+            " spaced name ",
+        ] {
+            assert!(
+                validate_path_identifier(name, "table name").is_ok(),
+                "{:?} should be accepted",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_names_that_escape_or_confuse_the_path() {
+        for name in [
+            "",
+            ".",
+            "..",
+            "../evil",
+            "../../../etc/passwd",
+            "a/b",
+            "a\\b",
+            "/absolute",
+            "with\0null",
+            "C:escape",
+            "a:b",
+        ] {
+            assert!(
+                validate_path_identifier(name, "table name").is_err(),
+                "{:?} should be rejected",
+                name
+            );
+        }
+    }
+
+    /// Regression for the colon rule. This started as a probe asserting that
+    /// drive-relative names stay inside the base; it passed on macOS and Linux
+    /// and *failed* on windows-latest, which is how the rule was confirmed to
+    /// be needed rather than assumed. It now asserts the rejection instead.
+    #[test]
+    fn rejects_windows_drive_relative_names() {
+        for name in ["C:escape", "C:\\abs", "a:b", "::"] {
+            assert!(
+                validate_path_identifier(name, "table name").is_err(),
+                "{:?} must be rejected: on Windows base.join({:?}) discards the base entirely",
+                name,
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn the_error_names_the_identifier_and_the_reason() {
+        let error = validate_path_identifier("../evil", "index name")
+            .expect_err("a traversing name must be rejected");
+        let message = error.to_string();
+        assert!(message.contains("index name"), "got: {}", message);
+        assert!(message.contains("../evil"), "got: {}", message);
+        assert!(message.contains("path separator"), "got: {}", message);
+    }
+}


### PR DESCRIPTION
#255 수정입니다. 이슈에서 검증 위치를 여쭤봤는데, 답을 기다리는 동안 **어느 방향이든 필요한 부분**을 먼저 만들었습니다. 방향이 다르면 옮기기 쉬운 형태입니다.

## 문제

인덱스/테이블/데이터베이스 이름이 데이터 디렉터리에 그대로 이어붙습니다. 인용 식별자는 임의 문자를 허용하므로:

```
CREATE INDEX "../../../evil" ON foo (bar);   -> 파서 통과
create_index(...)                            -> Ok(()), base 바깥에 파일 생성
```

## 접근

**공용 함수 하나를 두고 쓰기 경로마다 호출**합니다. 이슈 코멘트에서 확인했듯 식별자가 경로가 되는 지점이 4곳이라, `IndexManager`에만 넣으면 나머지가 남습니다:

```
create_database   database_name
create_table      database_name, table_name
create_index      index_name, table_name, database_name
alter_table       rename 대상 이름
```

`alter_table`은 이슈를 쓸 때는 못 봤던 지점입니다. 테이블 디렉터리를 옮기므로 새 이름도 경로 요소가 됩니다.

**읽기 경로에는 넣지 않았습니다.** 생성 시점에 막으면 그런 이름이 존재할 수 없어 조회도 자연히 실패합니다. 조회 경로는 지점이 훨씬 많아(`get_table_config`, `scan`, `drop_table`, `etc.rs` 등) 하나씩 막으면 누락이 생깁니다.

## 정화가 아니라 거부

구분자를 제거하거나 `..`를 접는 방식은 택하지 않았습니다. 서로 다른 식별자가 같은 파일로 접혀서, 두 테이블이 저장소를 공유하게 됩니다.

거부 범위는 최소로 잡았습니다:

```
거부:  ""  "."  ".."  "../evil"  "a/b"  "a\b"  "/absolute"  "with\0null"
허용:  "foo"  "a.b"  "..leading"  "trailing.."  "a..b"  "-"  " spaced "  "테이블"
```

`..`는 **그 자체일 때만** 막습니다. 이름에 점이 들어간다는 이유로 거부하면 멀쩡한 식별자를 잃습니다.

## 테스트가 실제로 무언가를 잡는지

검증을 제거하고 확인했습니다:

```
create_index_rejects_a_traversing_index_name    FAILED
create_index_rejects_a_traversing_table_name    FAILED
create_index_still_accepts_an_ordinary_name     ok      <- guard rail은 양쪽에서 통과
```

guard rail이 양쪽 구현에서 통과하는 게 중요합니다. 그래야 "거부를 늘려서 통과시킨 것"이 아님이 확인됩니다. 이 테스트는 인덱스를 만들고 `insert` → `get`까지 해서 실제로 쓸 수 있는지 봅니다.

거부 테스트는 에러 메시지만 보지 않고 **파일이 실제로 생기지 않았는지**까지 확인합니다. 검사의 요지가 "바이트가 어디에 떨어지는가"이므로, 에러만 확인하면 절반만 보는 셈입니다.

## 검증

```
cargo test              681 passed / 0 failed   (master 669 + 12)
cargo clippy --all-targets  경고 73건 — master와 동일
```

## 남은 판단

이슈에 적은 세 가지 선택지 중 1번(공용 함수)입니다. 파서 레벨에서 막는 2번이 낫다고 보시면, 검증 함수는 그대로 두고 호출 지점만 옮기면 됩니다. 다만 그 경우 인용 식별자의 SQL 표준 의미(임의 문자 허용)를 바꾸는 결정이 됩니다.

`ALTER TABLE RENAME` 외에 제가 못 본 쓰기 경로가 있다면 알려주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **보안 개선**
  * 데이터베이스, 테이블, 인덱스 이름 및 테이블 디렉터리/경로 변경 시 경로 식별자 검증을 강화했습니다.
  * 빈 문자열, 특수 문자/경로 구분자, 절대/상위 경로 유사 입력 등 경로 탈출을 유발할 수 있는 값은 즉시 차단합니다.
* **테스트**
  * 경로 탈출 거부 동작 및 에러 메시지 포함 여부, 정상 흐름의 생성→삽입→조회 연동까지 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->