### PR TITLE
[#258] fix(index): InternalPage 불변식을 디코딩 시점에 검증

### DIFF
--- a/src/engine/index/page.rs
+++ b/src/engine/index/page.rs
@@ -126,6 +126,21 @@ pub fn decode_page(buf: &[u8]) -> errors::Result<Page> {
             let internal: InternalPage = bincode::deserialize(payload).map_err(|e| {
                 ExecuteError::wrap(format!("failed to decode internal page: {}", e))
             })?;
+            // `keys.len() + 1 == children.len()` is what makes the child
+            // lookups in page_btree.rs total: `child_index` can be as large as
+            // `keys.len()`, so a page with fewer children than that indexes out
+            // of bounds and panics the task handling the query. bincode trusts
+            // the length prefixes it reads, so a single flipped bit in one of
+            // them is enough to produce such a page without any decode error
+            // (see #258). Check it here, where every read goes through.
+            if internal.children.len() != internal.keys.len() + 1 {
+                return Err(ExecuteError::wrap(format!(
+                    "corrupt internal page: {} keys with {} children (expected {})",
+                    internal.keys.len(),
+                    internal.children.len(),
+                    internal.keys.len() + 1
+                )));
+            }
             Ok(Page::Internal(internal))
         }
         other => Err(ExecuteError::wrap(format!("unknown page tag {}", other))),
@@ -202,5 +217,98 @@ mod tests {
         let encoded = encode_page(&Page::Leaf(small.clone()), 128).unwrap();
         assert_eq!(encoded.len(), 128);
         assert_eq!(decode_page(&encoded).unwrap(), Page::Leaf(small));
+    }
+
+    fn encode_internal_unchecked(keys: Vec<&str>, children: Vec<PageId>) -> Vec<u8> {
+        let page = InternalPage {
+            keys: keys.into_iter().map(|k| k.to_string()).collect(),
+            children,
+        };
+        encode_page(&Page::Internal(page), INDEX_PAGE_SIZE).expect("encoding is not the check")
+    }
+
+    /// #258: the child lookups in page_btree.rs index `children` with a value
+    /// that can be as large as `keys.len()`, so a page with too few children
+    /// panics the task reading it. Decoding has to refuse it instead.
+    #[test]
+    fn decode_rejects_an_internal_page_with_too_few_children() {
+        for (keys, children) in [
+            (vec!["a", "b", "c"], vec![1u32]),
+            (vec!["a", "b"], vec![1, 2]),
+            (vec!["a"], vec![1]),
+            (vec![], vec![]),
+        ] {
+            let encoded = encode_internal_unchecked(keys.clone(), children.clone());
+            let error = decode_page(&encoded).expect_err(&format!(
+                "{} keys with {} children must be rejected",
+                keys.len(),
+                children.len()
+            ));
+            assert!(
+                error.to_string().contains("corrupt internal page"),
+                "got: {}",
+                error
+            );
+        }
+    }
+
+    /// A page with too *many* children is equally broken, and would make the
+    /// tree lose a subtree rather than panic. Same check covers it.
+    #[test]
+    fn decode_rejects_an_internal_page_with_too_many_children() {
+        let encoded = encode_internal_unchecked(vec!["a"], vec![1, 2, 3]);
+        let error = decode_page(&encoded).expect_err("2 keys' worth of children with 1 key");
+        assert!(error.to_string().contains("corrupt internal page"));
+    }
+
+    /// Guard rail: refusing more is only a fix while every well-formed page
+    /// still round trips. Covers the smallest legal internal page and a
+    /// multi-level one.
+    #[test]
+    fn decode_still_accepts_well_formed_internal_pages() {
+        for (keys, children) in [
+            (vec![], vec![1u32]),
+            (vec!["m"], vec![1, 2]),
+            (vec!["a", "m", "z"], vec![1, 2, 3, 4]),
+        ] {
+            let page = InternalPage {
+                keys: keys.iter().map(|k| k.to_string()).collect(),
+                children: children.clone(),
+            };
+            let encoded = encode_page(&Page::Internal(page.clone()), INDEX_PAGE_SIZE).unwrap();
+            assert_eq!(
+                decode_page(&encoded).unwrap(),
+                Page::Internal(page),
+                "{} keys / {} children must still round trip",
+                keys.len(),
+                children.len()
+            );
+        }
+    }
+
+    /// The reason the check lives at decode rather than at a length check: a
+    /// single flipped bit in one of bincode's length prefixes produces a page
+    /// that deserializes cleanly but violates the invariant.
+    #[test]
+    fn a_single_bit_flip_can_break_the_invariant_and_is_now_caught() {
+        let encoded = encode_internal_unchecked(vec!["k1", "k2"], vec![1, 2, 3]);
+        let used = encoded.iter().rposition(|b| *b != 0).unwrap() + 1;
+
+        let mut caught = 0usize;
+        for pos in PAGE_ENCODING_OVERHEAD..used {
+            for bit in 0..8u8 {
+                let mut flipped = encoded.clone();
+                flipped[pos] ^= 1 << bit;
+                if let Err(error) = decode_page(&flipped)
+                    && error.to_string().contains("corrupt internal page")
+                {
+                    caught += 1;
+                }
+            }
+        }
+        assert!(
+            caught > 0,
+            "at least one single-bit flip should now be reported as corruption"
+        );
     }
 }

