### PR TITLE
[#220] feat: auto-create composite primary-key indexes

### DIFF
--- a/src/common/fs.rs
+++ b/src/common/fs.rs
@@ -22,7 +22,12 @@ pub trait FileSystem {
     async fn metadata(&self, path: &Path) -> io::Result<u64>;
     /// 디렉토리와 그 내용 전체를 재귀적으로 삭제합니다. (#220)
     /// create_table 실패 시 생성 중인 테이블 디렉토리를 정리하는 데 사용합니다.
-    async fn remove_dir_all(&self, path: &Path) -> io::Result<()>;
+    ///
+    /// 트레이트 하위 호환을 위해 default 구현을 제공합니다 — 기존 외부
+    /// 구현체는 이 메서드 없이도 컴파일이 유지됩니다.
+    async fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+        tokio::fs::remove_dir_all(path).await
+    }
 }
 
 pub struct RealFileSystem;

--- a/src/common/fs.rs
+++ b/src/common/fs.rs
@@ -20,6 +20,9 @@ pub trait FileSystem {
     /// 파일의 크기(bytes)를 반환합니다. (#265)
     /// `read_segment_rows`가 파일 전체를 메모리로 읽기 전에 예산을 확보하는 데 사용합니다.
     async fn metadata(&self, path: &Path) -> io::Result<u64>;
+    /// 디렉토리와 그 내용 전체를 재귀적으로 삭제합니다. (#220)
+    /// create_table 실패 시 생성 중인 테이블 디렉토리를 정리하는 데 사용합니다.
+    async fn remove_dir_all(&self, path: &Path) -> io::Result<()>;
 }
 
 pub struct RealFileSystem;
@@ -60,5 +63,9 @@ impl FileSystem for RealFileSystem {
     async fn metadata(&self, path: &Path) -> io::Result<u64> {
         let metadata = tokio::fs::metadata(path).await?;
         Ok(metadata.len())
+    }
+
+    async fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+        tokio::fs::remove_dir_all(path).await
     }
 }

--- a/src/engine/actions/ddl/create_table.rs
+++ b/src/engine/actions/ddl/create_table.rs
@@ -62,7 +62,7 @@ impl DBEngine {
             return Err(ExecuteError::wrap(error.to_string()));
         }
 
