### PR TITLE
[#260] fix(insert): 존재하지 않는 컬럼을 패닉 대신 에러로 보고

### DIFF
--- a/src/engine/actions/dml/insert.rs
+++ b/src/engine/actions/dml/insert.rs
@@ -116,7 +116,16 @@ impl DBEngine {
 
                     // 명시적으로 전달된 컬럼값 리스트 처리
                     for (i, column_name) in query.columns.iter().enumerate() {
-                        let column_config_info = columns_map.get(column_name).unwrap();
+                        // `query.columns`는 SQL에서 그대로 온 값이라 스키마에 없는
+                        // 이름이 들어올 수 있습니다. 파서는 값 개수만 확인하고
+                        // 컬럼의 존재 여부는 모릅니다 (#260).
+                        let column_config_info =
+                            columns_map.get(column_name).ok_or_else(|| {
+                                ExecuteError::wrap(format!(
+                                    "column '{}' does not exist on table '{}'",
+                                    column_name, table_name
+                                ))
+                            })?;
 
                         let default_value = match &column_config_info.default {
                             Some(default) => default.to_owned(),
@@ -424,6 +433,74 @@ mod tests {
     /// 두 INSERT를 동시에 실행해 unique 인덱스 사전 검증과 실제
     /// `index_manager.insert` 사이의 경합 창을 유도합니다. 롤백이 없다면
     /// 패자 쪽 row가 테이블에는 남고 인덱스에는 반영되지 않는 상태가 됩니다.
+    /// #260: `query.columns` comes straight from the SQL text, so a column
+    /// that does not exist reached `columns_map.get(...).unwrap()` and panicked
+    /// the task handling the query. It has to be an ordinary SQL error.
+    #[tokio::test]
+    async fn insert_reports_an_unknown_column_instead_of_panicking() {
+        let (engine, wal) = build_test_engine("insert_unknown_column").await;
+        execute_sql(&engine, wal.clone(), "create database rrdb;")
+            .await
+            .unwrap();
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "create table users (id integer primary key, score integer);",
+        )
+        .await
+        .unwrap();
+
+        // Mixed with a real column, so the "required column missing" check
+        // that catches the all-unknown case does not fire first.
+        let error = execute_sql(
+            &engine,
+            wal.clone(),
+            "insert into users (id, nope) values (1, 2);",
+        )
+        .await
+        .expect_err("an unknown column must be reported, not panic");
+
+        let message = error.to_string();
+        assert!(message.contains("nope"), "got: {}", message);
+        assert!(message.contains("does not exist"), "got: {}", message);
+
+        // The failed statement must not have written anything.
+        assert!(
+            engine.full_scan(users_table()).await.unwrap().is_empty(),
+            "a rejected insert must not leave a row behind"
+        );
+    }
+
+    /// Guard rail: rejecting more is only a fix while every valid insert still
+    /// works, including the forms that exercise defaults and column reordering.
+    #[tokio::test]
+    async fn insert_still_accepts_valid_column_lists() {
+        let (engine, wal) = build_test_engine("insert_valid_columns").await;
+        execute_sql(&engine, wal.clone(), "create database rrdb;")
+            .await
+            .unwrap();
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "create table users (id integer primary key, score integer);",
+        )
+        .await
+        .unwrap();
+
+        for sql in [
+            "insert into users (id, score) values (1, 10);",
+            "insert into users (score, id) values (20, 2);",
+            "insert into users (id) values (3);",
+        ] {
+            execute_sql(&engine, wal.clone(), sql)
+                .await
+                .unwrap_or_else(|error| panic!("{:?} must still be accepted: {}", sql, error));
+        }
+
+        let rows = engine.full_scan(users_table()).await.unwrap();
+        assert_eq!(rows.len(), 3, "all three valid inserts should have landed");
+    }
+
     #[tokio::test]
     async fn failed_unique_index_insert_does_not_leave_orphan_row() {
         let (engine, wal) = build_test_engine("orphan_row_rollback").await;


### PR DESCRIPTION
#260 수정입니다.

## 문제

존재하지 않는 컬럼명을 쓴 `INSERT`가 패닉합니다:

```sql
insert into users (id, nope) values (1, 2);
-- thread panicked at src/engine/actions/dml/insert.rs:119:79
```

`insert.rs:119`가 사용자가 준 컬럼명을 스키마 맵에서 조회하며 `unwrap()`합니다. `query.columns`는 SQL 텍스트에서 그대로 온 값입니다.

인증이 없으므로 접속만 되면 누구나 **오타 한 줄**로 연결 태스크를 죽일 수 있습니다.

## 파서가 못 막는 이유

값 개수 불일치는 파서가 잡습니다:

```
insert into users (id, score) values (1);
  -> parse Err(The number of values in insert and the number of columns do not match.)
```

하지만 컬럼의 **존재 여부**는 스키마를 알아야 하는 일이라 파서가 모릅니다:

```
insert into users (id, nope) values (1, 2);   -> parse Ok
```

`insert into users (nope) values (1)`처럼 전부 미지의 컬럼이면 다른 검사(`column 'id' is required`)에 먼저 걸립니다. 하지만 **실재하는 컬럼과 섞이면** 그 검사를 지나쳐 119행에 도달합니다. 테스트도 이 형태로 작성했습니다.

## 참고: 이미 인지된 조회였습니다

몇 줄 뒤에 같은 조회를 안전하게 처리하는 코드가 이미 있습니다:

```rust
match columns_map.get(column_name) {
    Some(column) => { ... }
```

즉 실패 가능성은 알려져 있었고 119행만 `unwrap()`으로 남아 있었습니다. 169행에도 같은 형태가 있지만 그쪽은 **스키마에서 유래한 이름**을 순회하므로 안전합니다 — 확인하고 건드리지 않았습니다.

## 테스트 2건

- `insert_reports_an_unknown_column_instead_of_panicking` — 에러 메시지뿐 아니라 **실패한 문장이 행을 남기지 않았는지**도 확인합니다
- `insert_still_accepts_valid_column_lists` — **guard rail.** 정상 순서, 역순, 일부 컬럼 생략 세 형태가 모두 통과하는지 봅니다

## 이 테스트들이 실제로 무언가를 잡는지

`unwrap()`으로 되돌리고 확인했습니다:

```
insert_reports_an_unknown_column_instead_of_panicking   FAILED (그 지점에서 패닉)
insert_still_accepts_valid_column_lists                 ok     <- guard rail은 양쪽에서 통과
```

## 검증

```
cargo test              673 passed / 0 failed   (master 669 + 4)
cargo clippy --all-targets  경고 73건 — master와 동일
```

## 범위

`UPDATE` 쪽도 확인했는데 같은 형태의 `unwrap()`은 없었습니다. 다른 곳에 제가 못 본 지점이 있으면 알려주세요.