--- a/src/engine/index/page_btree.rs
+++ b/src/engine/index/page_btree.rs
@@ -962,3 +962,52 @@ mod tests {
         assert_ne!(entries[split - 1].key, entries[split].key);
     }
 }
+
+#[cfg(test)]
+mod invariant_integration {
+    use super::*;
+    use crate::engine::index::page::{InternalPage, Page};
+    use crate::engine::index::page_store::PageStore;
+
+    /// #258 end to end: a corrupt root used to panic the task in
+    /// `find_leftmost_leaf`. Asserted through a real file and the public API,
+    /// because the value of the decode check is that callers see an error.
+    #[tokio::test]
+    async fn scan_reports_a_corrupt_root_instead_of_panicking() {
+        let dir = std::path::PathBuf::from("target/test_invariant_integration");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("corrupt_root.idx");
+        let _ = tokio::fs::remove_file(&path).await;
+
+        {
+            let store = PageStore::create(&path, INDEX_PAGE_SIZE).await.unwrap();
+            let id = store.allocate_page().await.unwrap();
+            store
+                .write_page(
+                    id,
+                    &Page::Internal(InternalPage {
+                        keys: vec![],
+                        children: vec![],
+                    }),
+                )
+                .await
+                .unwrap();
+            store.set_root_page_id(Some(id)).await.unwrap();
+        }
+
+        let index = PageBackedBTreeIndex::open(&path, "c".to_string(), false)
+            .await
+            .unwrap();
+        let error = index
+            .scan_all()
+            .await
+            .expect_err("a corrupt root must surface as an error");
+        assert!(
+            error.to_string().contains("corrupt internal page"),
+            "got: {}",
+            error
+        );
+
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+}


### PR DESCRIPTION
#258 수정입니다.

## 문제

`InternalPage`의 불변식 `keys.len() + 1 == children.len()`이 주석으로만 있고 `decode_page`가 확인하지 않습니다. `page_btree.rs`의 자식 조회는 `child_index`가 `keys.len()`까지 나올 수 있어서, children이 그보다 적은 페이지를 읽으면 범위 초과로 패닉합니다:

```
thread panicked at src/engine/index/page_btree.rs:413:48
```

패닉이 나면 그 쿼리를 처리하던 연결 태스크가 죽습니다.

## "손상된 파일이 있어야 하니 이론적" 아닌가

저도 그렇게 넘길 뻔해서 확인했습니다. 정상 페이지를 인코딩한 뒤 페이로드 전체에 **단일 비트 플립을 전수로** 시도했습니다:

```
flip byte=5  bit=1 -> Ok keys=0 children=2   INVARIANT BROKEN
flip byte=33 bit=0 -> Ok keys=2 children=2   INVARIANT BROKEN
flip byte=33 bit=1 -> Ok keys=2 children=1   INVARIANT BROKEN
```

`bincode`가 길이 접두사를 그대로 신뢰하므로, 그중 한 비트만 뒤집혀도 원소 수가 달라진 채 **오류 없이** 디코딩됩니다.

대조를 위해 프레임 꼬리를 1/2/4/8바이트 0으로 덮는 경우도 봤는데, 전부 불변식이 유지됩니다. **문제는 길이 필드이지 페이로드 끝이 아닙니다.** 그래서 "잘린 파일" 류의 검사로는 잡히지 않고, 디코딩 지점에서 구조를 봐야 합니다.

## 테스트 5건

- `decode_rejects_an_internal_page_with_too_few_children` — 4가지 조합
- `decode_rejects_an_internal_page_with_too_many_children` — 반대 방향. 패닉 대신 서브트리를 잃습니다
- `decode_still_accepts_well_formed_internal_pages` — **guard rail**
- `a_single_bit_flip_can_break_the_invariant_and_is_now_caught` — 위 근거를 테스트로 고정
- `scan_reports_a_corrupt_root_instead_of_panicking` — **실제 파일 + 공개 API**

마지막 것이 요지입니다. 이 검사의 가치는 호출자가 패닉 대신 에러를 본다는 데 있으므로, 단위 테스트가 아니라 실제 인덱스 파일을 만들어 `scan_all()`이 에러를 돌려주는지 확인합니다.

## 이 테스트들이 실제로 무언가를 잡는지

검사를 제거하고 확인했습니다:

```
decode_rejects_an_internal_page_with_too_few_children      FAILED
decode_rejects_an_internal_page_with_too_many_children     FAILED
a_single_bit_flip_can_break_the_invariant_and_is_now_caught FAILED
decode_still_accepts_well_formed_internal_pages            ok   <- guard rail은 양쪽에서 통과
```

## 검증

```
cargo test              679 passed / 0 failed   (master 669 + 10)
cargo clippy --all-targets  경고 73건 — master와 동일
```

## 참고

이건 #251(WAL 프레임 무결성)과 같은 계열이지만 **포맷 변경 없이 고칠 수 있다는 점이 다릅니다.** 체크섬이 생기면 손상을 더 일찍 잡겠지만, 그와 별개로 구조 불변식은 디코딩 지점에서 확인하는 편이 맞다고 봅니다. 두 변경은 서로 독립적입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 손상되거나 구조가 올바르지 않은 내부 인덱스 페이지를 안전하게 감지하고 오류로 처리합니다.
  * 인덱스 손상 시 패닉 대신 명확한 오류가 반환됩니다.
  * 정상적인 최소 및 다단계 내부 페이지는 기존처럼 정상 처리됩니다.

* **테스트**
  * 자식 페이지 수 불일치와 데이터 손상 상황에 대한 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->