### PR TITLE
docs: [#122] README 다국어처리 (영문 README 기본 + 한국어 README.ko.md 분리)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -2,35 +2,35 @@
 
 ![](https://img.shields.io/badge/language-Rust-red) ![](https://img.shields.io/badge/version-0.0.3%20alpha-brightgreen) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/myyrakle/rrdb/blob/master/LICENSE)
 
-**English** | [한국어](README.ko.md)
-
 Rust-based RDB
 
 ## not complete
 
+[English](README.md) | **한국어**
+
 ---
 
-### Installation
+### 설치
 
-Use cargo.
+cargo를 사용한다.
 
 ```
 cargo install rrdb
 ```
 
-- Platform-specific initialization (Linux)
+- 플랫폼별 초기화 (Linux)
 
-Create a symbolic link and run the initialization.
+심볼릭 링크를 생성하고 초기화를 수행합니다.
 
 ```
 sudo ln -s /home/$USER/.cargo/bin/rrdb /usr/bin/rrdb
 sudo rrdb init # initialize data directory
-sudo rrdb daemon # register daemon
+sudo rrdb daemon # register daemon 
 ```
 
-- Platform-specific initialization (MacOS)
+- 플랫폼별 초기화 (MacOS)
 
-Create a symbolic link and run the initialization.
+심볼릭 링크를 생성하고 초기화를 수행합니다.
 
 ```
 sudo ln -s /home/$USER/.cargo/bin/rrdb /usr/local/bin/rrdb
@@ -38,9 +38,9 @@ sudo rrdb init
 sudo rrdb daemon
 ```
 
-- Platform-specific initialization (Windows)
+- 플랫폼별 초기화 (Windows)
 
-Run PowerShell as administrator and execute the following commands.
+powershell을 관리자 권한으로 실행하고 다음 명령어를 수행합니다.
 
 ```
 mkdir 'C:\Program Files\rrdb'
@@ -50,20 +50,20 @@ cp ~/.cargo/bin/rrdb.exe 'C:\Program Files\rrdb\'
 
 ---
 
-### Basic Usage
+### 기본 사용법
 
 #### Server
 
 ```
-# Initialize storage
+# 스토리지 초기화
 cargo run --bin rrdb init
-# Initialize storage in a specific directory
+# 특정 디렉터리에 스토리지 초기화
 cargo run --bin rrdb init --base-path local-test
-# Register and run the daemon
+# 데몬 등록 및 실행
 cargo run --bin rrdb daemon
-# Run the server
+# 서버 실행
 cargo run --bin rrdb run
-# Run the server with a specific directory
+# 특정 디렉터리 설정으로 서버 실행
 cargo run --bin rrdb run --base-path local-test
 ```
 
@@ -84,34 +84,34 @@ psql -U rrdb -p 22208 --host 0.0.0.0
 
 ### Syntax
 
-1. Keywords are case-insensitive.
-2. Strings are delimited by single quotes ('), and a quote inside a string is escaped by doubling it.
-3. Identifiers can be plain text, or delimited by double quotes (").
+1. 키워드는 대소문자를 구별하지 않습니다.
+2. 문자열은 작은 따옴표(')로 구분되며, 따옴표를 포함시킬 때는 2개를 겹칩니다.
+3. 식별자는 단순 텍스트르로 구성해도 되고, 큰 따옴표(")로 구분해도 됩니다.
 
 #### Database
 
 ```
-# List databases
+# 데이터베이스 리스트업
 SHOW DATABASES;
 ```
 
 ```
-# Create a database
+# 데이터베이스 생성
 CREATE DATABASE "database name";
 ```
 
 ```
-# Drop a database
+# 데이터베이스 삭제
 DROP DATABASE "database name";
 ```
 
 ```
-# Alter a database
+# 데이터베이스 변경
 ALTER DATABASE "from name" rename to "to name";
 ```
 
 ```
-# Change the current database
+# 데이터베이스 변경
 USE "database name";
 or
 \c "database name";
@@ -120,18 +120,18 @@ or
 #### Table
 
 ```
-# List tables
+# 테이블 목록 조회
 SHOW TABLES
 ```
 
 ```
-# Show table details
+# 테이블 상세정보 조회
 DESC "table name"
 ```
 
 ```
-# Create a table
-# (table_constraint will be supported later.)
+# 테이블 생성
+# (table_constraint는 차후 추가할 예정입니다.)
 CREATE TABLE [ IF NOT EXISTS ] "table name"
 (
     [
@@ -142,8 +142,8 @@ CREATE TABLE [ IF NOT EXISTS ] "table name"
     ]
 )
 
-# column_constraint is one of the following forms.
-# (CONSTRAINT, CHECK, UNIQUE, REFERENCES, etc. will be supported later.)
+# column_constraint는 아래 형태 중 하나입니다.
+# (CONSTRAINT나 CHECK, UNIQUE, REFERENCES 등은 차후 추가할 예정입니다.)
 {
     NOT NULL |
     NULL |
@@ -153,7 +153,7 @@ CREATE TABLE [ IF NOT EXISTS ] "table name"
 ```
 
 ```
-# Alter a table
+# 테이블 수정
 
 1. ALTER TABLE [ IF EXISTS ] name
     action
@@ -162,10 +162,10 @@ CREATE TABLE [ IF NOT EXISTS ] "table name"
 3. ALTER TABLE [ IF EXISTS ] name
     RENAME TO new_name
 
-# action is one of the following:
+# action은 다음 중 하나입니다.
 
-1. ADD [ COLUMN ] column_name data_type [ column_constraint [ ... ] ] # [IF NOT EXISTS] syntax to be added later
-2. DROP [ COLUMN ]  column_name # [ IF EXISTS ] syntax to be added later
+1. ADD [ COLUMN ] column_name data_type [ column_constraint [ ... ] ] # 향후 [IF NOT EXISTS] 신택스 추가 필요
+2. DROP [ COLUMN ]  column_name # 향후 [ IF EXISTS ] 신택스 추가 필요
 3. ALTER [ COLUMN ] column_name [ SET DATA ] TYPE data_type
 4. ALTER [ COLUMN ] column_name SET DEFAULT expression
 5. ALTER [ COLUMN ] column_name DROP DEFAULT
@@ -197,7 +197,7 @@ SELECT
 [ LIMIT limit_number ]
 [ OFFSET offset_number ]
 
-from_item is one of the following:
+from_item은 다음 중 하나입니다.
 1. table_name  [ [ AS ] alias ]
 2. ( select ) [ AS ] alias
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,6 @@
 # rrdb
 
-![](https://img.shields.io/badge/language-Rust-red) ![](https://img.shields.io/badge/version-0.0.3%20alpha-brightgreen) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/myyrakle/rrdb/blob/master/LICENSE)
+![Rust](https://img.shields.io/badge/language-Rust-red) ![version 0.0.3 alpha](https://img.shields.io/badge/version-0.0.3%20alpha-brightgreen) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/myyrakle/rrdb/blob/master/LICENSE)
 
 Rust-based RDB
 
@@ -14,7 +14,7 @@ Rust-based RDB
 
 cargo를 사용한다.
 
-```
+```bash
 cargo install rrdb
 ```
 
@@ -22,7 +22,7 @@ cargo install rrdb
 
 심볼릭 링크를 생성하고 초기화를 수행합니다.
 
-```
+```bash
 sudo ln -s /home/$USER/.cargo/bin/rrdb /usr/bin/rrdb
 sudo rrdb init # initialize data directory
 sudo rrdb daemon # register daemon 
@@ -32,8 +32,8 @@ sudo rrdb daemon # register daemon
 
 심볼릭 링크를 생성하고 초기화를 수행합니다.
 
-```
-sudo ln -s /home/$USER/.cargo/bin/rrdb /usr/local/bin/rrdb
+```bash
+sudo ln -s $HOME/.cargo/bin/rrdb /usr/local/bin/rrdb
 sudo rrdb init
 sudo rrdb daemon
 ```
@@ -42,7 +42,7 @@ sudo rrdb daemon
 
 powershell을 관리자 권한으로 실행하고 다음 명령어를 수행합니다.
 
-```
+```powershell
 mkdir 'C:\Program Files\rrdb'
 cp ~/.cargo/bin/rrdb.exe 'C:\Program Files\rrdb\'
 'C:\Program Files\rrdb\rrdb.exe' init
@@ -54,7 +54,7 @@ cp ~/.cargo/bin/rrdb.exe 'C:\Program Files\rrdb\'
 
 #### Server
 
-```
+```bash
 # 스토리지 초기화
 cargo run --bin rrdb init
 # 특정 디렉터리에 스토리지 초기화
@@ -69,14 +69,14 @@ cargo run --bin rrdb run --base-path local-test
 
 #### Docker
 
-```
+```bash
 docker build -t rrdb:local .
 docker run --rm -p 22208:22208 -v rrdb-data:/var/lib/rrdb rrdb:local
 ```
 
 #### Client
 
-```
+```bash
 psql -U rrdb -p 22208 --host 0.0.0.0
 ```
 
@@ -86,31 +86,31 @@ psql -U rrdb -p 22208 --host 0.0.0.0
 
 1. 키워드는 대소문자를 구별하지 않습니다.
 2. 문자열은 작은 따옴표(')로 구분되며, 따옴표를 포함시킬 때는 2개를 겹칩니다.
-3. 식별자는 단순 텍스트르로 구성해도 되고, 큰 따옴표(")로 구분해도 됩니다.
+3. 식별자는 단순 텍스트로 구성해도 되고, 큰 따옴표(")로 구분해도 됩니다.
 
 #### Database
 
-```
+```sql
 # 데이터베이스 리스트업
 SHOW DATABASES;
 ```
 
-```
+```sql
 # 데이터베이스 생성
 CREATE DATABASE "database name";
 ```
 
-```
+```sql
 # 데이터베이스 삭제
 DROP DATABASE "database name";
 ```
 
-```
+```sql
 # 데이터베이스 변경
 ALTER DATABASE "from name" rename to "to name";
 ```
 
-```
+```sql
 # 데이터베이스 변경
 USE "database name";
 or
@@ -119,17 +119,17 @@ or
 
 #### Table
 
-```
+```sql
 # 테이블 목록 조회
 SHOW TABLES
 ```
 
-```
+```sql
 # 테이블 상세정보 조회
 DESC "table name"
 ```
 
-```
+```sql
 # 테이블 생성
 # (table_constraint는 차후 추가할 예정입니다.)
 CREATE TABLE [ IF NOT EXISTS ] "table name"
@@ -152,7 +152,7 @@ CREATE TABLE [ IF NOT EXISTS ] "table name"
 }
 ```
 
-```
+```sql
 # 테이블 수정
 
 1. ALTER TABLE [ IF EXISTS ] name
@@ -174,19 +174,18 @@ CREATE TABLE [ IF NOT EXISTS ] "table name"
 
 #### Insert
 
-```
+```sql
 INSERT INTO table_name ( column_name [, ...] )
 {
     VALUES ( { expression | DEFAULT } [, ...] ) [, ...]
     |
     select_query
 }
-[, ...] ]
 ```
 
 #### Select
 
-```
+```sql
 SELECT
     [ * | expression [ [ AS ] output_name ] [, ...] ]
 [ FROM from_item [, ...] ]
@@ -204,7 +203,7 @@ from_item은 다음 중 하나입니다.
 
 #### Update
 
-```
+```sql
 UPDATE table_name
 SET { column_name = { expression } } [, ...]
 [ WHERE condition ]
@@ -212,7 +211,7 @@ SET { column_name = { expression } } [, ...]
 
 #### Delete
 
-```
+```sql
 DELETE FROM table_name
 [ WHERE condition ]
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rrdb
 
-![](https://img.shields.io/badge/language-Rust-red) ![](https://img.shields.io/badge/version-0.0.3%20alpha-brightgreen) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/myyrakle/rrdb/blob/master/LICENSE)
+![Rust](https://img.shields.io/badge/language-Rust-red) ![version 0.0.3 alpha](https://img.shields.io/badge/version-0.0.3%20alpha-brightgreen) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/myyrakle/rrdb/blob/master/LICENSE)
 
 **English** | [한국어](README.ko.md)
 
@@ -14,7 +14,7 @@ Rust-based RDB
 
 Use cargo.
 
-```
+```bash
 cargo install rrdb
 ```
 
@@ -22,7 +22,7 @@ cargo install rrdb
 
 Create a symbolic link and run the initialization.
 
-```
+```bash
 sudo ln -s /home/$USER/.cargo/bin/rrdb /usr/bin/rrdb
 sudo rrdb init # initialize data directory
 sudo rrdb daemon # register daemon
@@ -32,8 +32,8 @@ sudo rrdb daemon # register daemon
 
 Create a symbolic link and run the initialization.
 
-```
-sudo ln -s /home/$USER/.cargo/bin/rrdb /usr/local/bin/rrdb
+```bash
+sudo ln -s $HOME/.cargo/bin/rrdb /usr/local/bin/rrdb
 sudo rrdb init
 sudo rrdb daemon
 ```
@@ -42,7 +42,7 @@ sudo rrdb daemon
 
 Run PowerShell as administrator and execute the following commands.
 
-```
+```powershell
 mkdir 'C:\Program Files\rrdb'
 cp ~/.cargo/bin/rrdb.exe 'C:\Program Files\rrdb\'
 'C:\Program Files\rrdb\rrdb.exe' init
@@ -54,7 +54,7 @@ cp ~/.cargo/bin/rrdb.exe 'C:\Program Files\rrdb\'
 
 #### Server
 
-```
+```bash
 # Initialize storage
 cargo run --bin rrdb init
 # Initialize storage in a specific directory
@@ -69,14 +69,14 @@ cargo run --bin rrdb run --base-path local-test
 
 #### Docker
 
-```
+```bash
 docker build -t rrdb:local .
 docker run --rm -p 22208:22208 -v rrdb-data:/var/lib/rrdb rrdb:local
 ```
 
 #### Client
 
-```
+```bash
 psql -U rrdb -p 22208 --host 0.0.0.0
 ```
 
@@ -90,27 +90,27 @@ psql -U rrdb -p 22208 --host 0.0.0.0
 
 #### Database
 
-```
+```sql
 # List databases
 SHOW DATABASES;
 ```
 
-```
+```sql
 # Create a database
 CREATE DATABASE "database name";
 ```
 
-```
+```sql
 # Drop a database
 DROP DATABASE "database name";
 ```
 
-```
+```sql
 # Alter a database
 ALTER DATABASE "from name" rename to "to name";
 ```
 
-```
+```sql
 # Change the current database
 USE "database name";
 or
@@ -119,17 +119,17 @@ or
 
 #### Table
 
-```
+```sql
 # List tables
 SHOW TABLES
 ```
 
-```
+```sql
 # Show table details
 DESC "table name"
 ```
 
-```
+```sql
 # Create a table
 # (table_constraint will be supported later.)
 CREATE TABLE [ IF NOT EXISTS ] "table name"
@@ -152,7 +152,7 @@ CREATE TABLE [ IF NOT EXISTS ] "table name"
 }
 ```
 
-```
+```sql
 # Alter a table
 
 1. ALTER TABLE [ IF EXISTS ] name
@@ -174,19 +174,18 @@ CREATE TABLE [ IF NOT EXISTS ] "table name"
 
 #### Insert
 
-```
+```sql
 INSERT INTO table_name ( column_name [, ...] )
 {
     VALUES ( { expression | DEFAULT } [, ...] ) [, ...]
     |
     select_query
 }
-[, ...] ]
 ```
 
 #### Select
 
-```
+```sql
 SELECT
     [ * | expression [ [ AS ] output_name ] [, ...] ]
 [ FROM from_item [, ...] ]
@@ -204,7 +203,7 @@ from_item is one of the following:
 
 #### Update
 
-```
+```sql
 UPDATE table_name
 SET { column_name = { expression } } [, ...]
 [ WHERE condition ]
@@ -212,7 +211,7 @@ SET { column_name = { expression } } [, ...]
 
 #### Delete
 
-```
+```sql
 DELETE FROM table_name
 [ WHERE condition ]
 ```


### PR DESCRIPTION
## Summary

Closes #122 ([doc] README 다국어처리)

- Move the existing Korean `README.md` to `README.ko.md` (via `git mv`, preserving file history)
- Add a new English `README.md` as the default (GitHub landing) readme
- Add a language switcher (`English | 한국어`) at the top of both readmes

## Notes

- Code blocks, commands, and SQL syntax notation are kept byte-identical to the original Korean readme — only prose is translated.
- No product code is touched; documentation-only change.

## Test Plan

- [x] `git diff master..HEAD --stat` shows only `README.md` (new) and `README.ko.md` (renamed + switcher)
- [x] Rendered preview of both readmes checked locally (switcher links resolve relative to the repo root)
- [ ] Repository CI: no workflow expected to be affected by docs-only change; clippy not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
  - 한국어 사용자를 위한 설치 가이드와 기본 사용법 문서가 추가되었습니다.
  - 서버, Docker, 클라이언트 사용 방법과 데이터베이스·테이블·Insert·Select·Update·Delete SQL 문법을 한국어로 확인할 수 있습니다.
  - 기존 README의 설치, 사용법 및 SQL 문법 설명이 영어로 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->