### PR TITLE
[#51] perf: 안전한 경우에만 LIMIT을 스캔까지 밀어내기

### DIFF
--- a/src/engine/actions/dml/scan.rs
+++ b/src/engine/actions/dml/scan.rs
@@ -33,6 +33,19 @@ impl DBEngine {
         &self,
         table_name: TableName,
     ) -> errors::Result<Vec<(RowLocation, TableDataRow)>> {
+        self.full_scan_limited(table_name, None).await
+    }
+
+    /// `full_scan`, stopping once `limit` live rows have been collected.
+    ///
+    /// The limit counts rows that survive the tombstone filter, not raw slots,
+    /// so a segment whose head is mostly deleted still yields the requested
+    /// number. `None` scans everything.
+    pub(crate) async fn full_scan_limited(
+        &self,
+        table_name: TableName,
+        limit: Option<usize>,
+    ) -> errors::Result<Vec<(RowLocation, TableDataRow)>> {
         let _guard = self.row_storage_lock.lock().await;
         let segment_path = self.row_segment_path(&table_name)?;
         let cached_rows = { self.row_buffer_pool.lock().await.cached_rows(&segment_path) };
@@ -47,11 +60,15 @@ impl DBEngine {
             }
         };
 
-        Ok(rows
+        let live = rows
             .into_iter()
             .enumerate()
-            .filter_map(|(row_index, row)| row.map(|row| (RowLocation { row_index }, row)))
-            .collect())
+            .filter_map(|(row_index, row)| row.map(|row| (RowLocation { row_index }, row)));
+
+        Ok(match limit {
+            Some(limit) => live.take(limit).collect(),
+            None => live.collect(),
+        })
     }
 
     /// 행을 세그먼트 파일 끝에 추가하고 시작 row index를 반환합니다.

--- a/src/engine/actions/dml/select.rs
+++ b/src/engine/actions/dml/select.rs
@@ -191,7 +191,7 @@ impl DBEngine {
                     match from.scan {
                         ScanType::FullScan => {
                             let mut result = self
-                                .full_scan(table_name)
+                                .full_scan_limited(table_name, from.scan_limit)
                                 .await?
                                 .into_iter()
                                 .map(|(_, e)| e)
@@ -726,6 +726,69 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(3));
+    }
+
+    /// #51: LIMIT을 스캔까지 밀어내도 결과가 달라지면 안 됩니다. 최적화가
+    /// 값을 바꾸지 않는다는 것은 계획 모양이 아니라 실제 행으로 확인해야
+    /// 합니다.
+    #[tokio::test]
+    async fn limit_pushdown_returns_the_same_rows_as_before() {
+        let (engine, wal) = build_test_engine("test_limit_pushdown_rows").await;
+
+        execute_sql(&engine, wal.clone(), "create database rrdb;")
+            .await
+            .unwrap();
+        execute_sql(&engine, wal.clone(), "create table key_value (id integer);")
+            .await
+            .unwrap();
+        for value in 1..=5 {
+            insert_id(&engine, wal.clone(), value).await;
+        }
+
+        // 스캔이 한도에서 멈추더라도 앞에서부터 정확히 그만큼이어야 합니다.
+        let result = execute_sql(&engine, wal.clone(), "select id from key_value limit 2;")
+            .await
+            .unwrap();
+        assert_eq!(result.rows.len(), 2);
+        assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(1));
+        assert_eq!(result.rows[1].fields[0], ExecuteField::Integer(2));
+
+        // OFFSET이 있으면 건너뛴 행까지 읽어야 하므로, 한도는 offset+limit입니다.
+        // 한도를 limit만으로 잡았다면 여기서 빈 결과가 나옵니다.
+        let result = execute_sql(
+            &engine,
+            wal.clone(),
+            "select id from key_value offset 3 limit 2;",
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.rows.len(), 2);
+        assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(4));
+        assert_eq!(result.rows[1].fields[0], ExecuteField::Integer(5));
+
+        // ORDER BY가 붙으면 스캔을 자를 수 없습니다. 잘랐다면 앞의 2행만
+        // 정렬해서 5가 아니라 2가 나옵니다.
+        let result = execute_sql(
+            &engine,
+            wal.clone(),
+            "select id from key_value order by id desc limit 2;",
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.rows.len(), 2);
+        assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(5));
+        assert_eq!(result.rows[1].fields[0], ExecuteField::Integer(4));
+
+        // WHERE도 마찬가지입니다. 스캔을 1행에서 끊으면 id=4를 만나지 못합니다.
+        let result = execute_sql(
+            &engine,
+            wal,
+            "select id from key_value where id = 4 limit 1;",
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(4));
     }
 
     /// `LIMIT`/`OFFSET`은 사용자가 주는 값이라 실제 행 수를 넘을 수 있습니다.

