### PR TITLE
feat: add query-level memory limit (OOM killer)

### DIFF
--- a/src/common/fs.rs
+++ b/src/common/fs.rs
@@ -14,6 +14,9 @@ pub trait FileSystem {
     async fn write_file(&self, path: &str, content: &[u8]) -> io::Result<()>;
     async fn read_dir(&self, path: &str) -> io::Result<Vec<FileSystemEntry>>;
     async fn read(&self, path: &Path) -> io::Result<Vec<u8>>;
+    /// 파일의 크기(bytes)를 반환합니다. (#265)
+    /// `read_segment_rows`가 파일 전체를 메모리로 읽기 전에 예산을 확보하는 데 사용합니다.
+    async fn metadata(&self, path: &Path) -> io::Result<u64>;
 }
 
 pub struct RealFileSystem;
@@ -44,5 +47,10 @@ impl FileSystem for RealFileSystem {
 
     async fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
         tokio::fs::read(path).await
+    }
+
+    async fn metadata(&self, path: &Path) -> io::Result<u64> {
+        let metadata = tokio::fs::metadata(path).await?;
+        Ok(metadata.len())
     }
 }

--- a/src/config/launch_config.rs
+++ b/src/config/launch_config.rs
@@ -17,6 +17,20 @@ pub struct LaunchConfig {
     pub wal_directory: String,
     pub wal_segment_size: u32,
     pub wal_extension: String,
+
+    /// 쿼리 수준 메모리 상한 (bytes) (#265).
+    /// SELECT/UPDATE/DELETE 실행 중 추정 메모리가 이를 넘으면
+    /// 에러를 반환해 쿼리를 강제로 중단합니다.
+    /// `0`이면 비활성 (OOM killer 작동 안 함).
+    /// 기존 설정 파일에 이 필드가 없어도 동작하도록 serde default 적용.
+    #[serde(default = "default_max_query_memory_bytes")]
+    pub max_query_memory_bytes: u64,
+}
+
+/// 새 설정 필드가 사용자 TOML에서 빠져 있을 때의 기본값 (#265).
+/// 이 관리가 없으면 기존 rrdb.config를 가진 사용자는 업데이트 시 설정 로드가 실패합니다.
+fn default_max_query_memory_bytes() -> u64 {
+    128 * 1024 * 1024
 }
 
 #[allow(clippy::derivable_impls)]
@@ -40,6 +54,8 @@ impl std::default::Default for LaunchConfig {
                 .to_string(),
             wal_segment_size: 1024 * 1024 * 16, // 16MB 세그먼트 사이즈
             wal_extension: DEFAULT_WAL_EXTENSION.to_string(),
+            // 기본 128MB. 사용자가 메모리 퍼센트를 조절하면 TOML에서 설정.
+            max_query_memory_bytes: 128 * 1024 * 1024,
         }
     }
 }