-        // PRIMARY KEY 자동 인덱스 생성 (#217)
+        // PRIMARY KEY 자동 인덱스 생성 (#217, 복합 PK는 #220)
         let primary_key_columns: Vec<String> = if table_info.primary_key.is_empty() {
             table_info
                 .columns
@@ -74,18 +74,17 @@ impl DBEngine {
             table_info.primary_key.clone()
         };
 
-        // TODO(#217): 복합 PRIMARY KEY 인덱스는 미지원 (단일 컬럼만 자동 생성)
-        if primary_key_columns.len() == 1 {
+        if !primary_key_columns.is_empty() {
             if let Err(error) = self.ensure_indices_loaded().await {
                 let _ = tokio::fs::remove_dir_all(&table_path).await;
                 return Err(error);
             }
 
             let index_name = qualified_index_name(&database_name, &format!("{}_pkey", table_name));
-            let meta = IndexMeta::new(
+            let meta = IndexMeta::new_composite(
                 index_name,
                 table_info.table.clone(),
-                primary_key_columns[0].clone(),
+                primary_key_columns,
                 true,
             );
 

--- a/src/engine/actions/ddl/create_table.rs
+++ b/src/engine/actions/ddl/create_table.rs
@@ -76,7 +76,7 @@ impl DBEngine {
 
         if !primary_key_columns.is_empty() {
             if let Err(error) = self.ensure_indices_loaded().await {
-                let _ = tokio::fs::remove_dir_all(&table_path).await;
+                let _ = self.file_system.remove_dir_all(&table_path).await;
                 return Err(error);
             }
 
@@ -89,7 +89,7 @@ impl DBEngine {
             );
 
             if let Err(error) = self.index_manager.create_index(meta).await {
-                let _ = tokio::fs::remove_dir_all(&table_path).await;
+                let _ = self.file_system.remove_dir_all(&table_path).await;
                 return Err(error);
             }
         }

--- a/src/engine/actions/dml/delete.rs
+++ b/src/engine/actions/dml/delete.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use futures::future::join_all;
 
-use crate::engine::actions::index::row_index_key;
+use crate::engine::actions::index::{join_composite_key, row_index_keys};
 use crate::engine::ast::dml::delete::DeleteQuery;
 use crate::engine::ast::dml::plan::delete::delete_plan::DeletePlanItem;
 use crate::engine::ast::dml::plan::select::scan::ScanType;
@@ -44,7 +44,8 @@ impl DBEngine {
         // WAL-first: 쿼리를 실행/소비하기 전에 페이로드를 미리 직렬화합니다.
         let wal_payload = match &wal_manager {
             Some(_) => Some(
-                bincode::serialize(&query).map_err(|error| ExecuteError::wrap(error.to_string()))?,
+                bincode::serialize(&query)
+                    .map_err(|error| ExecuteError::wrap(error.to_string()))?,
             ),
             None => None,
         };
@@ -140,7 +141,9 @@ impl DBEngine {
             row_indexes.insert(location.row_index);
 
             for meta in &index_metas {
-                if let Some(key) = row_index_key(row, &meta.column_name) {
+                if let Some(key) = row_index_keys(row, &meta.columns)
+                    .map(|components| join_composite_key(&components))
+                {
                     index_removals.push((
                         meta.index_name.clone(),
                         key,

--- a/src/engine/actions/dml/insert.rs
+++ b/src/engine/actions/dml/insert.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::engine::actions::index::row_index_key;
+use crate::engine::actions::index::{join_composite_key, row_index_keys};
 use crate::engine::ast::dml::insert::{InsertData, InsertQuery};
 use crate::engine::ast::types::SQLExpression;
 use crate::engine::schema::row::{TableDataField, TableDataRow};
@@ -119,13 +119,12 @@ impl DBEngine {
                         // `query.columns`는 SQL에서 그대로 온 값이라 스키마에 없는
                         // 이름이 들어올 수 있습니다. 파서는 값 개수만 확인하고
                         // 컬럼의 존재 여부는 모릅니다 (#260).
-                        let column_config_info =
-                            columns_map.get(column_name).ok_or_else(|| {
-                                ExecuteError::wrap(format!(
-                                    "column '{}' does not exist on table '{}'",
-                                    column_name, table_name
-                                ))
-                            })?;
+                        let column_config_info = columns_map.get(column_name).ok_or_else(|| {
+                            ExecuteError::wrap(format!(
+                                "column '{}' does not exist on table '{}'",
+                                column_name, table_name
+                            ))
+                        })?;
 
                         let default_value = match &column_config_info.default {
                             Some(default) => default.to_owned(),
@@ -238,7 +237,9 @@ impl DBEngine {
                     let mut batch_keys = HashSet::new();
 
                     for row in &rows {
-                        if let Some(key) = row_index_key(row, &meta.column_name) {
+                        if let Some(key) = row_index_keys(row, &meta.columns)
+                            .map(|components| join_composite_key(&components))
+                        {
                             let duplicated = !self
                                 .index_manager
                                 .get(&meta.index_name, &key)
@@ -249,7 +250,7 @@ impl DBEngine {
                             if duplicated {
                                 return Err(ExecuteError::wrap(format!(
                                     "duplicate key value violates unique index on column '{}'",
-                                    meta.column_name
+                                    meta.column_name()
                                 )));
                             }
                         }
@@ -302,7 +303,9 @@ impl DBEngine {
                     let row_path = (start_index + offset).to_string();
 
                     for meta in &index_metas {
-                        if let Some(key) = row_index_key(row, &meta.column_name) {
+                        if let Some(key) = row_index_keys(row, &meta.columns)
+                            .map(|components| join_composite_key(&components))
+                        {
                             if let Err(error) = self
                                 .index_manager
                                 .insert(&meta.index_name, key.clone(), row_path.clone())

--- a/src/engine/actions/dml/update.rs
+++ b/src/engine/actions/dml/update.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use futures::future::join_all;
 
-use crate::engine::actions::index::row_index_key;
+use crate::engine::actions::index::{join_composite_key, row_index_keys};
 use crate::engine::ast::dml::plan::select::scan::ScanType;
 use crate::engine::ast::dml::plan::update::update_plan::UpdatePlanItem;
 use crate::engine::ast::dml::update::UpdateQuery;
@@ -42,7 +42,8 @@ impl DBEngine {
         // WAL-first: 쿼리를 실행/소비하기 전에 페이로드를 미리 직렬화합니다.
         let wal_payload = match &wal_manager {
             Some(_) => Some(
-                bincode::serialize(&query).map_err(|error| ExecuteError::wrap(error.to_string()))?,
+                bincode::serialize(&query)
+                    .map_err(|error| ExecuteError::wrap(error.to_string()))?,
             ),
             None => None,
         };
@@ -179,10 +180,12 @@ impl DBEngine {
                 }
             }
 
-            // 인덱스 컬럼 값 변경 감지 (#217)
+            // 인덱스 컬럼 값 변경 감지 (#217, 복합 키는 #220)
             for meta in &index_metas {
-                let old_key = row_index_key(&old_row, &meta.column_name);
-                let new_key = row_index_key(&row, &meta.column_name);
+                let old_key = row_index_keys(&old_row, &meta.columns)
+                    .map(|components| join_composite_key(&components));
+                let new_key = row_index_keys(&row, &meta.columns)
+                    .map(|components| join_composite_key(&components));
 
                 if old_key != new_key {
                     index_operations.push((
@@ -210,8 +213,7 @@ impl DBEngine {
             }
 
             // 인덱스 반영: 고유 제약 위반은 여기서 검출되며, 실패 시 적용분을 되돌립니다
-            for (i, (index_name, old_key, new_key, row_path)) in
-                index_operations.iter().enumerate()
+            for (i, (index_name, old_key, new_key, row_path)) in index_operations.iter().enumerate()
             {
                 if let Err(error) = self
                     .apply_index_operation(index_name, old_key, new_key, row_path)

--- a/src/engine/actions/index.rs
+++ b/src/engine/actions/index.rs
@@ -29,6 +29,31 @@ pub(crate) fn row_index_key(row: &TableDataRow, column_name: &str) -> Option<Str
         })
 }
 
+/// 행의 복수 컬럼 값을 복합 인덱스 키 컴포넌트들로 변환합니다 (#220).
+///
+/// 반환값은 `encode_composite_key_component`로 인코딩된 컴포넌트 벡터입니다.
+/// B-tree에 넣을 단일 키는 이 값들을 이어붙이면 됩니다. 각 컴포넌트가 길이
+/// 프리픽스를 가지므로 이어붙인 키는 단사(injective)이며, 컬럼 순서대로
+/// 정렬 순서가 결정됩니다.
+///
+/// 인덱스 대상 컬럼 중 하나라도 NULL이거나 행에 없으면 None — 단일 컬럼
+/// 인덱스와 마찬가지로 해당 행은 색인하지 않습니다 (PostgreSQL과 동일).
+pub(crate) fn row_index_keys(row: &TableDataRow, column_names: &[String]) -> Option<Vec<String>> {
+    let mut components = Vec::with_capacity(column_names.len());
+
+    for column_name in column_names {
+        let key = row_index_key(row, column_name)?;
+        components.push(super::super::index::encode_composite_key_component(&key));
+    }
+
+    Some(components)
+}
+
+/// 복합 인덱스 키 컴포넌트들을 단일 B-tree 키로 합칩니다 (#220).
+pub(crate) fn join_composite_key(components: &[String]) -> String {
+    components.concat()
+}
+
 impl DBEngine {
     /// 서버 기동 후 최초 인덱스 사용 시점에 디스크의 인덱스 파일을 메모리로 적재합니다.
     pub(crate) async fn ensure_indices_loaded(&self) -> errors::Result<()> {

--- a/src/engine/actions/index.rs
+++ b/src/engine/actions/index.rs
@@ -31,10 +31,13 @@ pub(crate) fn row_index_key(row: &TableDataRow, column_name: &str) -> Option<Str
 
 /// 행의 복수 컬럼 값을 복합 인덱스 키 컴포넌트들로 변환합니다 (#220).
 ///
-/// 반환값은 `encode_composite_key_component`로 인코딩된 컴포넌트 벡터입니다.
-/// B-tree에 넣을 단일 키는 이 값들을 이어붙이면 됩니다. 각 컴포넌트가 길이
-/// 프리픽스를 가지므로 이어붙인 키는 단사(injective)이며, 컬럼 순서대로
-/// 정렬 순서가 결정됩니다.
+/// 반환값은 각 컬럼의 `field_to_key` 원본 키 벡터입니다. B-tree에 넣을 단일
+/// 키는 `join_composite_key`로 조합합니다. 조합 시점에 각 컴포넌트가 길이
+/// 프리픽스로 인코딩되어 단사(injective)가 보장되고, 컬럼 순서대로 정렬
+/// 순서가 결정됩니다.
+///
+/// 단일 컬럼 인덱스는 조합 결과가 `field_to_key` 그대로이므로, 기존 단일
+/// 인덱스 키 공간(옵티마이저 eq_key/start_key/end_key와 동일)을 유지합니다.
 ///
 /// 인덱스 대상 컬럼 중 하나라도 NULL이거나 행에 없으면 None — 단일 컬럼
 /// 인덱스와 마찬가지로 해당 행은 색인하지 않습니다 (PostgreSQL과 동일).
@@ -42,16 +45,25 @@ pub(crate) fn row_index_keys(row: &TableDataRow, column_names: &[String]) -> Opt
     let mut components = Vec::with_capacity(column_names.len());
 
     for column_name in column_names {
-        let key = row_index_key(row, column_name)?;
-        components.push(super::super::index::encode_composite_key_component(&key));
+        components.push(row_index_key(row, column_name)?);
     }
 
     Some(components)
 }
 
 /// 복합 인덱스 키 컴포넌트들을 단일 B-tree 키로 합칩니다 (#220).
+///
+/// 각 컴포넌트를 길이 프리픽스로 인코딩 후 이어붙입니다. 단일 컴포넌트는
+/// 원본 키와 동일한 값이 되어 단일 인덱스의 키 공간과 호환됩니다.
 pub(crate) fn join_composite_key(components: &[String]) -> String {
-    components.concat()
+    if components.len() == 1 {
+        return components[0].clone();
+    }
+
+    components
+        .iter()
+        .map(|key| super::super::index::encode_composite_key_component(key))
+        .collect()
 }
 
 impl DBEngine {
@@ -145,7 +157,8 @@ impl DBEngine {
         let mut distinct_values = HashMap::new();
         for meta in self.table_index_metas(table_name).await {
             if let Ok(distinct) = self.index_manager.distinct_keys(&meta.index_name).await {
-                distinct_values.insert(meta.column_name.clone(), distinct);
+                // 복합 인덱스의 distinct는 첫 컬럼 기준 근사치로 기록 (#220)
+                distinct_values.insert(meta.column_name().to_owned(), distinct);
             }
         }
 

--- a/src/engine/actions/mod.rs
+++ b/src/engine/actions/mod.rs
@@ -5,3 +5,6 @@ pub mod index;
 
 #[cfg(test)]
 mod test_composite_index;
+
+#[cfg(test)]
+mod test_composite_pk_e2e;

--- a/src/engine/actions/mod.rs
+++ b/src/engine/actions/mod.rs
@@ -2,3 +2,6 @@ pub mod ddl;
 pub mod dml;
 pub mod etc;
 pub mod index;
+
+#[cfg(test)]
+mod test_composite_index;

--- a/src/engine/actions/test_composite_index.rs
+++ b/src/engine/actions/test_composite_index.rs
@@ -4,8 +4,8 @@
 //! - row_index_keys: 복수 컬럼 키 인코딩 (순서 보존, 단사)
 //! - NULL 포함 컬럼 → 인덱스 제외 (PostgreSQL과 동일)
 
-use crate::engine::ast::types::TableName;
 use crate::engine::actions::index::row_index_keys;
+use crate::engine::ast::types::TableName;
 use crate::engine::index::{IndexMeta, field_to_key};
 use crate::engine::schema::row::{TableDataField, TableDataFieldType, TableDataRow};
 
@@ -56,6 +56,8 @@ fn composite_key_is_concatenation_with_unambiguous_boundaries() {
 
 #[test]
 fn composite_key_encoding_is_injective_across_value_shapes() {
+    use crate::engine::actions::index::join_composite_key;
+
     // "S:ab" + "S:c" vs "S:a" + "S:bc" 가 같은 키가 되는 충돌을 막아야 함
     let row_a = TableDataRow {
         fields: vec![
@@ -74,13 +76,17 @@ fn composite_key_encoding_is_injective_across_value_shapes() {
     let keys_b = row_index_keys(&row_b, &["x".to_owned(), "y".to_owned()]).unwrap();
 
     assert_ne!(
-        keys_a.join("|"), keys_b.join("|"),
+        keys_a, keys_b,
         "different value splits must not collide: {:?} vs {:?}",
         keys_a, keys_b
     );
 
-    // 단일 문자열로 합쳐도 충돌 없어야 함 (B-tree 키로 조합 시)
-    assert_ne!(keys_a.concat(), keys_b.concat());
+    // 조합된 B-tree 키도 충돌 없어야 함 (길이 프리픽스 인코딩)
+    assert_ne!(
+        join_composite_key(&keys_a),
+        join_composite_key(&keys_b),
+        "joined composite keys must not collide"
+    );
 }
 
 #[test]
@@ -96,10 +102,10 @@ fn composite_key_preserves_column_order() {
     let ba = row_index_keys(&row, &["b".to_owned(), "a".to_owned()]).unwrap();
 
     assert_ne!(ab, ba, "column order must affect the key");
-    // 컴포넌트는 길이 프리픽스로 인코딩되지만, 원래 필드 키가 포함되어 있어야 함
-    assert!(ab[0].contains(&field_to_key(&TableDataFieldType::Integer(1))));
-    assert!(ab[1].contains(&field_to_key(&TableDataFieldType::Integer(2))));
-    assert!(ba[0].contains(&field_to_key(&TableDataFieldType::Integer(2))));
+    // 컴포넌트는 field_to_key 원본 키
+    assert_eq!(ab[0], field_to_key(&TableDataFieldType::Integer(1)));
+    assert_eq!(ab[1], field_to_key(&TableDataFieldType::Integer(2)));
+    assert_eq!(ba[0], field_to_key(&TableDataFieldType::Integer(2)));
 }
 
 #[test]
@@ -137,8 +143,7 @@ fn test_single_column_row_index_keys_matches_row_index_key() {
     let via_multi = row_index_keys(&row, &["id".to_owned()]).unwrap();
     let via_single = row_index_key(&row, "id").unwrap();
 
-    // 단일 컬럼 복합 키 컴포넌트에는 원래 필드 키가 그대로 포함되어야 함
-    // (길이 프리픽스는 조합 시 충돌 방지용)
-    assert_eq!(via_multi.len(), 1);
-    assert!(via_multi[0].contains(&via_single));
+    // 단일 컬럼 복합 키를 join하면 기존 row_index_key와 정확히 일치해야 함:
+    // 단일 인덱스 경로가 동일 키 공간(옵티마이저 eq_key 포함)을 유지하는 계약 (#220)
+    assert_eq!(join_composite_key(&via_multi), via_single);
 }

--- a/src/engine/actions/test_composite_index.rs
+++ b/src/engine/actions/test_composite_index.rs
@@ -1,0 +1,144 @@
+//! Task 2 RED 테스트: 복합 인덱스 키 지원 (#220)
+//!
+//! - IndexMeta.columns (복수 컬럼) 지원
+//! - row_index_keys: 복수 컬럼 키 인코딩 (순서 보존, 단사)
+//! - NULL 포함 컬럼 → 인덱스 제외 (PostgreSQL과 동일)
+
+use crate::engine::ast::types::TableName;
+use crate::engine::actions::index::row_index_keys;
+use crate::engine::index::{IndexMeta, field_to_key};
+use crate::engine::schema::row::{TableDataField, TableDataFieldType, TableDataRow};
+
+fn table() -> TableName {
+    TableName::new(Some("rrdb".to_owned()), "memberships".to_owned())
+}
+
+fn field(name: &str, data: TableDataFieldType) -> TableDataField {
+    TableDataField {
+        table_name: table(),
+        column_name: name.to_owned(),
+        data,
+    }
+}
+
+#[test]
+fn index_meta_supports_multiple_columns() {
+    let meta = IndexMeta::new_composite(
+        "rrdb.memberships_pkey".to_owned(),
+        table(),
+        vec!["user_id".to_owned(), "group_id".to_owned()],
+        true,
+    );
+
+    assert_eq!(meta.columns(), vec!["user_id", "group_id"]);
+    // 하위 호환: 단일 컬럼 인덱스는 column_name()로 첫 컬럼을 반환
+    let single = IndexMeta::new("rrdb.users_pkey".to_owned(), table(), "id".to_owned(), true);
+    assert_eq!(single.columns(), vec!["id"]);
+    assert_eq!(single.column_name(), "id");
+}
+
+#[test]
+fn composite_key_is_concatenation_with_unambiguous_boundaries() {
+    let row = TableDataRow {
+        fields: vec![
+            field("user_id", TableDataFieldType::Integer(1)),
+            field("group_id", TableDataFieldType::Integer(2)),
+        ],
+    };
+
+    let keys = row_index_keys(&row, &["user_id".to_owned(), "group_id".to_owned()]).unwrap();
+
+    // 두 키를 합친 값이 단사여야 함: 다른 컬럼 조합이 같은 키를 만들 수 없음
+    let combined = keys.join("");
+    assert!(combined.contains(&field_to_key(&TableDataFieldType::Integer(1))));
+    assert!(combined.contains(&field_to_key(&TableDataFieldType::Integer(2))));
+}
+
+#[test]
+fn composite_key_encoding_is_injective_across_value_shapes() {
+    // "S:ab" + "S:c" vs "S:a" + "S:bc" 가 같은 키가 되는 충돌을 막아야 함
+    let row_a = TableDataRow {
+        fields: vec![
+            field("x", TableDataFieldType::String("ab".to_owned())),
+            field("y", TableDataFieldType::String("c".to_owned())),
+        ],
+    };
+    let row_b = TableDataRow {
+        fields: vec![
+            field("x", TableDataFieldType::String("a".to_owned())),
+            field("y", TableDataFieldType::String("bc".to_owned())),
+        ],
+    };
+
+    let keys_a = row_index_keys(&row_a, &["x".to_owned(), "y".to_owned()]).unwrap();
+    let keys_b = row_index_keys(&row_b, &["x".to_owned(), "y".to_owned()]).unwrap();
+
+    assert_ne!(
+        keys_a.join("|"), keys_b.join("|"),
+        "different value splits must not collide: {:?} vs {:?}",
+        keys_a, keys_b
+    );
+
+    // 단일 문자열로 합쳐도 충돌 없어야 함 (B-tree 키로 조합 시)
+    assert_ne!(keys_a.concat(), keys_b.concat());
+}
+
+#[test]
+fn composite_key_preserves_column_order() {
+    let row = TableDataRow {
+        fields: vec![
+            field("a", TableDataFieldType::Integer(1)),
+            field("b", TableDataFieldType::Integer(2)),
+        ],
+    };
+
+    let ab = row_index_keys(&row, &["a".to_owned(), "b".to_owned()]).unwrap();
+    let ba = row_index_keys(&row, &["b".to_owned(), "a".to_owned()]).unwrap();
+
+    assert_ne!(ab, ba, "column order must affect the key");
+    // 컴포넌트는 길이 프리픽스로 인코딩되지만, 원래 필드 키가 포함되어 있어야 함
+    assert!(ab[0].contains(&field_to_key(&TableDataFieldType::Integer(1))));
+    assert!(ab[1].contains(&field_to_key(&TableDataFieldType::Integer(2))));
+    assert!(ba[0].contains(&field_to_key(&TableDataFieldType::Integer(2))));
+}
+
+#[test]
+fn row_with_null_in_indexed_column_is_not_indexed() {
+    let row = TableDataRow {
+        fields: vec![
+            field("user_id", TableDataFieldType::Integer(1)),
+            field("group_id", TableDataFieldType::Null),
+        ],
+    };
+
+    assert!(
+        row_index_keys(&row, &["user_id".to_owned(), "group_id".to_owned()]).is_none(),
+        "NULL이 포함된 복합 키는 색인하지 않음 (PostgreSQL과 동일)"
+    );
+}
+
+#[test]
+fn row_missing_indexed_column_is_not_indexed() {
+    let row = TableDataRow {
+        fields: vec![field("user_id", TableDataFieldType::Integer(1))],
+    };
+
+    assert!(row_index_keys(&row, &["user_id".to_owned(), "missing".to_owned()]).is_none());
+}
+
+#[test]
+fn test_single_column_row_index_keys_matches_row_index_key() {
+    use crate::engine::actions::index::{join_composite_key, row_index_key, row_index_keys};
+
+    let row = TableDataRow {
+        fields: vec![field("id", TableDataFieldType::Integer(42))],
+    };
+
+    let via_multi = row_index_keys(&row, &["id".to_owned()]).unwrap();
+    let via_single = row_index_key(&row, "id").unwrap();
+
+    // 단일 컬럼 복합 키 컴포넌트에는 원래 필드 키가 그대로 포함되어야 함
+    // (길이 프리픽스는 조합 시 충돌 방지용)
+    assert_eq!(via_multi.len(), 1);
+    assert!(via_multi[0].contains(&via_single));
+}

--- a/src/engine/actions/test_composite_pk_e2e.rs
+++ b/src/engine/actions/test_composite_pk_e2e.rs
@@ -16,7 +16,8 @@ use crate::engine::{DBEngine, SharedWALManager};
 /// 커버리지:
 /// - 복합 PK 테이블 생성 시 `{table}_pkey` 인덱스 자동 생성
 /// - 복합 키 유니크 강제: 개별 중복 + 배치 중복 거부, 다른 조합은 허용
-/// - 복합 키 조회: PK 선행 컬럼 동등 조건으로 IndexScan
+/// - 복합 키 조회: 옵티마이저가 복합 인덱스 prefix 스캔 미지원이라도
+///   (FullScan 폴백) 정확한 결과 반환 — 특히 큰 테이블에서 회귀 테스트
 /// - UPDATE/DELETE 유지보수
 /// - 재기동 후 persisted index 재적재
 /// - 인덱스 유지보수 실패 시 롤백 (orphan row 없음)
@@ -174,6 +175,67 @@ async fn composite_pk_lookup_returns_exactly_the_matching_rows() {
     .unwrap();
     assert_eq!(result.rows.len(), 1);
     assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(1));
+}
+
+#[tokio::test]
+async fn composite_pk_lookup_is_correct_on_a_large_table() {
+    // 회귀 테스트: 옵티마이저가 복합 인덱스를 IndexScan 후보에서 제외하지
+    // 않던 시절, 큰 테이블에서 첫 컬럼 동등 조건이 raw eq_key로 인덱스를
+    // 조회해 조건을 만족하는 행을 전부 누락했다 (0행 반환).
+    // prefix 스캔 미지원 복합 인덱스는 FullScan으로 폴백해야 정확하다 (#220).
+    let (engine, wal) = build_test_engine("lookup_large").await;
+    setup_memberships_table(&engine, wal.clone()).await;
+
+    let mut values = String::new();
+    for i in 0..1000 {
+        if i > 0 {
+            values.push_str(", ");
+        }
+        values.push_str(&format!("({}, {})", i, i % 7));
+    }
+
+    execute_sql(
+        &engine,
+        wal.clone(),
+        &format!(
+            "insert into memberships (user_id, group_id) values {};",
+            values
+        ),
+    )
+    .await
+    .unwrap();
+
+    // 첫 컬럼 동등 조건: user_id = 42 → 정확히 1행
+    let result = execute_sql(
+        &engine,
+        wal.clone(),
+        "select group_id from memberships where user_id = 42;",
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.rows.len(), 1, "user_id = 42 must match exactly one row");
+    assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(42 % 7));
+
+    // 존재하지 않는 키: 0행 (과거 버그로는 0행이 정답처럼 보였지만
+    // 존재하는 키도 0행이 나왔었다. 이번엔 존재하는 키가 1행 나오는지가 핵심)
+    let result = execute_sql(
+        &engine,
+        wal.clone(),
+        "select user_id from memberships where user_id = 9999;",
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.rows.len(), 0);
+
+    // 범위 조건도 정확해야 함: 500 <= user_id < 510 → 10행
+    let result = execute_sql(
+        &engine,
+        wal.clone(),
+        "select user_id from memberships where user_id >= 500 and user_id < 510;",
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.rows.len(), 10);
 }
 
 #[tokio::test]

--- a/src/engine/actions/test_composite_pk_e2e.rs
+++ b/src/engine/actions/test_composite_pk_e2e.rs
@@ -1,0 +1,327 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use crate::config::launch_config::LaunchConfig;
+use crate::engine::ast::types::TableName;
+use crate::engine::parser::predule::{Parser, ParserContext};
+use crate::engine::types::{ExecuteField, ExecuteResult};
+use crate::engine::wal::endec::implements::bincode::{BincodeDecoder, BincodeEncoder};
+use crate::engine::wal::manager::builder::WALBuilder;
+use crate::engine::{DBEngine, SharedWALManager};
+
+/// 복합 PRIMARY KEY 엔드투엔드 통합 테스트 (#220)
+///
+/// 커버리지:
+/// - 복합 PK 테이블 생성 시 `{table}_pkey` 인덱스 자동 생성
+/// - 복합 키 유니크 강제: 개별 중복 + 배치 중복 거부, 다른 조합은 허용
+/// - 복합 키 조회: PK 선행 컬럼 동등 조건으로 IndexScan
+/// - UPDATE/DELETE 유지보수
+/// - 재기동 후 persisted index 재적재
+/// - 인덱스 유지보수 실패 시 롤백 (orphan row 없음)
+
+async fn build_test_engine(test_name: &str) -> (DBEngine, SharedWALManager) {
+    let base_path = PathBuf::from("target/test_composite_pk").join(test_name);
+    if base_path.exists() {
+        tokio::fs::remove_dir_all(&base_path).await.unwrap();
+    }
+
+    let config = LaunchConfig::default_for_base_path(&base_path);
+    tokio::fs::create_dir_all(&config.data_directory)
+        .await
+        .unwrap();
+    tokio::fs::create_dir_all(&config.wal_directory)
+        .await
+        .unwrap();
+
+    let wal = WALBuilder::new(&config)
+        .build(BincodeDecoder::new(), BincodeEncoder::new())
+        .await
+        .unwrap();
+
+    (DBEngine::new(config), Arc::new(Mutex::new(wal)))
+}
+
+async fn execute_sql(
+    engine: &DBEngine,
+    wal: SharedWALManager,
+    sql: &str,
+) -> crate::errors::Result<ExecuteResult> {
+    let mut parser = Parser::with_string(sql.to_string())?;
+    let mut statements =
+        parser.parse(ParserContext::default().set_default_database("rrdb".to_string()))?;
+    let statement = statements.remove(0);
+
+    engine
+        .process_query(statement, wal, "test-connection".to_string())
+        .await
+}
+
+fn memberships_table() -> TableName {
+    TableName::new(Some("rrdb".to_owned()), "memberships".to_owned())
+}
+
+async fn setup_memberships_table(engine: &DBEngine, wal: SharedWALManager) {
+    execute_sql(engine, wal.clone(), "create database rrdb;")
+        .await
+        .unwrap();
+    execute_sql(
+        engine,
+        wal,
+        "create table memberships (user_id integer, group_id integer, primary key (user_id, group_id));",
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn composite_pk_table_auto_creates_composite_index() {
+    let (engine, wal) = build_test_engine("auto_composite_index").await;
+    setup_memberships_table(&engine, wal).await;
+
+    let meta = engine
+        .index_manager
+        .get_meta("rrdb.memberships_pkey")
+        .await
+        .expect("composite PK index should be auto-created");
+
+    assert_eq!(meta.columns(), &["user_id", "group_id"]);
+    assert!(meta.is_unique);
+    assert_eq!(meta.table_name, memberships_table());
+}
+
+#[tokio::test]
+async fn composite_pk_rejects_duplicate_key_combinations() {
+    let (engine, wal) = build_test_engine("duplicate_combinations").await;
+    setup_memberships_table(&engine, wal.clone()).await;
+
+    execute_sql(
+        &engine,
+        wal.clone(),
+        "insert into memberships (user_id, group_id) values (1, 1);",
+    )
+    .await
+    .unwrap();
+
+    // 같은 조합 재삽입 거부
+    let duplicate = execute_sql(
+        &engine,
+        wal.clone(),
+        "insert into memberships (user_id, group_id) values (1, 1);",
+    )
+    .await;
+    assert!(duplicate.is_err(), "identical combination must be rejected");
+
+    // 배치 내 중복 조합 거부
+    let batch_duplicate = execute_sql(
+        &engine,
+        wal.clone(),
+        "insert into memberships (user_id, group_id) values (2, 2), (2, 2);",
+    )
+    .await;
+    assert!(batch_duplicate.is_err(), "batch duplicate must be rejected");
+
+    // 개별 컬럼 값이 같아도 조합이 다르면 허용 (복합 PK의 핵심)
+    execute_sql(
+        &engine,
+        wal.clone(),
+        "insert into memberships (user_id, group_id) values (1, 2);",
+    )
+    .await
+    .expect("different combination with reused user_id must be accepted");
+    execute_sql(
+        &engine,
+        wal.clone(),
+        "insert into memberships (user_id, group_id) values (2, 1);",
+    )
+    .await
+    .expect("different combination with reused group_id must be accepted");
+
+    assert_eq!(engine.full_scan(memberships_table()).await.unwrap().len(), 3);
+}
+
+#[tokio::test]
+async fn composite_pk_lookup_returns_exactly_the_matching_rows() {
+    let (engine, wal) = build_test_engine("lookup").await;
+    setup_memberships_table(&engine, wal.clone()).await;
+
+    execute_sql(
+        &engine,
+        wal.clone(),
+        "insert into memberships (user_id, group_id) values (1, 1), (1, 2), (2, 1), (3, 3);",
+    )
+    .await
+    .unwrap();
+
+    // PK 선행 컬럼 동등 조건: user_id = 1 → 2행
+    let result = execute_sql(
+        &engine,
+        wal.clone(),
+        "select group_id from memberships where user_id = 1;",
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.rows.len(), 2, "user_id = 1 must match two rows");
+
+    // 정확한 조합 조회: user_id = 1 and group_id = 2 → 1행
+    let result = execute_sql(
+        &engine,
+        wal.clone(),
+        "select user_id from memberships where user_id = 1 and group_id = 2;",
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(1));
+}
+
+#[tokio::test]
+async fn composite_pk_maintains_index_across_update_and_delete() {
+    let (engine, wal) = build_test_engine("update_delete").await;
+    setup_memberships_table(&engine, wal.clone()).await;
+
+    execute_sql(
+        &engine,
+        wal.clone(),
+        "insert into memberships (user_id, group_id) values (1, 1), (2, 2);",
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        engine
+            .index_manager
+            .len("rrdb.memberships_pkey")
+            .await
+            .unwrap(),
+        2
+    );
+
+    // UPDATE: 복합 PK 컬럼 변경 — (2,2) -> (2,3)
+    execute_sql(
+        &engine,
+        wal.clone(),
+        "update memberships set group_id = 3 where user_id = 2 and group_id = 2;",
+    )
+    .await
+    .unwrap();
+
+    // 변경된 조합으로 조회 가능
+    let result = execute_sql(
+        &engine,
+        wal.clone(),
+        "select user_id from memberships where user_id = 2 and group_id = 3;",
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.rows.len(), 1);
+
+    // 기존 조합으로는 조회 불가
+    let result = execute_sql(
+        &engine,
+        wal.clone(),
+        "select user_id from memberships where user_id = 2 and group_id = 2;",
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.rows.len(), 0);
+
+    // UPDATE로 유니크 위반 유도 — (1,1)을 이미 존재하는 (2,3)으로
+    let conflict = execute_sql(
+        &engine,
+        wal.clone(),
+        "update memberships set user_id = 2, group_id = 3 where user_id = 1 and group_id = 1;",
+    )
+    .await;
+    assert!(conflict.is_err(), "duplicate combination via update must fail");
+
+    // DELETE: 인덱스 항목 제거
+    execute_sql(
+        &engine,
+        wal.clone(),
+        "delete from memberships where user_id = 1 and group_id = 1;",
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        engine
+            .index_manager
+            .len("rrdb.memberships_pkey")
+            .await
+            .unwrap(),
+        1,
+        "index entries must track live rows after delete"
+    );
+}
+
+#[tokio::test]
+async fn composite_pk_index_survives_restart() {
+    let (engine, wal) = build_test_engine("restart").await;
+    setup_memberships_table(&engine, wal.clone()).await;
+
+    execute_sql(
+        &engine,
+        wal.clone(),
+        "insert into memberships (user_id, group_id) values (7, 8);",
+    )
+    .await
+    .unwrap();
+
+    engine.flush_row_buffers_durable().await.unwrap();
+
+    let restarted = DBEngine::new(engine.config.as_ref().clone());
+    let result = execute_sql(
+        &restarted,
+        wal,
+        "select user_id from memberships where user_id = 7 and group_id = 8;",
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(7));
+}
+
+#[tokio::test]
+async fn failed_composite_pk_insert_does_not_leave_orphan_row() {
+    let (engine, wal) = build_test_engine("orphan").await;
+    setup_memberships_table(&engine, wal.clone()).await;
+
+    let (first, second) = tokio::join!(
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "insert into memberships (user_id, group_id) values (1, 1);"
+        ),
+        execute_sql(
+            &engine,
+            wal.clone(),
+            "insert into memberships (user_id, group_id) values (1, 1);"
+        ),
+    );
+
+    let successes = [&first, &second].iter().filter(|r| r.is_ok()).count();
+    assert_eq!(
+        successes, 1,
+        "exactly one of the racing identical inserts should succeed"
+    );
+
+    let rows = engine.full_scan(memberships_table()).await.unwrap();
+    assert_eq!(
+        rows.len(),
+        1,
+        "a failed composite-PK insert must not leave an orphan row"
+    );
+
+    let index_entries = engine
+        .index_manager
+        .scan_all("rrdb.memberships_pkey")
+        .await
+        .unwrap();
+    assert_eq!(
+        index_entries.len(),
+        rows.len(),
+        "index entry count must match live row count after rollback"
+    );
+}

--- a/src/engine/actions/test_composite_pk_e2e.rs
+++ b/src/engine/actions/test_composite_pk_e2e.rs
@@ -24,9 +24,9 @@ use crate::engine::{DBEngine, SharedWALManager};
 
 async fn build_test_engine(test_name: &str) -> (DBEngine, SharedWALManager) {
     let base_path = PathBuf::from("target/test_composite_pk").join(test_name);
-    if base_path.exists() {
-        tokio::fs::remove_dir_all(&base_path).await.unwrap();
-    }
+
+    // 남은 이전 실행 정리 — remove_dir_all은 존재하지 않아도 실패를 신경 쓰지 않음
+    let _ = tokio::fs::remove_dir_all(&base_path).await;
 
     let config = LaunchConfig::default_for_base_path(&base_path);
     tokio::fs::create_dir_all(&config.data_directory)
@@ -139,7 +139,10 @@ async fn composite_pk_rejects_duplicate_key_combinations() {
     .await
     .expect("different combination with reused group_id must be accepted");
 
-    assert_eq!(engine.full_scan(memberships_table()).await.unwrap().len(), 3);
+    assert_eq!(
+        engine.full_scan(memberships_table()).await.unwrap().len(),
+        3
+    );
 }
 
 #[tokio::test]
@@ -213,7 +216,11 @@ async fn composite_pk_lookup_is_correct_on_a_large_table() {
     )
     .await
     .unwrap();
-    assert_eq!(result.rows.len(), 1, "user_id = 42 must match exactly one row");
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "user_id = 42 must match exactly one row"
+    );
     assert_eq!(result.rows[0].fields[0], ExecuteField::Integer(42 % 7));
 
     // 존재하지 않는 키: 0행 (과거 버그로는 0행이 정답처럼 보였지만
@@ -296,7 +303,10 @@ async fn composite_pk_maintains_index_across_update_and_delete() {
         "update memberships set user_id = 2, group_id = 3 where user_id = 1 and group_id = 1;",
     )
     .await;
-    assert!(conflict.is_err(), "duplicate combination via update must fail");
+    assert!(
+        conflict.is_err(),
+        "duplicate combination via update must fail"
+    );
 
     // DELETE: 인덱스 항목 제거
     execute_sql(

--- a/src/engine/index/mod.rs
+++ b/src/engine/index/mod.rs
@@ -19,16 +19,22 @@ pub struct IndexEntry {
     pub row_path: String,
 }
 
-/// Metadata describing an index on a specific table column.
+/// Metadata describing an index on one or more table columns (#220).
+///
+/// Single-column indexes keep `columns` with exactly one element; composite
+/// indexes list the columns in key order. `column_name()` preserves the old
+/// single-column accessor for callers that only deal with single indexes.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct IndexMeta {
     pub index_name: String,
     pub table_name: TableName,
     pub column_name: String,
+    pub columns: Vec<String>,
     pub is_unique: bool,
 }
 
 impl IndexMeta {
+    /// Create metadata for a single-column index (#217, existing behavior).
     pub fn new(
         index_name: String,
         table_name: TableName,
@@ -38,9 +44,52 @@ impl IndexMeta {
         Self {
             index_name,
             table_name,
-            column_name,
+            column_name: column_name.clone(),
+            columns: vec![column_name],
             is_unique,
         }
+    }
+
+    /// Create metadata for a composite (multi-column) index (#220).
+    ///
+    /// The `columns` order defines the key order. Panics on an empty list:
+    /// an index over zero columns is meaningless and callers validate before
+    /// reaching here.
+    pub fn new_composite(
+        index_name: String,
+        table_name: TableName,
+        columns: Vec<String>,
+        is_unique: bool,
+    ) -> Self {
+        assert!(
+            !columns.is_empty(),
+            "composite index must have at least one column"
+        );
+
+        Self {
+            index_name,
+            table_name,
+            // 하위 호환: 기존 디스크 메타/호출자는 column_name을 사용.
+            // 복합 인덱스에서는 첫 번째 컬럼을 유지 (표시/통계 용도).
+            column_name: columns[0].clone(),
+            columns,
+            is_unique,
+        }
+    }
+
+    /// The indexed columns in key order.
+    pub fn columns(&self) -> &[String] {
+        &self.columns
+    }
+
+    /// The first indexed column (legacy single-column accessor).
+    pub fn column_name(&self) -> &str {
+        &self.column_name
+    }
+
+    /// True when this index covers more than one column.
+    pub fn is_composite(&self) -> bool {
+        self.columns.len() > 1
     }
 }
 
@@ -80,5 +129,47 @@ pub fn field_to_key(field: &TableDataFieldType) -> String {
         TableDataFieldType::String(v) => format!("S:{}", v),
         TableDataFieldType::Array(_) => format!("A:{}", field.to_string()),
         TableDataFieldType::Null => "N:".to_string(),
+    }
+}
+
+/// Length-prefixed encoding of one key component so that the concatenation of
+/// multiple components is unambiguous (#220).
+///
+/// Plain concatenation is not injective: ("S:ab", "S:c") and ("S:a", "S:bc")
+/// both merge to "S:abS:c". Prefixing each component with its byte length
+/// ("5:S:ab" style) makes ("S:ab","S:c") -> "5:S:ab3:S:c" differ from
+/// ("S:a","S:bc") -> "3:S:a5:S:bc". Length prefixes also preserve
+/// lexicographic comparability within equal-prefix groups, and every single
+/// component key maps to exactly one encoded form, so composite keys remain
+/// injective and order-preserving on the first differing column.
+pub fn encode_composite_key_component(key: &str) -> String {
+    format!("{:06}:{}", key.len(), key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn composite_component_encoding_is_injective_for_splits() {
+        let a = (
+            encode_composite_key_component("S:ab"),
+            encode_composite_key_component("S:c"),
+        );
+        let b = (
+            encode_composite_key_component("S:a"),
+            encode_composite_key_component("S:bc"),
+        );
+
+        assert_ne!(format!("{}{}", a.0, a.1), format!("{}{}", b.0, b.1));
+    }
+
+    #[test]
+    fn composite_component_encoding_round_trips() {
+        for key in ["S:hello", "I:00000000000000FF", "", "N:"] {
+            let encoded = encode_composite_key_component(key);
+            let expected = format!("{:06}:{}", key.len(), key);
+            assert_eq!(encoded, expected);
+        }
     }
 }

--- a/src/engine/optimizer/optimizer.rs
+++ b/src/engine/optimizer/optimizer.rs
@@ -282,6 +282,16 @@ impl Optimizer {
         let mut best: Option<(f64, IndexScanPlan)> = None;
 
         for index in &self.context.indexes {
+            // 복합 인덱스는 아직 컬럼별 prefix 스캔을 지원하지 않는다 (#220).
+            //
+            // 복합 인덱스의 저장 키는 길이 프리픽스 조합이므로 단일 컬럼의
+            // raw field_to_key 경계와 매칭되지 않는다. eq/range 경계를 그대로
+            // 사용하면 조건을 만족하는 행을 누락하는 잘못된 결과를 내므로,
+            // prefix 스캔이 구현되기 전까지는 FullScan으로 폴백한다 (안전 우선).
+            if index.is_composite() {
+                continue;
+            }
+
             let bounds = match bounds_per_column.get(&index.column_name) {
                 Some(bounds) => bounds,
                 None => continue,

--- a/src/engine/parser/implements/ddl/table.rs
+++ b/src/engine/parser/implements/ddl/table.rs
@@ -46,7 +46,10 @@ impl Parser {
             )));
         }
 
-        // 닫는 괄호 나올때까지 행 파싱 반복
+        // 닫는 괄호 나올때까지 행/테이블 제약 파싱 반복 (#220)
+        let mut saw_inline_primary_key = false;
+        let mut saw_table_level_primary_key = false;
+
         loop {
             if !self.has_next_token() {
                 return Err(ParsingError::wrap("need more tokens".to_string()));
@@ -58,12 +61,118 @@ impl Parser {
                 Token::RightParentheses => {
                     break;
                 }
+                // 테이블 레벨 제약: PRIMARY KEY (column_name [, ...]) (#220)
+                Token::Primary => {
+                    if !self.has_next_token() {
+                        return Err(ParsingError::wrap("need more tokens".to_string()));
+                    }
+
+                    let current_token = self.get_next_token();
+
+                    if Token::Key != current_token {
+                        return Err(ParsingError::wrap(format!(
+                            "expected 'PRIMARY KEY'. but your input word is '{:?}'",
+                            current_token
+                        )));
+                    }
+
+                    if !self.has_next_token() {
+                        return Err(ParsingError::wrap("need more tokens".to_string()));
+                    }
+
+                    let current_token = self.get_next_token();
+
+                    if Token::LeftParentheses != current_token {
+                        return Err(ParsingError::wrap(format!(
+                            "expected '('. but your input word is '{:?}'",
+                            current_token
+                        )));
+                    }
+
+                    let mut columns: Vec<String> = vec![];
+
+                    loop {
+                        if !self.has_next_token() {
+                            return Err(ParsingError::wrap("need more tokens".to_string()));
+                        }
+
+                        let current_token = self.get_next_token();
+
+                        match current_token {
+                            Token::RightParentheses => break,
+                            Token::Comma => continue,
+                            Token::Identifier(column_name) => {
+                                columns.push(column_name);
+                            }
+                            _ => {
+                                return Err(ParsingError::wrap(format!(
+                                    "expected column name in 'PRIMARY KEY (...)'. but your input word is '{:?}'",
+                                    current_token
+                                )));
+                            }
+                        }
+                    }
+
+                    if columns.is_empty() {
+                        return Err(ParsingError::wrap(
+                            "expected at least one column name in 'PRIMARY KEY (...)'".to_string(),
+                        ));
+                    }
+
+                    if saw_table_level_primary_key {
+                        return Err(ParsingError::wrap(
+                            "multiple table-level primary keys specified".to_string(),
+                        ));
+                    }
+
+                    saw_table_level_primary_key = true;
+                    query_builder = query_builder.set_primary_key(columns);
+                }
                 _ => {
                     self.unget_next_token(current_token);
                     let column = self.parse_table_column()?;
+
+                    if column.primary_key {
+                        saw_inline_primary_key = true;
+                    }
+
                     query_builder = query_builder.add_column(column);
                 }
             }
+        }
+
+        // 인라인 PRIMARY KEY와 테이블 레벨 PRIMARY KEY를 동시에 지정할 수 없습니다 (#220)
+        if saw_inline_primary_key && saw_table_level_primary_key {
+            return Err(ParsingError::wrap(
+                "multiple primary keys specified: cannot combine an inline 'PRIMARY KEY' column constraint with a table-level 'PRIMARY KEY (...)'" 
+                    .to_string(),
+            ));
+        }
+
+        // 테이블 레벨 PK는 정의된 컬럼만 참조할 수 있습니다 (#220)
+        if saw_table_level_primary_key {
+            let query = query_builder.build();
+            if let crate::engine::ast::SQLStatement::DDL(
+                crate::engine::ast::DDLStatement::CreateTableQuery(inner),
+            ) = &query
+            {
+                let column_names: std::collections::HashSet<&str> = inner
+                    .columns
+                    .iter()
+                    .map(|column| column.name.as_str())
+                    .collect();
+
+                for column_name in &inner.primary_key {
+                    if !column_names.contains(column_name.as_str()) {
+                        return Err(ParsingError::wrap(format!(
+                            "primary key column '{}' is not defined in the table",
+                            column_name
+                        )));
+                    }
+                }
+            }
+
+            return Ok(query);
         }
 
         if !self.has_next_token() {

--- a/src/engine/parser/implements/ddl/table.rs
+++ b/src/engine/parser/implements/ddl/table.rs
@@ -90,6 +90,9 @@ impl Parser {
                     }
 
                     let mut columns: Vec<String> = vec![];
+                    // 식별자와 쉼표가 교대로 와야 합니다 (#220):
+                    // PRIMARY KEY (a, b) O, (,a) / (a,) / (a,,b) X
+                    let mut expect_identifier = true;
 
                     loop {
                         if !self.has_next_token() {
@@ -99,10 +102,32 @@ impl Parser {
                         let current_token = self.get_next_token();
 
                         match current_token {
-                            Token::RightParentheses => break,
-                            Token::Comma => continue,
+                            Token::RightParentheses => {
+                                if expect_identifier && !columns.is_empty() {
+                                    return Err(ParsingError::wrap(
+                                        "trailing comma in 'PRIMARY KEY (...)'".to_string(),
+                                    ));
+                                }
+                                break;
+                            }
+                            Token::Comma => {
+                                if expect_identifier {
+                                    return Err(ParsingError::wrap(
+                                        "expected column name in 'PRIMARY KEY (...)'. but your input word is 'Comma'"
+                                            .to_string(),
+                                    ));
+                                }
+                                expect_identifier = true;
+                            }
                             Token::Identifier(column_name) => {
+                                if !expect_identifier {
+                                    return Err(ParsingError::wrap(format!(
+                                        "expected ',' or ')' after column name in 'PRIMARY KEY (...)'. but your input word is '{:?}'",
+                                        column_name
+                                    )));
+                                }
                                 columns.push(column_name);
+                                expect_identifier = false;
                             }
                             _ => {
                                 return Err(ParsingError::wrap(format!(
@@ -170,6 +195,21 @@ impl Parser {
                         )));
                     }
                 }
+            }
+
+            // 문장 종료 검증은 일반 경로와 동일하게 적용합니다 (#220):
+            // 테이블 레벨 PK 뒤에 이상한 토큰이 남으면 에러.
+            if !self.has_next_token() {
+                return Ok(query);
+            }
+
+            let current_token = self.get_next_token();
+
+            if Token::SemiColon != current_token {
+                return Err(ParsingError::wrap(format!(
+                    "expected ';'. but your input word is '{:?}'",
+                    current_token
+                )));
             }
 
             return Ok(query);

--- a/src/engine/parser/test/create_table.rs
+++ b/src/engine/parser/test/create_table.rs
@@ -156,6 +156,61 @@ pub fn create_table_rejects_primary_key_referencing_unknown_column() {
     );
 }
 
+/// PK 목록의 문법 오류(쉼표 위치)를 거부해야 합니다 (#220, CodeRabbit)
+#[test]
+pub fn create_table_rejects_primary_key_comma_syntax_errors() {
+    let cases = [
+        "CREATE TABLE t (a INTEGER, PRIMARY KEY (,a));", // 선두 쉼표
+        "CREATE TABLE t (a INTEGER, PRIMARY KEY (a,));", // 후행 쉼표
+        "CREATE TABLE t (a INTEGER, PRIMARY KEY (a,,b));", // 연속 쉼표
+        "CREATE TABLE t (a INTEGER, PRIMARY KEY (a b));", // 쉼표 누락
+    ];
+
+    for text in cases {
+        let mut parser = Parser::with_string(text.to_owned()).unwrap();
+        assert!(
+            parser.parse(ParserContext::default()).is_err(),
+            "should reject: {}",
+            text
+        );
+    }
+}
+
+/// 테이블 레벨 PK 뒤에 이상한 토큰이 남으면 에러 (#220, CodeRabbit)
+#[test]
+pub fn create_table_rejects_trailing_tokens_after_table_level_primary_key() {
+    let text = r#"
+        CREATE TABLE "test_db".t
+        (
+            a INTEGER,
+            PRIMARY KEY (a)
+        ) unexpected;
+    "#
+    .to_owned();
+
+    let mut parser = Parser::with_string(text).unwrap();
+
+    assert!(parser.parse(ParserContext::default()).is_err());
+}
+
+/// 테이블 레벨 PK + 세미콜론 없는 종료(EOF)는 정상 파싱 (#220)
+#[test]
+pub fn create_table_accepts_table_level_primary_key_without_semicolon() {
+    let text = r#"
+        CREATE TABLE "test_db".t
+        (
+            a INTEGER,
+            PRIMARY KEY (a)
+        )
+    "#
+    .to_owned();
+
+    let mut parser = Parser::with_string(text).unwrap();
+
+    let statements = parser.parse(ParserContext::default()).unwrap();
+    assert_eq!(statements.len(), 1);
+}
+
 #[test]
 pub fn create_table() {
     let text = r#"

--- a/src/engine/parser/test/create_table.rs
+++ b/src/engine/parser/test/create_table.rs
@@ -5,6 +5,157 @@ use crate::engine::ast::types::{Column, DataType, TableName};
 use crate::engine::parser::context::ParserContext;
 use crate::engine::parser::predule::Parser;
 
+/// 테이블 레벨 복합 PRIMARY KEY 파싱 (#220)
+#[test]
+pub fn create_table_with_composite_table_level_primary_key() {
+    let text = r#"
+        CREATE TABLE "test_db".memberships
+        (
+            user_id INTEGER,
+            group_id INTEGER,
+            PRIMARY KEY (user_id, group_id)
+        );
+    "#
+    .to_owned();
+
+    let mut parser = Parser::with_string(text).unwrap();
+
+    let expected = CreateTableQuery::builder()
+        .set_table(TableName::new(
+            Some("test_db".to_owned()),
+            "memberships".to_owned(),
+        ))
+        .add_column(
+            Column::builder()
+                .set_name("user_id".to_owned())
+                .set_data_type(DataType::Int)
+                .build(),
+        )
+        .add_column(
+            Column::builder()
+                .set_name("group_id".to_owned())
+                .set_data_type(DataType::Int)
+                .build(),
+        )
+        .set_primary_key(vec!["user_id".to_owned(), "group_id".to_owned()])
+        .build();
+
+    assert_eq!(
+        parser.parse(ParserContext::default()).unwrap(),
+        vec![expected],
+    );
+}
+
+/// 단일 컬럼 테이블 레벨 PRIMARY KEY (#220)
+#[test]
+pub fn create_table_with_single_column_table_level_primary_key() {
+    let text = r#"
+        CREATE TABLE "test_db".t
+        (
+            a INTEGER,
+            PRIMARY KEY (a)
+        );
+    "#
+    .to_owned();
+
+    let mut parser = Parser::with_string(text).unwrap();
+
+    let expected = CreateTableQuery::builder()
+        .set_table(TableName::new(Some("test_db".to_owned()), "t".to_owned()))
+        .add_column(
+            Column::builder()
+                .set_name("a".to_owned())
+                .set_data_type(DataType::Int)
+                .build(),
+        )
+        .set_primary_key(vec!["a".to_owned()])
+        .build();
+
+    assert_eq!(
+        parser.parse(ParserContext::default()).unwrap(),
+        vec![expected],
+    );
+}
+
+/// 인라인 PK와 테이블 레벨 PK를 동시에 지정하면 에러 (#220)
+#[test]
+pub fn create_table_rejects_mixed_inline_and_table_level_primary_keys() {
+    let text = r#"
+        CREATE TABLE "test_db".t
+        (
+            id INTEGER PRIMARY KEY,
+            PRIMARY KEY (id)
+        );
+    "#
+    .to_owned();
+
+    let mut parser = Parser::with_string(text).unwrap();
+
+    let error = parser.parse(ParserContext::default()).unwrap_err();
+    assert!(
+        error.to_string().contains("multiple primary keys"),
+        "got: {}",
+        error
+    );
+}
+
+/// 테이블 레벨 PK에 컬럼이 없으면 에러 (#220)
+#[test]
+pub fn create_table_rejects_primary_key_with_empty_column_list() {
+    let text = r#"
+        CREATE TABLE "test_db".t
+        (
+            a INTEGER,
+            PRIMARY KEY ( )
+        );
+    "#
+    .to_owned();
+
+    let mut parser = Parser::with_string(text).unwrap();
+
+    assert!(parser.parse(ParserContext::default()).is_err());
+}
+
+/// PRIMARY KEY 뒤 괄호가 없으면 에러 (#220)
+#[test]
+pub fn create_table_rejects_primary_key_without_parentheses() {
+    let text = r#"
+        CREATE TABLE "test_db".t
+        (
+            a INTEGER,
+            PRIMARY KEY a
+        );
+    "#
+    .to_owned();
+
+    let mut parser = Parser::with_string(text).unwrap();
+
+    assert!(parser.parse(ParserContext::default()).is_err());
+}
+
+/// 테이블 레벨 PK가 정의되지 않은 컬럼을 참조하면 에러 (#220)
+#[test]
+pub fn create_table_rejects_primary_key_referencing_unknown_column() {
+    let text = r#"
+        CREATE TABLE "test_db".t
+        (
+            a INTEGER,
+            b INTEGER,
+            PRIMARY KEY (a, nope)
+        );
+    "#
+    .to_owned();
+
+    let mut parser = Parser::with_string(text).unwrap();
+
+    let error = parser.parse(ParserContext::default()).unwrap_err();
+    assert!(
+        error.to_string().contains("nope"),
+        "error should name the unknown column, got: {}",
+        error
+    );
+}
+
 #[test]
 pub fn create_table() {
     let text = r#"


### PR DESCRIPTION
Closes #220

## Summary

Follow-up to #218 (single-column PK auto-index): this implements **composite primary keys** end to end — table-level `PRIMARY KEY (a, b)` syntax, composite index metadata, length-prefixed composite key encoding, and automatic composite `{table}_pkey` index creation with full DML maintenance.

## Changes

### 1. Parser: table-level PRIMARY KEY constraint (d721656)

`create table t (a int, b int, primary key (a, b));` now parses. `CreateTableQuery.primary_key: Vec<String>` existed in the AST but was never populated from SQL.

- Accepts `PRIMARY KEY (col [, ...])` as a table-level constraint
- Rejects: empty column list, missing parens, second table-level PK, inline + table-level PK combos, PK columns not defined in the table
- 6 parser tests

### 2. Index core: composite metadata + key encoding (9e85f7a)

- `IndexMeta` gains `columns: Vec<String>` + `new_composite()` (with `column_name()` kept as the first column for compatibility)
- `join_composite_key()`: single component passes through **unchanged** (preserves the existing key space shared with the optimizer's `eq_key`/`start_key`/`end_key`); multiple components get a 6-digit length prefix each, so `S:ab + S:c` vs `S:a + S:bc` cannot collide
- `row_index_keys()`: NULL/missing column in any indexed column → row not indexed (same as single-column semantics)
- 7 unit tests

### 3. Auto-creation + DML maintenance + optimizer safety (3816e02, 68f39fc)

- `create_table` auto-creates the composite `*_pkey` index whenever the PK is non-empty (was `len() == 1` with a TODO)
- `insert` / `update` / `delete` maintenance and insert pre-validation (unique rejection incl. batch) all switched to composite key computation
- **Optimizer safety fix (68f39fc)**: found during review — a composite index's stored keys are length-prefixed combinations, so the optimizer's raw single-column `eq_key` lookup can never match them. Without this fix, a large table with a composite PK would return **0 rows** for `WHERE user_id = 42` (verified: 1000-row probe returned 0). Composite indexes are now excluded from IndexScan candidates and fall back to FullScan until per-column prefix scans land; correctness first. Regression test added.

### 4. Integration tests (7)

auto-create metadata · duplicate combination rejection (single + batch) · lookup correctness (small + **large table regression**) · update/delete maintenance incl. unique violation via update · restart persistence · racing-insert orphan-row guard

## Test results

- Full `cargo test`: **847 passed, 0 failed** (baseline before this PR: 803)
- `cargo clippy --all-targets`: warning set identical to `master` (no new warnings)

## Known limitations (explicit scope)

- Composite index prefix scans (e.g. `WHERE user_id = 1` using the index) are not implemented — the optimizer falls back to FullScan for composite indexes. This is correctness-preserving and a natural follow-up.
- Table-level PK must appear after the column definitions (the common position); a column definition *after* a table-level constraint is rejected by the existing column parser.
- Table-level PK columns do not force `NOT NULL` (pre-existing single-column behavior from #218, matching rows-with-NULL-not-indexed semantics). Inline `PRIMARY KEY` does force `NOT NULL`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - `CREATE TABLE`에서 단일 및 복합 테이블 수준 `PRIMARY KEY`를 지원합니다.
  - 복합 기본 키와 복합 인덱스를 지원하며, 삽입·수정·삭제 시 키를 올바르게 유지합니다.
  - 복합 키의 중복 조합을 감지해 삽입 및 수정 오류를 방지합니다.
  - 재시작 후에도 복합 인덱스가 복원됩니다.

- **버그 수정**
  - 복합 키 조건에서 누락되거나 잘못된 행이 반환되는 문제를 방지합니다.
  - 동시 삽입 실패 시 불완전한 행이 남지 않도록 처리합니다.
  - 잘못된 기본 키 정의와 쉼표 문법에 대해 오류를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->