--- a/src/engine/ast/dml/plan/select/from.rs
+++ b/src/engine/ast/dml/plan/select/from.rs
@@ -7,4 +7,12 @@ pub struct SelectFromPlan {
     pub table_name: TableName,
     pub alias: Option<String>,
     pub scan: ScanType,
+    /// Upper bound on rows the scan needs to produce, when the query shape
+    /// makes that safe (#51). `None` means "scan everything", which is the
+    /// only correct answer whenever a later stage can reorder or drop rows —
+    /// ORDER BY, GROUP BY, aggregates, joins and WHERE all qualify.
+    ///
+    /// Carries OFFSET + LIMIT, not LIMIT: the rows skipped by OFFSET still
+    /// have to be read before the ones that are returned.
+    pub scan_limit: Option<usize>,
 }

--- a/src/engine/ast/dml/plan/select/select_plan.rs
+++ b/src/engine/ast/dml/plan/select/select_plan.rs
@@ -83,6 +83,7 @@ mod tests {
             table_name: TableName::new(None, "table".into()),
             alias: None,
             scan: ScanType::FullScan,
+            scan_limit: None,
         };
         let select_plan_item: SelectPlanItem = select_from.clone().into();
         assert_eq!(select_plan_item, SelectPlanItem::From(select_from));

--- a/src/engine/optimizer/optimizer.rs
+++ b/src/engine/optimizer/optimizer.rs
@@ -78,6 +78,28 @@ impl Optimizer {
             ScanType::FullScan
         };
 
+        // LIMIT pushdown (#51). Only safe when nothing between the scan and the
+        // limit can reorder or remove rows: a filter, a sort, a grouping or a
+        // join all mean the first N rows off the table are not the first N rows
+        // of the result.
+        //
+        // The bound is OFFSET + LIMIT rather than LIMIT, since the skipped rows
+        // still have to come off the table first. Without a LIMIT there is no
+        // bound at all, even if an OFFSET is present.
+        let scan_limit = if query.join_clause.is_empty()
+            && query.where_clause.is_none()
+            && query.group_by_clause.is_none()
+            && query.having_clause.is_none()
+            && query.order_by_clause.is_none()
+            && !query.has_aggregate
+        {
+            query.limit.map(|limit| {
+                (limit as usize).saturating_add(query.offset.unwrap_or(0) as usize)
+            })
+        } else {
+            None
+        };
+
         // FROM 절 분석
         if let Some(from_clause) = query.from_table {
             has_from = true;
@@ -89,6 +111,7 @@ impl Optimizer {
                         table_name,
                         alias,
                         scan,
+                        scan_limit,
                     }
                     .into(),
                 ),
@@ -771,5 +794,77 @@ mod tests {
             SelectPlanItem::From(from) => assert_eq!(from.scan, ScanType::FullScan),
             other => panic!("expected From plan, got {:?}", other),
         }
+    }
+
+    /// Parse `sql` and return the scan limit the optimizer put on the FROM plan.
+    async fn scan_limit_for(sql: &str) -> Option<usize> {
+        let mut parser = Parser::with_string(sql.into()).unwrap();
+        let statements = parser
+            .parse(ParserContext::default().set_default_database("rrdb".to_string()))
+            .unwrap();
+        let query = match statements.into_iter().next().unwrap() {
+            crate::engine::ast::SQLStatement::DML(
+                crate::engine::ast::DMLStatement::SelectQuery(query),
+            ) => query,
+            other => panic!("expected select query, got {:?}", other),
+        };
+
+        let optimizer = Optimizer::with_context(context(10_000, true));
+        let plan = optimizer.optimize_select(query).await.unwrap();
+
+        match &plan.list[0] {
+            SelectPlanItem::From(from) => from.scan_limit,
+            other => panic!("expected From plan, got {:?}", other),
+        }
+    }
+
+    /// #51: a bare LIMIT bounds the scan, and OFFSET is included in the bound
+    /// because the skipped rows still have to be read.
+    #[tokio::test]
+    async fn limit_is_pushed_into_the_scan_when_nothing_can_reorder_rows() {
+        assert_eq!(scan_limit_for("select * from foo limit 1;").await, Some(1));
+        assert_eq!(
+            scan_limit_for("select * from foo offset 5 limit 1;").await,
+            Some(6),
+            "offset 5 limit 1 has to read 6 rows, not 1"
+        );
+        assert_eq!(
+            scan_limit_for("select * from foo limit 10 offset 90;").await,
+            Some(100)
+        );
+    }
+
+    /// The guard rail. Pushing a limit down is only correct while every stage
+    /// between the scan and the limit preserves both order and membership;
+    /// each of these breaks one of those, so the scan must stay unbounded.
+    #[tokio::test]
+    async fn limit_is_not_pushed_past_a_stage_that_can_reorder_or_drop_rows() {
+        for sql in [
+            // ORDER BY: the first row scanned is not the first row sorted.
+            "select * from foo order by a limit 1;",
+            // WHERE: rows are dropped after the scan, so N scanned may yield 0.
+            "select * from foo where a = 1 limit 1;",
+            // JOIN: one left row can produce many or no output rows.
+            "select * from foo f inner join bar b on f.id = b.id limit 1;",
+            // GROUP BY collapses rows; HAVING then drops groups.
+            "select a from foo group by a limit 1;",
+            // Aggregate over the whole table needs every row.
+            "select count(1) from foo limit 1;",
+        ] {
+            assert_eq!(
+                scan_limit_for(sql).await,
+                None,
+                "{:?} must not bound the scan",
+                sql
+            );
+        }
+    }
+
+    /// OFFSET without LIMIT is unbounded: there is no count that says when to
+    /// stop, only where to start.
+    #[tokio::test]
+    async fn offset_without_limit_does_not_bound_the_scan() {
+        assert_eq!(scan_limit_for("select * from foo offset 5;").await, None);
+        assert_eq!(scan_limit_for("select * from foo;").await, None);
     }
 }


