### PR TITLE
[#268] fix: WAL torn write 시 recovery가 실패하던 문제 수정

### DIFF
--- a/src/common/fs.rs
+++ b/src/common/fs.rs
@@ -14,6 +14,9 @@ pub trait FileSystem {
     async fn write_file(&self, path: &str, content: &[u8]) -> io::Result<()>;
     async fn read_dir(&self, path: &str) -> io::Result<Vec<FileSystemEntry>>;
     async fn read(&self, path: &Path) -> io::Result<Vec<u8>>;
+    /// 파일을 지정한 크기로 자릅니다. (#268)
+    /// WAL 복구 시 newest segment의 torn tail을 제거하는 데 사용합니다.
+    async fn truncate(&self, path: &Path, size: u64) -> io::Result<()>;
     /// 파일의 크기(bytes)를 반환합니다. (#265)
     /// `read_segment_rows`가 파일 전체를 메모리로 읽기 전에 예산을 확보하는 데 사용합니다.
     async fn metadata(&self, path: &Path) -> io::Result<u64>;
@@ -47,6 +50,11 @@ impl FileSystem for RealFileSystem {
 
     async fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
         tokio::fs::read(path).await
+    }
+
+    async fn truncate(&self, path: &Path, size: u64) -> io::Result<()> {
+        let file = tokio::fs::OpenOptions::new().write(true).open(path).await?;
+        file.set_len(size).await
     }
 
     async fn metadata(&self, path: &Path) -> io::Result<u64> {

--- a/src/engine/wal/manager/builder.rs
+++ b/src/engine/wal/manager/builder.rs
@@ -93,10 +93,26 @@ impl<'a> WALBuilder<'a> {
             let content = self.file_system.read(&path).await.map_err(|e| {
                 WALError::wrap(format!("failed to read log file {:?}: {}", path, e))
             })?;
-            let used_bytes = used_wal_bytes(&content).map_err(|e| {
+            let (used_bytes, torn) = used_wal_bytes(&content).map_err(|e| {
                 WALError::wrap(format!("failed to inspect log file {:?}: {}", path, e))
             })?;
-            let entries: Vec<WALEntry> = decoder.decode(&content).map_err(|e| {
+
+            if let Some(reason) = torn {
+                if sequence != max_sequence {
+                    return Err(WALError::wrap(format!(
+                        "corrupt intermediate segment {:?}: {}",
+                        path, reason
+                    )));
+                }
+                // #268: a torn write (partial header or truncated frame body)
+                // in the newest segment is an uncommitted record, not file
+                // corruption. Discard it and recover only the complete frames
+                // before it, following the PostgreSQL/SQLite recovery
+                // convention.
+                log::warn!("discarding torn WAL tail in {:?}: {}", path, reason);
+            }
+
+            let entries: Vec<WALEntry> = decoder.decode(&content[..used_bytes]).map_err(|e| {
                 WALError::wrap(format!("failed to decode log file {:?}: {}", path, e))
             })?;
 
@@ -124,16 +140,25 @@ impl<'a> WALBuilder<'a> {
     }
 }
 
-fn used_wal_bytes(content: &[u8]) -> errors::Result<usize> {
+/// Walks the frames of a WAL segment and returns the byte offset of the last
+/// complete frame boundary, along with the reason the tail after it is torn
+/// (`None` when the segment ends on a clean frame boundary or zero padding).
+///
+/// #268: a torn write leaves a frame whose length header is valid but whose
+/// body never fully landed (or a header that was only partially written).
+/// That is an *uncommitted* record, not corruption, so the truncation is
+/// reported instead of being an error; the caller decides whether discarding
+/// the tail is acceptable (newest segment) or not (intermediate segment).
+fn used_wal_bytes(content: &[u8]) -> errors::Result<(usize, Option<String>)> {
     let mut offset = 0;
 
     while offset < content.len() {
         if content.len() - offset < size_of::<u32>() {
             if content[offset..].iter().all(|byte| *byte == 0) {
-                return Ok(offset);
+                return Ok((offset, None));
             }
 
-            return Err(WALError::wrap("truncated wal frame header".to_string()));
+            return Ok((offset, Some("truncated wal frame header".to_string())));
         }
 
         let frame_len = u32::from_le_bytes(
@@ -143,17 +168,20 @@ fn used_wal_bytes(content: &[u8]) -> errors::Result<usize> {
         ) as usize;
 
         if frame_len == 0 {
-            return Ok(offset);
+            return Ok((offset, None));
         }
 
         offset += size_of::<u32>();
 
         if content.len() - offset < frame_len {
-            return Err(WALError::wrap("truncated wal frame body".to_string()));
+            return Ok((
+                offset - size_of::<u32>(),
+                Some("truncated wal frame body".to_string()),
+            ));
         }
 
         offset += frame_len;
     }
 
-    Ok(offset)
+    Ok((offset, None))
 }

--- a/src/engine/wal/manager/builder.rs
+++ b/src/engine/wal/manager/builder.rs
@@ -110,6 +110,20 @@ impl<'a> WALBuilder<'a> {
                 // before it, following the PostgreSQL/SQLite recovery
                 // convention.
                 log::warn!("discarding torn WAL tail in {:?}: {}", path, reason);
+
+                // Truncate the torn tail on disk. Otherwise the stale bytes
+                // would survive a checkpoint and, once this segment rotates
+                // into an intermediate one, the next restart would treat
+                // them as intermediate corruption and fail to start.
+                self.file_system
+                    .truncate(&path, used_bytes as u64)
+                    .await
+                    .map_err(|e| {
+                        WALError::wrap(format!(
+                            "failed to truncate torn WAL tail in {:?}: {}",
+                            path, e
+                        ))
+                    })?;
             }
 
             let entries: Vec<WALEntry> = decoder.decode(&content[..used_bytes]).map_err(|e| {

--- a/src/engine/wal/manager/mod.rs
+++ b/src/engine/wal/manager/mod.rs
@@ -120,7 +120,19 @@ where
         frame[..size_of::<u32>()].copy_from_slice(&frame_len.to_le_bytes());
 
         self.rotate_if_needed(frame.len()).await?;
-        self.append_frame_to_mmap(&frame).await?;
+
+        // #268: write the body first and patch the length header last. The
+        // length then acts as a commit marker: if a crash interrupts the
+        // memcpy, the on-disk frame either has len == 0 (unwritten) or a
+        // truncated body under a valid len — both are discarded on recovery.
+        let header_offset = self.current_offset;
+        let header = &frame[..size_of::<u32>()];
+        // Reserve the header slot first (as zeros = "not committed"), then
+        // write the body, then patch the header last (see #268).
+        self.append_frame_to_mmap(header).await?;
+        let body = &frame[size_of::<u32>()..];
+        self.append_frame_to_mmap(body).await?;
+        self.patch_frame_header_at(header_offset, header).await?;
 
         self.unsynced_bytes += frame.len();
         if self.unsynced_bytes >= GROUP_COMMIT_THRESHOLD_BYTES {
@@ -174,6 +186,33 @@ where
         segment.mmap[segment.offset..end_offset].copy_from_slice(frame);
         segment.offset = end_offset;
         self.current_offset = end_offset;
+
+        Ok(())
+    }
+
+    /// Overwrites the length header of the frame just written, at the
+    /// absolute offset its slot occupies. Used by `write_entry` to patch the
+    /// 4-byte length header *after* the body (see #268).
+    async fn patch_frame_header_at(
+        &mut self,
+        header_offset: usize,
+        header: &[u8],
+    ) -> errors::Result<()> {
+        self.open_current_segment_if_needed().await?;
+
+        let segment = self
+            .current_segment
+            .as_mut()
+            .ok_or_else(|| WALError::wrap("wal segment is not open".to_string()))?;
+
+        // The slot was reserved by the body write; patching it must not move
+        // the segment offset.
+        debug_assert!(
+            header_offset + header.len() <= segment.offset,
+            "header slot must lie within the already-written frame"
+        );
+
+        segment.mmap[header_offset..header_offset + header.len()].copy_from_slice(header);
 
         Ok(())
     }
@@ -612,6 +651,89 @@ mod tests {
         );
     }
 
+    /// #268: a torn write (valid frame_len, truncated body) at the end of the
+    /// newest segment is an *uncommitted* record, not corruption — it must be
+    /// discarded and recovery must proceed with the complete entries before
+    /// it, instead of failing startup.
+    #[tokio::test]
+    async fn test_build_discards_torn_tail_of_newest_segment() {
+        let wal_dir = setup_test_wal_dir("torn_tail_newest_segment").await;
+        let config = get_test_config(&wal_dir);
+        write_wal_file(
+            &config,
+            1,
+            &vec![
+                create_entry(EntryType::Insert, Some("complete-1")),
+                create_entry(EntryType::Set, Some("complete-2")),
+            ],
+        )
+        .await;
+
+        // Simulate a torn write: the frame_len header says 8, but only 3
+        // body bytes landed before the crash.
+        let path = wal_dir.join(format!("00000001.{}", config.wal_extension));
+        let mut file = tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .await
+            .unwrap();
+        file.write_all(&8u32.to_le_bytes()).await.unwrap();
+        file.write_all(&[1, 2, 3]).await.unwrap();
+        drop(file);
+
+        let wal_manager = WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .expect("a torn tail must not prevent startup");
+
+        let payloads: Vec<_> = wal_manager
+            .pending_entries()
+            .iter()
+            .map(|entry| entry.data.clone().unwrap())
+            .collect();
+        assert_eq!(
+            payloads,
+            vec![b"complete-1".to_vec(), b"complete-2".to_vec()],
+            "the complete entries before the torn frame must be replayed, the torn one discarded"
+        );
+    }
+
+    /// #268: a partially written frame header (fewer than 4 non-zero bytes
+    /// landed) in the newest segment is likewise an uncommitted write and
+    /// must be discarded rather than failing startup.
+    #[tokio::test]
+    async fn test_build_discards_partial_frame_header_of_newest_segment() {
+        let wal_dir = setup_test_wal_dir("partial_header_newest_segment").await;
+        let config = get_test_config(&wal_dir);
+        write_wal_file(
+            &config,
+            1,
+            &vec![create_entry(EntryType::Insert, Some("complete"))],
+        )
+        .await;
+
+        let path = wal_dir.join(format!("00000001.{}", config.wal_extension));
+        let mut file = tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .await
+            .unwrap();
+        file.write_all(&[0xAB, 0xCD]).await.unwrap();
+        drop(file);
+
+        let wal_manager = WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .expect("a partial frame header must not prevent startup");
+
+        let payloads: Vec<_> = wal_manager
+            .pending_entries()
+            .iter()
+            .map(|entry| entry.data.clone().unwrap())
+            .collect();
+        assert_eq!(payloads, vec![b"complete".to_vec()]);
+    }
+
     #[tokio::test]
     async fn test_build_rejects_corrupt_intermediate_segment() {
         let wal_dir = setup_test_wal_dir("corrupt_intermediate_segment").await;
@@ -772,7 +894,10 @@ mod tests {
                 .build(BincodeDecoder::new(), BincodeEncoder::new())
                 .await
                 .unwrap_or_else(|error| {
-                    panic!("current behaviour: cut={} was expected to be accepted, got {}", cut, error)
+                    panic!(
+                        "current behaviour: cut={} was expected to be accepted, got {}",
+                        cut, error
+                    )
                 });
             assert_eq!(
                 reopened.pending_entries().len(),

--- a/src/engine/wal/manager/mod.rs
+++ b/src/engine/wal/manager/mod.rs
@@ -126,12 +126,13 @@ where
         // memcpy, the on-disk frame either has len == 0 (unwritten) or a
         // truncated body under a valid len — both are discarded on recovery.
         let header_offset = self.current_offset;
-        let header = &frame[..size_of::<u32>()];
-        // Reserve the header slot first (as zeros = "not committed"), then
-        // write the body, then patch the header last (see #268).
-        self.append_frame_to_mmap(header).await?;
+        // Reserve the header slot as zeros first: an unwritten slot can never
+        // be mistaken for a committed frame. Then write the body, and patch
+        // the real length header last (see #268).
+        self.append_frame_to_mmap(&[0u8; size_of::<u32>()]).await?;
         let body = &frame[size_of::<u32>()..];
         self.append_frame_to_mmap(body).await?;
+        let header = &frame[..size_of::<u32>()];
         self.patch_frame_header_at(header_offset, header).await?;
 
         self.unsynced_bytes += frame.len();
@@ -732,6 +733,47 @@ mod tests {
             .map(|entry| entry.data.clone().unwrap())
             .collect();
         assert_eq!(payloads, vec![b"complete".to_vec()]);
+    }
+
+    /// #268: after discarding a torn tail the file itself must be truncated,
+    /// so the segment stays clean even after it later becomes an intermediate
+    /// segment (rotation) — otherwise the next restart would fail.
+    #[tokio::test]
+    async fn test_build_truncates_torn_tail_from_disk() {
+        let wal_dir = setup_test_wal_dir("truncate_torn_tail").await;
+        let config = get_test_config(&wal_dir);
+        write_wal_file(
+            &config,
+            1,
+            &vec![create_entry(EntryType::Insert, Some("complete"))],
+        )
+        .await;
+
+        let path = wal_dir.join(format!("00000001.{}", config.wal_extension));
+        let intact_len = tokio::fs::metadata(&path).await.unwrap().len();
+        {
+            let mut file = tokio::fs::OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .await
+                .unwrap();
+            file.write_all(&8u32.to_le_bytes()).await.unwrap();
+            file.write_all(&[1, 2, 3]).await.unwrap();
+        }
+        assert!(tokio::fs::metadata(&path).await.unwrap().len() > intact_len);
+
+        let wal_manager = WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .expect("a torn tail must not prevent startup");
+        assert_eq!(wal_manager.pending_entries().len(), 1);
+
+        // The torn bytes must be gone from the file itself.
+        assert_eq!(
+            tokio::fs::metadata(&path).await.unwrap().len(),
+            intact_len,
+            "the torn tail must be truncated from disk, not just ignored"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

WAL segment 끝에 **torn write**(frame_len은 유효하지만 body가 잘린 frame, 또는 부분적으로만 기록된 header)가 남아 있으면 재시작 시 recovery가 실패해 서버가 기동되지 않던 문제를 수정합니다. (#268)

torn frame은 파일 손상이 아니라 **아직 커밋되지 않은 기록**이므로, PostgreSQL/SQLite의 복구 관례에 따라 마지막 완전한 frame까지만 인정하고 그 이후는 버립니다.

## Approach

이슈에서 제안된 (a) + (b)를 모두 적용했습니다.

### (a) recovery 측 (`builder.rs`)

- `used_wal_bytes`가 truncated frame header/body를 만나면 에러 대신 `(마지막 유효 frame 경계, torn 이유)`를 반환하도록 변경
- **newest 세그먼트**: torn tail을 uncommitted 기록으로 간주해 `log::warn!`을 남기고 그 경계까지만 decode하여 복구 계속
- **중간 세그먼트**: 기존 동작 유지 — corrupt intermediate segment는 여전히 에러 (기존 `test_build_rejects_corrupt_intermediate_segment` 그대로 green)
- decode도 `content[..used_bytes]`로 유효 경계까지만 수행해, torn tail이 decoder 에러를 유발하지 않도록 함

### (b) write 측 (`manager.rs`)

- `write_entry`에서 header 슬롯을 먼저 0으로 예약 → body를 mmap에 기록 → `frame_len` 패치를 **마지막에** 수행
- 크래시가 memcpy 중간에 끼어들면 disk에는 `len == 0`(미기록) 또는 유효한 len 아래 잘린 body만 남고, 두 경우 모두 (a)의 recovery에서 discard됨
- `frame_len`이 사실상 commit marker로 동작하게 되어 write/recovery 양쪽이 견고해짐

## Tests

- `test_build_discards_torn_tail_of_newest_segment`: frame_len 유효 + body 잘림 상태를 인위적으로 구성 → 기동 성공, 완전한 entry만 replay, torn entry는 버려짐 (sabotage run으로 fix 없이는 실패하는 것 확인)
- `test_build_discards_partial_frame_header_of_newest_segment`: 부분 header(4바이트 미만)도 동일하게 discard
- 기존 테스트 전체(`cargo test --lib` 387개) green — zero-padding tail 허용, corrupt intermediate segment 거부, #251/#236 계열 replay 테스트 포함
- `cargo clippy` baseline 대비 경고 증가 없음, `cargo fmt` 대상 파일 clean

## Risk

- write 경로의 memcpy가 2회(header 예약 + body) + 1회 패치로 늘어나지만, 같은 mmap 영역 내 연속 슬롯 기록이라 비용은 무시 가능
- 중간 세그먼트 strict 거부 정책은 유지되므로, 실제 손상(중간 위치 corruption)은 여전히 기동 실패로 명확히 드러남

## Related

- Closes #268
- #192 (crash recovery epic) 하위 항목

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 쓰기 중 중단되어 불완전해진 최신 로그 데이터를 자동으로 감지하고 폐기합니다.
  * 손상된 로그 꼬리 부분이 있어도 애플리케이션이 정상적으로 시작됩니다.
  * 완전히 기록된 데이터만 복구하므로 중단 시점의 미완료 레코드가 잘못 반영되지 않습니다.
  * 최신 세그먼트가 아닌 위치에서 로그가 손상된 경우에는 오류로 처리해 데이터 무결성을 보호합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->