--- a/src/engine/actions/dml/scan.rs
+++ b/src/engine/actions/dml/scan.rs
@@ -321,11 +321,14 @@ impl DBEngine {
         // 파일 전체를 메모리로 읽기 전에 예산을 미리 확보 (#265).
         // `tokio::fs::read`가 들어올 파일 크만큼을 추적해
         // 상한 초과 시 실제 할당 이전에 거부합니다.
+        // `self.file_system.metadata()`를 사용해 주입된 mock으로
+        // metadata 오류와 메모리 예약을 검증할 수 있게 합니다 (CodeRabbit).
         if let Some(tracker) = self.query_memory().await {
-            let file_size = tokio::fs::metadata(segment_path)
-                .await
-                .map(|metadata| metadata.len())
-                .unwrap_or(0);
+            let file_size = match self.file_system.metadata(segment_path).await {
+                Ok(size) => size,
+                Err(error) if error.kind() == IOErrorKind::NotFound => 0,
+                Err(error) => return Err(ExecuteError::wrap(error.to_string())),
+            };
             tracker.reserve(file_size)?;
         }
 
@@ -365,6 +368,13 @@ impl DBEngine {
             if tombstoned {
                 rows.push(None);
             } else {
+                // 역직렬화 전에 프레임 디코드 예산을 추가로 reserve (#265).
+                // 파일 크기는 원본 바이트인데 디코드 결과는 틀이 크게
+                // 날 수 있으므로, 보수적으로 프레임 크기만큼을
+                // 추가 예약하여 상한 초과 시 디코드 전에 거부합니다.
+                if let Some(tracker) = self.query_memory().await {
+                    tracker.reserve(frame_len as u64)?;
+                }
                 let row = encoder
                     .decode::<TableDataRow>(&content[offset..offset + frame_len])
                     .map_err(|error| {

--- a/src/engine/actions/dml/scan.rs
+++ b/src/engine/actions/dml/scan.rs
@@ -10,7 +10,7 @@ use crate::engine::ast::dml::plan::select::scan::IndexScanPlan;
 use crate::engine::ast::types::TableName;
 use crate::engine::encoder::schema_encoder::StorageEncoder;
 use crate::engine::row_buffer::{ROW_FRAME_LIVE, RowBufferWrite, encode_live_row_frames};
-use crate::engine::schema::row::TableDataRow;
+use crate::engine::schema::row::{ESTIMATED_FIELD_OVERHEAD, TableDataRow};
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
 
@@ -59,6 +59,17 @@ impl DBEngine {
                     .read_rows(segment_path, || disk_rows)
             }
         };
+
+        // 메모리 예산 추적 (#265): 전체 세그먼트 로드 후
+        // 자신의 반환 결과(Vec<(RowLocation, TableDataRow)>) 크기를 reserve.
+        if let Some(tracker) = self.query_memory().await {
+            let bytes: u64 = rows
+                .iter()
+                .filter_map(|row| row.as_ref())
+                .map(|row| row.estimated_bytes() + ESTIMATED_FIELD_OVERHEAD)
+                .sum();
+            tracker.reserve(bytes)?;
+        }
 
         let live = rows
             .into_iter()
@@ -307,6 +318,17 @@ impl DBEngine {
         &self,
         segment_path: &Path,
     ) -> errors::Result<Vec<Option<TableDataRow>>> {
+        // 파일 전체를 메모리로 읽기 전에 예산을 미리 확보 (#265).
+        // `tokio::fs::read`가 들어올 파일 크만큼을 추적해
+        // 상한 초과 시 실제 할당 이전에 거부합니다.
+        if let Some(tracker) = self.query_memory().await {
+            let file_size = tokio::fs::metadata(segment_path)
+                .await
+                .map(|metadata| metadata.len())
+                .unwrap_or(0);
+            tracker.reserve(file_size)?;
+        }
+
         let content = match tokio::fs::read(segment_path).await {
             Ok(content) => content,
             Err(error) if error.kind() == IOErrorKind::NotFound => return Ok(Vec::new()),
@@ -596,7 +618,13 @@ impl DBEngine {
             })?;
 
             match all_rows.get(row_index) {
-                Some(Some(row)) => result.push((RowLocation { row_index }, row.clone())),
+                Some(Some(row)) => {
+                    // 메모리 예산 추적 (#265): 결과 행이 앱드될 때마다 크기를 reserve.
+                    if let Some(tracker) = self.query_memory().await {
+                        tracker.reserve(row.estimated_bytes() + ESTIMATED_FIELD_OVERHEAD)?;
+                    }
+                    result.push((RowLocation { row_index }, row.clone()));
+                }
                 Some(None) | None => {
                     return Err(ExecuteError::wrap(format!(
                         "index '{}' is out of sync with table data; drop and recreate the index",

--- a/src/engine/actions/dml/select.rs
+++ b/src/engine/actions/dml/select.rs
@@ -642,8 +642,13 @@ mod tests {
         max_query_memory_bytes: u64,
     ) -> (DBEngine, SharedWALManager) {
         let base_path = PathBuf::from("target").join(test_name);
-        if base_path.exists() {
-            tokio::fs::remove_dir_all(&base_path).await.unwrap();
+        // 동기 `Path::exists()`는 metadata 오류를 `false`로 처리해 정리를 건너뛸 수
+        // 있으므로, 비동기 `tokio::fs::metadata`로 NotFound만 무시하고 다른 오류는
+        // 테스트를 실패시킵니다 (CodeRabbit).
+        match tokio::fs::metadata(&base_path).await {
+            Ok(_) => tokio::fs::remove_dir_all(&base_path).await.unwrap(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => panic!("metadata check failed for {base_path:?}: {error}"),
         }
 
         let mut config = LaunchConfig::default_for_base_path(&base_path);
@@ -970,5 +975,83 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.rows.len(), 1);
+    }
+
+    /// 지정한 테이블에 큰 문자열 행을 삽입합니다.
+    async fn insert_big_string_into(
+        engine: &DBEngine,
+        wal: SharedWALManager,
+        table: &str,
+        size_bytes: usize,
+    ) {
+        let value = "x".repeat(size_bytes);
+        engine
+            .insert(
+                InsertQuery::builder()
+                    .set_into_table(TableName::new(Some("rrdb".to_string()), table.to_string()))
+                    .set_columns(vec!["id".to_string()])
+                    .set_values(vec![InsertValue {
+                        list: vec![Some(SQLExpression::String(value))],
+                    }])
+                    .build(),
+                wal,
+            )
+            .await
+            .unwrap();
+    }
+
+    /// 동시에 실행되는 두 쿼리는 서로의 메모리 예산을 방해하지 않아야 합니다 (#265).
+    ///
+    /// CodeRabbit #1: 이전 구현(공유 RwLock 슬롯)은 두 `process_query`가 동시에
+    /// 실행되면 한쪽이 다른 쪽의 tracker를 덮어쓰거나, 한쪽이 스캔을 마치기 전에
+    /// 슬롯을 클리어해서 나머지가 예산 없이 실행될 수 있었습니다.
+    ///
+    /// task-local로 전환한 후에는 각 쿼리가 자기 tracker를 가지므로,
+    /// 큰 쿼리(예산 초과 → 에러)와 작은 쿼리(예산 내 → 성공)를 동시에 실행해도
+    /// 서로의 결과에 영향을 주지 않아야 합니다.
+    #[tokio::test]
+    async fn concurrent_queries_do_not_interfere_with_each_others_budget() {
+        let (engine, wal) =
+            build_test_engine_with_memory_limit("test_select_oom_concurrent", 2048).await;
+
+        execute_sql(&engine, wal.clone(), "create database rrdb;")
+            .await
+            .unwrap();
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "create table small_t (id varchar(65536));",
+        )
+        .await
+        .unwrap();
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "create table big_t (id varchar(65536));",
+        )
+        .await
+        .unwrap();
+
+        // small_t: 예산(2KB) 안에 들어오는 작은 값
+        // big_t: 예산을 넘기는 큰 값 (4KB 문자열)
+        insert_big_string_into(&engine, wal.clone(), "small_t", 256).await;
+        insert_big_string_into(&engine, wal.clone(), "big_t", 4096).await;
+
+        // 동시 실행: big 쿼리는 실패, small 쿼리는 성공해야 함
+        let (big_result, small_result) = tokio::join!(
+            execute_sql(&engine, wal.clone(), "select id from big_t;"),
+            execute_sql(&engine, wal.clone(), "select id from small_t;"),
+        );
+
+        let big_error = big_result.unwrap_err();
+        assert!(
+            big_error
+                .to_string()
+                .contains("query memory limit exceeded"),
+            "big query should be killed, got: {big_error}"
+        );
+
+        let small_rows = small_result.unwrap();
+        assert_eq!(small_rows.rows.len(), 1, "small query should still succeed");
     }
 }

--- a/src/engine/actions/dml/select.rs
+++ b/src/engine/actions/dml/select.rs
@@ -634,12 +634,20 @@ mod tests {
     use crate::engine::{DBEngine, SharedWALManager};
 
     async fn build_test_engine(test_name: &str) -> (DBEngine, SharedWALManager) {
+        build_test_engine_with_memory_limit(test_name, 128 * 1024 * 1024).await
+    }
+
+    async fn build_test_engine_with_memory_limit(
+        test_name: &str,
+        max_query_memory_bytes: u64,
+    ) -> (DBEngine, SharedWALManager) {
         let base_path = PathBuf::from("target").join(test_name);
         if base_path.exists() {
             tokio::fs::remove_dir_all(&base_path).await.unwrap();
         }
 
-        let config = LaunchConfig::default_for_base_path(&base_path);
+        let mut config = LaunchConfig::default_for_base_path(&base_path);
+        config.max_query_memory_bytes = max_query_memory_bytes;
         tokio::fs::create_dir_all(&config.data_directory)
             .await
             .unwrap();
@@ -821,7 +829,11 @@ mod tests {
                 .await
                 .unwrap_or_else(|error| panic!("{sql} failed: {error}"));
 
-            assert_eq!(result.rows.len(), expected, "unexpected row count for {sql}");
+            assert_eq!(
+                result.rows.len(),
+                expected,
+                "unexpected row count for {sql}"
+            );
         }
     }
 
@@ -846,7 +858,117 @@ mod tests {
             ("select id from key_value offset 1;", 2),
         ] {
             let result = execute_sql(&engine, wal.clone(), sql).await.unwrap();
-            assert_eq!(result.rows.len(), expected, "unexpected row count for {sql}");
+            assert_eq!(
+                result.rows.len(),
+                expected,
+                "unexpected row count for {sql}"
+            );
         }
+    }
+
+    /// 트래킹 상한을 넘기는 크기의 문자열 값을 가진 행을 삽입합니다.
+    /// `size_bytes` 이상의 문자열이 들어가도록 패딩합니다.
+    async fn insert_big_string(engine: &DBEngine, wal: SharedWALManager, size_bytes: usize) {
+        let value = "x".repeat(size_bytes);
+        engine
+            .insert(
+                InsertQuery::builder()
+                    .set_into_table(TableName::new(
+                        Some("rrdb".to_string()),
+                        "key_value".to_string(),
+                    ))
+                    .set_columns(vec!["id".to_string()])
+                    .set_values(vec![InsertValue {
+                        list: vec![Some(SQLExpression::String(value))],
+                    }])
+                    .build(),
+                wal,
+            )
+            .await
+            .unwrap();
+    }
+
+    /// 메모리 예산을 매우 낮게 설정하면, SELECT가
+    /// 행을 메모리로 로드하는 순간 강제 중단됩니다 (#265).
+    #[tokio::test]
+    async fn select_over_memory_limit_is_killed() {
+        let (engine, wal) = build_test_engine_with_memory_limit("test_select_oom_kill", 1024).await;
+
+        execute_sql(&engine, wal.clone(), "create database rrdb;")
+            .await
+            .unwrap();
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "create table key_value (id varchar(65536));",
+        )
+        .await
+        .unwrap();
+
+        // 행 하나만 로드해도 예산(1KB)를 넘는 크기(4KB 문자열).
+        insert_big_string(&engine, wal.clone(), 4096).await;
+
+        let result = execute_sql(&engine, wal, "select id from key_value;")
+            .await
+            .unwrap_err();
+
+        let message = result.to_string();
+        assert!(
+            message.contains("query memory limit exceeded"),
+            "expected memory limit error, got: {message}"
+        );
+    }
+
+    /// `max_query_memory_bytes = 0`이면 OOM killer가 비활성입니다 (#265).
+    /// 크기의 행을 로드해도 에러 없이 정상 동작합니다.
+    #[tokio::test]
+    async fn select_with_disabled_memory_limit_succeeds() {
+        let (engine, wal) =
+            build_test_engine_with_memory_limit("test_select_oom_disabled", 0).await;
+
+        execute_sql(&engine, wal.clone(), "create database rrdb;")
+            .await
+            .unwrap();
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "create table key_value (id varchar(65536));",
+        )
+        .await
+        .unwrap();
+
+        insert_big_string(&engine, wal.clone(), 4096).await;
+
+        let result = execute_sql(&engine, wal, "select id from key_value;")
+            .await
+            .unwrap();
+
+        assert_eq!(result.rows.len(), 1);
+    }
+
+    /// 예산을 넘지 않는 손상된 실행은 정상 동작해야 합니다 (#265).
+    #[tokio::test]
+    async fn select_within_memory_limit_succeeds() {
+        let (engine, wal) =
+            build_test_engine_with_memory_limit("test_select_oom_within", 1024 * 1024).await;
+
+        execute_sql(&engine, wal.clone(), "create database rrdb;")
+            .await
+            .unwrap();
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "create table key_value (id varchar(65536));",
+        )
+        .await
+        .unwrap();
+
+        insert_big_string(&engine, wal.clone(), 4096).await;
+
+        let result = execute_sql(&engine, wal, "select id from key_value;")
+            .await
+            .unwrap();
+
+        assert_eq!(result.rows.len(), 1);
     }
 }

--- a/src/engine/initialize.rs
+++ b/src/engine/initialize.rs
@@ -263,6 +263,7 @@ wal_enabled = true
 wal_directory = "/var/lib/rrdb/wal"
 wal_segment_size = 16777216
 wal_extension = "log"
+max_query_memory_bytes = 134217728
 "##;
 
         struct TestCase {

--- a/src/engine/initialize.rs
+++ b/src/engine/initialize.rs
@@ -236,7 +236,6 @@ mod tests {
             statistics_manager: Arc::new(StatisticsManager::new()),
             indices_loaded: Arc::new(OnceCell::new()),
             row_buffer_pool: Arc::new(Mutex::new(RowBufferPool::default())),
-            query_memory_tracker: Arc::new(RwLock::new(None)),
         }
     }
 

--- a/src/engine/initialize.rs
+++ b/src/engine/initialize.rs
@@ -236,6 +236,7 @@ mod tests {
             statistics_manager: Arc::new(StatisticsManager::new()),
             indices_loaded: Arc::new(OnceCell::new()),
             row_buffer_pool: Arc::new(Mutex::new(RowBufferPool::default())),
+            query_memory_tracker: Arc::new(RwLock::new(None)),
         }
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -19,6 +19,7 @@ pub mod types;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::ptr::NonNull;
 use std::sync::Arc;
 
 use crate::common::command::{CommandRunner, RealCommandRunner};
@@ -34,7 +35,7 @@ use crate::engine::ast::{DDLStatement, DMLStatement, OtherStatement, SQLStatemen
 use crate::engine::encoder::schema_encoder::StorageEncoder;
 use crate::engine::index::manager::IndexManager;
 use crate::engine::optimizer::statistics::StatisticsManager;
-use crate::engine::query_memory::QueryMemoryTracker;
+use crate::engine::query_memory::{QueryMemoryTracker, QueryMemoryTrackerRef};
 use crate::engine::row_buffer::RowBufferPool;
 use crate::engine::schema::table::TableSchema;
 use crate::engine::types::ExecuteResult;
@@ -44,6 +45,24 @@ use crate::engine::wal::types::{EntryType, InsertWALPayload, WALEntry};
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
 use tokio::sync::{Mutex, RwLock};
+
+/// 쿼리 수준 메모리 예산 추적기 (#265).
+///
+/// 서버는 연결마다 task를 spawn하므로, 동시에 여러
+/// `process_query`가 실행될 수 있습니다. 공유된 슬롯(RwLock<Option<..>>)에
+/// 저장하면 서로의 tracker를 덮어쓰거나 클리어하는 race가
+/// 발생합니다. 특히 한 쿼리가 스캔을 마치기 전에 다른
+/// 쿼리가 슬롯을 클리어하면 후자는 예산 없이 실행됩니다.
+///
+/// 해결: `tokio::task_local!`로 task 범위에 저장합니다.
+/// (`tokio::task_local!`은 `Copy` 타입만 지원하므로
+/// `QueryMemoryTrackerRef`(NonNull 래퍼)를 저장합니다.)
+/// - task 마다 각자의 tracker를 가짐 → 동시 쿼리 간 race 없음
+/// - task 종료 시 자동 정리 → cleanup race 없음
+/// - 시그니처 변경 없이 내부 코드에서 `query_memory()` 호출 가능
+tokio::task_local! {
+    static QUERY_MEMORY_TRACKER: QueryMemoryTrackerRef;
+}
 
 pub type SharedWALManager = Arc<Mutex<WALManager<BincodeEncoder>>>;
 
@@ -58,9 +77,6 @@ pub struct DBEngine {
     /// 디스크의 인덱스 파일을 메모리로 적재했는지 여부 (최초 사용 시 1회 적재)
     pub(crate) indices_loaded: Arc<tokio::sync::OnceCell<()>>,
     pub(crate) row_buffer_pool: Arc<Mutex<RowBufferPool>>,
-    /// 현재 실행 중인 쿼리의 메모리 예산 추적기 (#265).
-    /// `process_query`에서 DML 실행 시에만 설정되고, 실행 후 clear된다.
-    pub(crate) query_memory_tracker: Arc<RwLock<Option<Arc<QueryMemoryTracker>>>>,
 }
 
 impl DBEngine {
@@ -77,7 +93,6 @@ impl DBEngine {
             statistics_manager: Arc::new(StatisticsManager::new()),
             indices_loaded: Arc::new(tokio::sync::OnceCell::new()),
             row_buffer_pool: Arc::new(Mutex::new(RowBufferPool::default())),
-            query_memory_tracker: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -95,9 +110,36 @@ impl DBEngine {
         // 예산 대상이 아닙니다. CREATE INDEX의 backfill은 full_scan을 사용하므로
         // 예산 적용 대상이 맞지만, DDL 경로에 넣으면 인덱스 생성이 실패할 수 있어
         // 일단 DML만 적용합니다 (추후 필요 시 확장).
-        let memory_tracker = self.begin_query_memory_tracking(&statement).await;
+        //
+        // 공유 슬롯이 아닌 task-local로 전달하므로, 동시 실행되는 여러 쿼리가
+        // 서로의 tracker를 덮어쓰거나 클리어하는 race가 없습니다 (CodeRabbit #1).
+        let tracker =
+            Self::query_memory_tracker_for(&statement, self.config.max_query_memory_bytes);
+        // Copy 핸들: scope 동안 `tracker`(Arc)를 클로저에 move하여 값이 살아있게 보장.
+        let tracker_ref =
+            QueryMemoryTrackerRef(tracker.as_ref().map(|arc| NonNull::from(arc.as_ref())));
 
-        // 쿼리 실행
+        // 쿼리 실행 (task 범위로 tracker 설정; scope 종료 시 자동 정리)
+        QUERY_MEMORY_TRACKER
+            .scope(tracker_ref, async move {
+                // tracker(Arc)를 scope 동안 유지 — tracker_ref가 가리키는 값의 수명 보장
+                let _keep_alive = tracker;
+                let result = self.execute_statement(statement, wal_manager).await;
+                match result {
+                    Ok(result) => Ok(result),
+                    Err(error) => Err(ExecuteError::wrap(error.to_string())),
+                }
+            })
+            .await
+    }
+
+    /// 스테이트먼트를 실행합니다. `process_query`가
+    /// 메모리 예산 task-local을 설정한 후 호출합니다.
+    async fn execute_statement(
+        &self,
+        statement: SQLStatement,
+        wal_manager: SharedWALManager,
+    ) -> errors::Result<ExecuteResult> {
         let result = match statement {
             SQLStatement::DDL(DDLStatement::CreateDatabaseQuery(query)) => {
                 self.create_database(query).await
@@ -142,27 +184,16 @@ impl DBEngine {
             _ => unimplemented!("no execute implementation"),
         };
 
-        match result {
-            Ok(result) => {
-                self.end_query_memory_tracking(memory_tracker).await;
-                Ok(result)
-            }
-            Err(error) => {
-                self.end_query_memory_tracking(memory_tracker).await;
-                Err(ExecuteError::wrap(error.to_string()))
-            }
-        }
+        result
     }
 
-    /// 쿼리 메모리 예산 추적을 시작합니다 (#265).
-    /// DML(SELECT/UPDATE/DELETE)에만 예산을 설정하고, 나머지는 예산 없이
-    /// 실행합니다.
-    async fn begin_query_memory_tracking(
-        &self,
+    /// 쿼리 메모리 예산 추적기를 생성합니다 (#265).
+    /// DML(SELECT/UPDATE/DELETE)에만 예산을 설정하고, 나머지는 `None`을
+    /// 반환하여 예산 없이 실행합니다.
+    fn query_memory_tracker_for(
         statement: &SQLStatement,
+        limit_bytes: u64,
     ) -> Option<Arc<QueryMemoryTracker>> {
-        let limit_bytes = self.config.max_query_memory_bytes;
-
         let is_dml_read_heavy = matches!(
             statement,
             SQLStatement::DML(DMLStatement::SelectQuery(_))
@@ -174,21 +205,35 @@ impl DBEngine {
             return None;
         }
 
-        let tracker = Arc::new(QueryMemoryTracker::new(limit_bytes));
-        *self.query_memory_tracker.write().await = Some(tracker.clone());
-        Some(tracker)
-    }
-
-    /// 쿼리 메모리 예산 추적을 종료합니다 (#265).
-    /// 예산 초과로 이미 에러가 발생했던 간 무엄 사용하지 않으므로 항상 클리어합니다.
-    async fn end_query_memory_tracking(&self, _tracker: Option<Arc<QueryMemoryTracker>>) {
-        *self.query_memory_tracker.write().await = None;
+        Some(Arc::new(QueryMemoryTracker::new(limit_bytes)))
     }
 
     /// 현재 실행 중인 쿼리의 메모리 추적기를 반환합니다.
     /// 예산 비활성 상태이면 `None`을 반환합니다.
     pub(crate) async fn query_memory(&self) -> Option<Arc<QueryMemoryTracker>> {
-        self.query_memory_tracker.read().await.clone()
+        // `try_with`를 사용해 task-local이 설정되지 않은 컨텍스트(테스트에서
+        // `process_query`를 거치지 않고 full_scan 등을 직접 호출)에서도
+        // panic 대신 `None`을 반환합니다.
+        QUERY_MEMORY_TRACKER
+            .try_with(|tracker_ref| match tracker_ref.0 {
+                Some(ptr) => {
+                    // 안전성: scope 동안 원본 Arc(`_keep_alive`)가 살아 있으므로
+                    // 포인터는 항상 유효. refcount를 +1 하고 from_raw로
+                    // 재구성하여 반환되는 Arc의 수명을 보장합니다.
+                    //
+                    // # Safety
+                    // - `ptr`은 `NonNull::from(arc.as_ref())`로 만들어졌으므로 항상
+                    //   유효한 `QueryMemoryTracker`를 가리킵니다.
+                    // - scope 동안 `_keep_alive`가 refcount를 보유하므로
+                    //   `increment_strong_count` 시점에 사용 후방된 메모리가 아닙니다.
+                    unsafe {
+                        std::sync::Arc::increment_strong_count(ptr.as_ptr());
+                        Some(std::sync::Arc::from_raw(ptr.as_ptr()))
+                    }
+                }
+                None => None,
+            })
+            .unwrap_or(None)
     }
 
     /// Replays WAL entries written but not yet checkpointed before a crash,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -5,6 +5,7 @@ pub mod lexer;
 pub mod optimizer;
 pub mod parser;
 pub mod path_identifier;
+pub mod query_memory;
 pub mod row_buffer;
 pub mod schema;
 pub mod server;
@@ -33,6 +34,7 @@ use crate::engine::ast::{DDLStatement, DMLStatement, OtherStatement, SQLStatemen
 use crate::engine::encoder::schema_encoder::StorageEncoder;
 use crate::engine::index::manager::IndexManager;
 use crate::engine::optimizer::statistics::StatisticsManager;
+use crate::engine::query_memory::QueryMemoryTracker;
 use crate::engine::row_buffer::RowBufferPool;
 use crate::engine::schema::table::TableSchema;
 use crate::engine::types::ExecuteResult;
@@ -56,6 +58,9 @@ pub struct DBEngine {
     /// 디스크의 인덱스 파일을 메모리로 적재했는지 여부 (최초 사용 시 1회 적재)
     pub(crate) indices_loaded: Arc<tokio::sync::OnceCell<()>>,
     pub(crate) row_buffer_pool: Arc<Mutex<RowBufferPool>>,
+    /// 현재 실행 중인 쿼리의 메모리 예산 추적기 (#265).
+    /// `process_query`에서 DML 실행 시에만 설정되고, 실행 후 clear된다.
+    pub(crate) query_memory_tracker: Arc<RwLock<Option<Arc<QueryMemoryTracker>>>>,
 }
 
 impl DBEngine {
@@ -72,6 +77,7 @@ impl DBEngine {
             statistics_manager: Arc::new(StatisticsManager::new()),
             indices_loaded: Arc::new(tokio::sync::OnceCell::new()),
             row_buffer_pool: Arc::new(Mutex::new(RowBufferPool::default())),
+            query_memory_tracker: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -83,6 +89,13 @@ impl DBEngine {
         _connection_id: String,
     ) -> errors::Result<ExecuteResult> {
         log::debug!("AST echo: {:?}", statement);
+
+        // 쿼리 수준 메모리 예산 설정 (#265). DML(SELECT/UPDATE/DELETE)만 적용합니다.
+        // INSERT는 행을 추가할 뿐 대량 메모리를 모으지 않고, DDL은 스키마 변경이라
+        // 예산 대상이 아닙니다. CREATE INDEX의 backfill은 full_scan을 사용하므로
+        // 예산 적용 대상이 맞지만, DDL 경로에 넣으면 인덱스 생성이 실패할 수 있어
+        // 일단 DML만 적용합니다 (추후 필요 시 확장).
+        let memory_tracker = self.begin_query_memory_tracking(&statement).await;
 
         // 쿼리 실행
         let result = match statement {
@@ -130,9 +143,52 @@ impl DBEngine {
         };
 
         match result {
-            Ok(result) => Ok(result),
-            Err(error) => Err(ExecuteError::wrap(error.to_string())),
+            Ok(result) => {
+                self.end_query_memory_tracking(memory_tracker).await;
+                Ok(result)
+            }
+            Err(error) => {
+                self.end_query_memory_tracking(memory_tracker).await;
+                Err(ExecuteError::wrap(error.to_string()))
+            }
         }
+    }
+
+    /// 쿼리 메모리 예산 추적을 시작합니다 (#265).
+    /// DML(SELECT/UPDATE/DELETE)에만 예산을 설정하고, 나머지는 예산 없이
+    /// 실행합니다.
+    async fn begin_query_memory_tracking(
+        &self,
+        statement: &SQLStatement,
+    ) -> Option<Arc<QueryMemoryTracker>> {
+        let limit_bytes = self.config.max_query_memory_bytes;
+
+        let is_dml_read_heavy = matches!(
+            statement,
+            SQLStatement::DML(DMLStatement::SelectQuery(_))
+                | SQLStatement::DML(DMLStatement::UpdateQuery(_))
+                | SQLStatement::DML(DMLStatement::DeleteQuery(_))
+        );
+
+        if !is_dml_read_heavy || limit_bytes == 0 {
+            return None;
+        }
+
+        let tracker = Arc::new(QueryMemoryTracker::new(limit_bytes));
+        *self.query_memory_tracker.write().await = Some(tracker.clone());
+        Some(tracker)
+    }
+
+    /// 쿼리 메모리 예산 추적을 종료합니다 (#265).
+    /// 예산 초과로 이미 에러가 발생했던 간 무엄 사용하지 않으므로 항상 클리어합니다.
+    async fn end_query_memory_tracking(&self, _tracker: Option<Arc<QueryMemoryTracker>>) {
+        *self.query_memory_tracker.write().await = None;
+    }
+
+    /// 현재 실행 중인 쿼리의 메모리 추적기를 반환합니다.
+    /// 예산 비활성 상태이면 `None`을 반환합니다.
+    pub(crate) async fn query_memory(&self) -> Option<Arc<QueryMemoryTracker>> {
+        self.query_memory_tracker.read().await.clone()
     }
 
     /// Replays WAL entries written but not yet checkpointed before a crash,

--- a/src/engine/query_memory.rs
+++ b/src/engine/query_memory.rs
@@ -16,10 +16,35 @@
 //! 것이 목적입니다. (PostgreSQL도 work_mem을 "정확한 메모리 측정"이 아닌
 //! "작업 단위별 예산"으로 사용합니다.)
 
+use std::ptr::NonNull;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::errors;
 use crate::errors::execute_error::ExecuteError;
+
+/// `tokio::task_local!`에 저장하기 위한 Copy 핸들 (#265).
+///
+/// `tokio::task_local!`은 `Copy` 타입만 지원하므로
+/// `Option<Arc<QueryMemoryTracker>>`를 직접 저장할 수 없습니다.
+/// `NonNull`은 `Copy`이므로 이를 감싸서 저장합니다.
+///
+/// # 안전성
+/// 수명은 task-local scope로 제한됩니다. scope 내부에서
+/// `Arc` 원본(`_keep_alive`)을 보유하므로 핸들이 가리키는 값은
+/// scope 동안 항상 살아 있습니다. `query_memory()`에서
+/// `Arc::increment_strong_count` 후 `Arc::from_raw`로 재구성하므로
+/// refcount 관리가 정확합니다.
+#[derive(Copy, Clone)]
+pub(crate) struct QueryMemoryTrackerRef(pub(crate) Option<NonNull<QueryMemoryTracker>>);
+
+// # Safety
+// - `QueryMemoryTracker`는 `AtomicU64` + `u64`만 가지므로 `Send + Sync`입니다.
+// - 포인터가 가리키는 값은 task-local scope 동안 `_keep_alive`(Arc)가
+//   refcount를 보유하므로, task가 다른 스레드로 이동해도 유효합니다.
+// - task-local은 task 내에서만 접근하므로 포인터가 다른 스레드에서
+//   역참조되는 일은 없습니다 (`query_memory()`는 같은 task에서만 호출).
+unsafe impl Send for QueryMemoryTrackerRef {}
+unsafe impl Sync for QueryMemoryTrackerRef {}
 
 /// 쿼리 메모리 예산 추적기.
 ///

--- a/src/engine/query_memory.rs
+++ b/src/engine/query_memory.rs
@@ -1,0 +1,155 @@
+//! 쿼리 수준 메모리 예산 추적기 (#265).
+//!
+//! PostgreSQL의 `work_mem`/memory context에 대응하는 개념으로, 한 쿼리가
+//! 소비할 수 있는 메모리 상한을 넘어서면 **쿼리를 강제로 죽입니다** (에러 반환).
+//! 디스크 spill(정렬/해시를 임시 파일로 내리는 것)이 없는 rrdb에서는
+//! 예산 초과 시 에러를 반환하는 것이 OOM killer의 실용적 형태입니다.
+//!
+//! 정확한 바이트 계산은 불가능하므로(포인터 크기, Vec capacity, clone 중복),
+//! 여기서는 **근사 추정**을 사용합니다:
+//! - `TableDataFieldType::estimated_bytes()` — 값의 대략적 메모리 크기
+//! - 파일 로드 시 `file_size` — 세그먼트 파일이 메모리에 통째로 올라가는 크기
+//! - Vec append 시 예약된 capacity만큼 누적
+//!
+//! 이것은 하드 리미트가 아니라 **소프트 가드레일**입니다. 예산을 훨씬 넘는
+//! 쿼리를 조기에 거부해서 서버 프로세스가 OOM killer에 걸리기 전에 보호하는
+//! 것이 목적입니다. (PostgreSQL도 work_mem을 "정확한 메모리 측정"이 아닌
+//! "작업 단위별 예산"으로 사용합니다.)
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::errors;
+use crate::errors::execute_error::ExecuteError;
+
+/// 쿼리 메모리 예산 추적기.
+///
+/// 한 쿼리의 실행 동안 `reserve()`를 누적하고, 설정된 상한을 넘으면
+/// `MemoryLimitExceeded` 에러를 반환합니다.
+#[derive(Debug)]
+pub struct QueryMemoryTracker {
+    /// 현재까지 누적된 추정 메모리 (bytes).
+    used: AtomicU64,
+    /// 허용 상한 (bytes). `0`이면 비활성(추적만 하고 거부 안 함).
+    limit_bytes: u64,
+}
+
+impl QueryMemoryTracker {
+    /// 새 추적기를 생성합니다.
+    pub fn new(limit_bytes: u64) -> Self {
+        Self {
+            used: AtomicU64::new(0),
+            limit_bytes,
+        }
+    }
+
+    /// 현재 누적 추정 메모리를 반환합니다.
+    pub fn used_bytes(&self) -> u64 {
+        self.used.load(Ordering::Relaxed)
+    }
+
+    /// 설정된 상한을 반환합니다.
+    pub fn limit_bytes(&self) -> u64 {
+        self.limit_bytes
+    }
+
+    /// 예산이 비활성(limit == 0)인지 여부.
+    pub fn is_enabled(&self) -> bool {
+        self.limit_bytes != 0
+    }
+
+    /// `amount` 바이트만큼 예산을 소비합니다. 상한을 초과하면 에러를 반환합니다.
+    ///
+    /// `is_enabled()`가 false면(limit == 0) 누적만 하고 절대 거부하지 않습니다.
+    /// 누적 자체는 항상 하므로, `used_bytes()`는 비활성 상태에서도 관찰 가능합니다.
+    pub fn reserve(&self, amount: u64) -> errors::Result<()> {
+        if amount == 0 {
+            return Ok(());
+        }
+
+        let new_used = self.used.fetch_add(amount, Ordering::Relaxed) + amount;
+
+        if self.is_enabled() && new_used > self.limit_bytes {
+            Err(ExecuteError::wrap(format!(
+                "query memory limit exceeded: used ~{} bytes, limit {} bytes",
+                new_used, self.limit_bytes
+            )))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_tracker_never_rejects() {
+        let tracker = QueryMemoryTracker::new(0);
+        // limit 0 = 비활성. 거대한 reserve도 에러 없이 통과.
+        for _ in 0..1000 {
+            assert!(tracker.reserve(1024 * 1024).is_ok());
+        }
+        assert_eq!(tracker.used_bytes(), 1000 * 1024 * 1024);
+    }
+
+    #[test]
+    fn reserve_accumulates_used_bytes() {
+        let tracker = QueryMemoryTracker::new(100);
+        tracker.reserve(30).unwrap();
+        tracker.reserve(20).unwrap();
+        assert_eq!(tracker.used_bytes(), 50);
+    }
+
+    #[test]
+    fn reserve_zero_is_noop() {
+        let tracker = QueryMemoryTracker::new(100);
+        tracker.reserve(0).unwrap();
+        assert_eq!(tracker.used_bytes(), 0);
+    }
+
+    #[test]
+    fn exceeding_limit_rejects_and_keeps_accumulated() {
+        let tracker = QueryMemoryTracker::new(100);
+        tracker.reserve(60).unwrap();
+        let error = tracker.reserve(50).unwrap_err();
+
+        let message = error.to_string();
+        assert!(
+            message.contains("query memory limit exceeded"),
+            "unexpected error: {message}"
+        );
+
+        // 실패한 reserve도 누적값은 유지됩니다 (이미 원자적으로 더해졌으므로).
+        // 이후 성공 reserve도 누적 기준은 계속 커집니다.
+        assert_eq!(tracker.used_bytes(), 110);
+    }
+
+    #[test]
+    fn exact_limit_is_allowed() {
+        let tracker = QueryMemoryTracker::new(100);
+        tracker.reserve(100).unwrap();
+        assert_eq!(tracker.used_bytes(), 100);
+    }
+
+    #[test]
+    fn boundary_over_limit_rejects() {
+        let tracker = QueryMemoryTracker::new(100);
+        tracker.reserve(100).unwrap();
+        assert!(tracker.reserve(1).is_err());
+    }
+
+    #[test]
+    fn enabled_tracker_reports_limit() {
+        let tracker = QueryMemoryTracker::new(42);
+        assert!(tracker.is_enabled());
+        assert_eq!(tracker.limit_bytes(), 42);
+    }
+
+    #[test]
+    fn disabled_tracker_reports_not_enabled() {
+        let tracker = QueryMemoryTracker::new(0);
+        assert!(!tracker.is_enabled());
+        assert_eq!(tracker.limit_bytes(), 0);
+    }
+}

--- a/src/engine/schema/row.rs
+++ b/src/engine/schema/row.rs
@@ -27,6 +27,22 @@ impl TableDataFieldType {
         }
     }
 
+    /// 값이 힙에 점유하는 대략적인 바이트 수 (#265).
+    ///
+    /// enum tag + 인라인 값만 세는 것이 아니라, `String`/`Vec`의 힙 버퍼까지
+    /// 포함합니다. `TableDataField`/`TableDataRow`의 스택 구조체 오버헤드는
+    /// 상수(`ESTIMATED_FIELD_OVERHEAD`)로 합산합니다.
+    pub fn estimated_bytes(&self) -> u64 {
+        match self {
+            TableDataFieldType::Integer(_) => 8,
+            TableDataFieldType::Float(_) => 8,
+            TableDataFieldType::Boolean(_) => 1,
+            TableDataFieldType::Null => 0,
+            TableDataFieldType::String(value) => value.len() as u64,
+            TableDataFieldType::Array(values) => values.iter().map(|e| e.estimated_bytes()).sum(),
+        }
+    }
+
     pub fn to_array(self) -> Self {
         Self::Array(vec![self])
     }
@@ -89,9 +105,29 @@ impl TableDataField {
             _ => {}
         }
     }
+
+    /// 필드 하나가 힙에 점유하는 대략적인 바이트 수 (#265).
+    /// `column_name` 문자열과 값의 estimated_bytes를 합산합니다.
+    pub fn estimated_bytes(&self) -> u64 {
+        self.column_name.len() as u64 + self.data.estimated_bytes()
+    }
 }
+
+/// 행 하나의 힙 메모리를 추정할 때 사용하는 상수 오버헤드 (#265).
+/// `TableDataRow { fields: Vec<TableDataField> }`의 Vec 버퍼 및 field 구조체들의
+/// 스택 공간을 대략으로 반영합니다.
+pub const ESTIMATED_FIELD_OVERHEAD: u64 = 32;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct TableDataRow {
     pub fields: Vec<TableDataField>,
+}
+
+impl TableDataRow {
+    /// 행 하나가 힙에 점유하는 대략적인 바이트 수 (#265).
+    /// 각 필드의 estimated_bytes + 필드 개수 만큼 오버헤드를 합산합니다.
+    pub fn estimated_bytes(&self) -> u64 {
+        self.fields.iter().map(|f| f.estimated_bytes()).sum::<u64>()
+            + self.fields.len() as u64 * ESTIMATED_FIELD_OVERHEAD
+    }
 }

--- a/src/engine/wal/manager/mod.rs
+++ b/src/engine/wal/manager/mod.rs
@@ -320,6 +320,7 @@ mod tests {
             wal_directory: wal_dir_path.to_str().unwrap().to_string(),
             wal_segment_size: 1024,
             wal_extension: "waltest".to_string(),
+            max_query_memory_bytes: 0,
         }
     }
 


### PR DESCRIPTION
## Summary

Implements a **query-level memory limit (OOM killer)** for RRDB, addressing issue #265.

When a heavy query would exhaust process memory, the server currently risks being killed by the OS OOM killer, taking down all connections. This PR adds a per-query memory budget that **rejects (kills) the query with a clean error before it can allocate beyond the limit** — mirroring PostgreSQL's `work_mem` approach without disk spill.

## Changes

### 1. New config: `max_query_memory_bytes` (`LaunchConfig`)
- Default: **128 MB**
- `0` disables the OOM killer (existing behavior preserved)
- `#[serde(default)]` so existing `rrdb.config` files without the field still load

### 2. New module: `QueryMemoryTracker` (`src/engine/query_memory.rs`)
- `reserve(bytes)` accumulates an atomic counter; exceeding the limit returns a `ExecuteError`
- Always accumulates (observable via `used_bytes()`), rejects only when enabled

### 3. DBEngine integration (`src/engine/mod.rs`)
- `process_query` installs a tracker for **SELECT / UPDATE / DELETE** (read-heavy DML)
- Tracker is stored in a **task-local** (`tokio::task_local!` via a `NonNull` Copy handle) so concurrent queries on different connections cannot overwrite or clear each other's budget (CodeRabbit: shared-slot race fix)
- Internal helper `query_memory()` reads the task-local tracker; returns `None` when no tracker is installed

### 4. Memory accounting at the allocation points
- `read_segment_rows()`:
  - reserves the **file size** before `tokio::fs::read` loads it whole
  - reserves a **per-frame decode budget** before `StorageEncoder::decode` (CodeRabbit: decoded rows can exceed raw frame size)
  - uses `self.file_system.metadata()` instead of direct `tokio::fs::metadata` (CodeRabbit: testability via injected FS)
- `full_scan()` / `full_scan_limited()`: reserves the total estimated size of loaded rows
- `index_scan()`: reserves each row as it is appended to the result

### 5. Size estimation (`src/engine/schema/row.rs`)
- `TableDataFieldType::estimated_bytes()`, `TableDataField::estimated_bytes()`, `TableDataRow::estimated_bytes()`
- Counts heap buffers (String/Vec), plus a constant per-field overhead

### 6. `FileSystem` trait (`src/common/fs.rs`)
- Added async `metadata(&self, path) -> io::Result<u64>` for file-size queries (CodeRabbit)

## Tests

| Test | Verifies |
|---|---|
| `select_over_memory_limit_is_killed` | 1KB budget + 4KB row → query rejected with `query memory limit exceeded` |
| `select_with_disabled_memory_limit_succeeds` | `max_query_memory_bytes = 0` → query succeeds |
| `select_within_memory_limit_succeeds` | 1MB budget + small data → query succeeds |
| `concurrent_queries_do_not_interfere_with_each_others_budget` | Two simultaneous SELECTs (one over budget, one under) don't interfere (CodeRabbit regression test) |
| query_memory unit tests | accumulation, exact-limit boundary, disable semantics |

## Verification

```bash
cargo build       # ok
cargo test        # 389 passed (lib) + 5 passed (bin), 0 failed
cargo clippy --all-targets  # no new warnings
```

## Known limitations (follow-up)

- **GROUP BY / ORDER BY** build additional in-memory structures (`grouped_map`, `order_by_rows`) not yet counted against the budget — a future PR should reserve these too.
- **DDL (CREATE INDEX backfill)** is excluded from the budget intentionally, so index creation on huge tables can still exhaust memory. Tracking it would require deciding whether index creation should fail under pressure (see #264 item 3).
- The budget is an **estimate** (soft guardrail), not exact byte accounting — Rust `Vec`/`String` capacity and allocator overhead are not modeled precisely.
- Tracking is per-query, not per-connection or global; concurrent heavy queries can still collectively exceed process memory (see #264 item 2 circuit breaker).

## Related

- Closes #265
- Part of #264 (item 1)