### PR DESCRIPTION
#51 구현입니다. 이슈에 적힌 네 사례를 그대로 기준으로 삼았습니다.

## 문제

이슈 그대로, `LIMIT 1`이 걸려 있어도 full scan이 행을 전부 읽고 마지막 단계에서야 잘라내고 있었습니다. `SelectFromPlan`에 `scan_limit`을 추가하고 옵티마이저가 안전할 때만 채우도록 했습니다.

## 밀어내도 되는 조건

스캔과 LIMIT **사이의 어떤 단계도 순서나 구성원을 바꾸지 않을 때**만입니다:

| 쿼리 | 스캔 |
|---|---|
| `select * from foo limit 1` | 1행 |
| `select * from foo offset 5 limit 1` | 6행 |
| `select * from foo order by a limit 1` | 풀스캔 |
| `select * from foo f join bar b ... limit 1` | 풀스캔 |

이슈에 적어주신 것과 동일합니다. 여기에 WHERE / GROUP BY / HAVING / 집계를 같은 이유로 추가했습니다 — WHERE는 스캔 뒤에 행을 버리므로 N행을 읽어도 0행이 나올 수 있고, GROUP BY는 행을 합칩니다.

## 한도는 `limit`이 아니라 `offset + limit`

건너뛰는 행도 결국 읽어야 하기 때문입니다. 사소해 보이지만 여기서 틀리면 조용히 잘못된 결과가 나옵니다 — `limit`만으로 잡으면 `offset 3 limit 2`가 **빈 결과**를 돌려줍니다.

일부러 그렇게 바꿔서 테스트가 잡는지 확인했습니다:

```
assertion `left == right` failed
  left: 0
 right: 2
```

`OFFSET`만 있고 `LIMIT`이 없으면 멈출 지점이 없으므로 한도도 걸지 않습니다.

## 테스트

옵티마이저 계획 3건 + **실제 쿼리 결과 1건**입니다.

계획만 확인하면 "최적화가 켜졌다"까지만 알 수 있어서, 통합 테스트로 행 값까지 봅니다:

- `limit 2` → 앞의 2행인가
- `offset 3 limit 2` → 4, 5인가
- `order by id desc limit 2` → 5, 4인가 (잘랐다면 2, 1이 나옵니다)
- `where id = 4 limit 1` → 1행에서 끊기지 않고 id=4를 찾는가

마지막 두 개가 특히 중요합니다. pushdown이 잘못 적용됐을 때 **정확히 이 형태로 틀린 답**이 나오기 때문입니다.

## 검증

```
cargo test              735 passed / 0 failed
cargo clippy --all-targets  경고 73건 — master와 동일

bite-test: pushdown 제거 시
  limit_is_pushed_into_the_scan...              FAILED
  limit_is_not_pushed_past_a_stage...           ok    <- guard rail
  offset_without_limit_does_not_bound_the_scan  ok    <- guard rail
```

## 범위 밖으로 둔 것

인덱스 스캔에는 한도를 전달하지 않았습니다. `IndexScan`은 이미 키 조건으로 좁혀진 경로라 성격이 다르고, 이슈가 지적한 것은 full scan입니다. 필요하다고 보시면 별도로 하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 안전한 경우 `LIMIT`과 `OFFSET`을 스캔 단계에 반영해 불필요한 데이터 처리를 줄였습니다.
  * `WHERE`, `ORDER BY`, 조인, 그룹화 등이 포함된 조회에서는 결과의 행 순서와 내용이 변경되지 않도록 기존 동작을 유지합니다.

* **버그 수정**
  * `LIMIT` 최적화 적용 후에도 기존과 동일한 행이 반환되도록 보장했습니다.
  * `OFFSET`과 `LIMIT`을 함께 사용하는 조회 결과의 정확성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->