### PR TITLE
[#271] fix: reject multiple inline PRIMARY KEY columns

### DIFF
--- a/src/engine/parser/implements/ddl/table.rs
+++ b/src/engine/parser/implements/ddl/table.rs
@@ -158,6 +158,11 @@ impl Parser {
                     let column = self.parse_table_column()?;
 
                     if column.primary_key {
+                        if saw_inline_primary_key {
+                            return Err(ParsingError::wrap(
+                                "multiple primary keys specified".to_string(),
+                            ));
+                        }
                         saw_inline_primary_key = true;
                     }
 

--- a/src/engine/parser/test/create_table.rs
+++ b/src/engine/parser/test/create_table.rs
@@ -77,6 +77,61 @@ pub fn create_table_with_single_column_table_level_primary_key() {
     );
 }
 
+/// 서로 다른 컬럼에 인라인 PRIMARY KEY를 중복 지정하면 에러 (#271)
+#[test]
+pub fn create_table_rejects_multiple_inline_primary_keys() {
+    let cases = [
+        "create table t (a int primary key, b int primary key);",
+        "CREATE TABLE t (a INT PRIMARY KEY, payload INT, b INT PRIMARY KEY);",
+        "CREATE TABLE t (a INT PRIMARY KEY, b INT PRIMARY KEY, c INT PRIMARY KEY);",
+        "CREATE TABLE IF NOT EXISTS t (a INT PRIMARY KEY, b INT PRIMARY KEY)",
+    ];
+
+    for text in cases {
+        let mut parser = Parser::with_string(text.to_owned()).unwrap();
+        let error = parser.parse(ParserContext::default()).expect_err(text);
+        assert_eq!(
+            error.kind,
+            crate::errors::ErrorKind::ParsingError("multiple primary keys specified".to_owned()),
+            "should reject: {}",
+            text,
+        );
+    }
+}
+
+/// 인라인 PK는 컬럼 위치와 관계없이 테이블마다 하나씩 허용합니다 (#271)
+#[test]
+pub fn create_table_accepts_one_inline_primary_key_per_table() {
+    let text = "CREATE TABLE t1 (a INT PRIMARY KEY, b INT); \
+                CREATE TABLE t2 (a INT, b INT PRIMARY KEY);";
+    let mut parser = Parser::with_string(text.to_owned()).unwrap();
+
+    let expected = [("t1", "a"), ("t2", "b")].map(|(table, primary_key)| {
+        CreateTableQuery::builder()
+            .set_table(TableName::new(None, table.to_owned()))
+            .add_column(
+                Column::builder()
+                    .set_name("a".to_owned())
+                    .set_data_type(DataType::Int)
+                    .set_primary_key(primary_key == "a")
+                    .build(),
+            )
+            .add_column(
+                Column::builder()
+                    .set_name("b".to_owned())
+                    .set_data_type(DataType::Int)
+                    .set_primary_key(primary_key == "b")
+                    .build(),
+            )
+            .build()
+    });
+
+    assert_eq!(
+        parser.parse(ParserContext::default()).unwrap(),
+        expected.to_vec(),
+    );
+}
+
 /// 인라인 PK와 테이블 레벨 PK를 동시에 지정하면 에러 (#220)
 #[test]
 pub fn create_table_rejects_mixed_inline_and_table_level_primary_keys() {


### PR DESCRIPTION
resolves: #271

## 설명

서로 다른 컬럼에 인라인 `PRIMARY KEY`를 선언하면 파서가 이를 허용하고, 의도하지 않은 복합 PK 인덱스가 생성되는 문제를 수정합니다.

- 기존 `saw_inline_primary_key` 플래그를 확인하여 두 번째 인라인 PK 컬럼에서 `ParsingError("multiple primary keys specified")`를 반환합니다.
- 회귀 테스트: 인접한 PK 컬럼, 일반 컬럼을 사이에 둔 PK 컬럼, 세 개의 PK 컬럼, `IF NOT EXISTS` 및 세미콜론 없는 입력을 검증합니다.
- 같은 입력의 서로 다른 `CREATE TABLE` 문에서는 각각 단일 인라인 PK를 허용하며, 첫 번째/마지막 컬럼 위치도 검증합니다.
- 기존 테이블 수준 복합 PK 및 인라인/테이블 수준 PK 혼용 거부 동작을 유지합니다.

최신 `master` (`828af746`, #272 반영)에서 분기한 독립 수정입니다. 이슈에 별도 제약으로 언급된 테이블 수준 PK 이후 컬럼 정의 허용은 이번 범위에 포함하지 않습니다. AST, 저장 형식, 인덱스 및 WAL 경로는 변경하지 않습니다.

## 검증

- [x] 수정 전 재현: 이슈의 SQL이 성공적으로 AST를 반환하여 회귀 테스트 실패 확인
- [x] `cargo test --locked`: **857 passed, 0 failed** (lib 424 + main 428 + test binary 5)
- [x] `cargo build --locked`
- [x] `cargo clippy --locked --all-targets`: 성공, 동일 도구 체인·의존성의 upstream 기준과 경고 집합 동일 (추가 경고 없음)
- [x] 변경 파일 `rustfmt --edition 2024 --check` 및 `git diff --check`

로컬 환경: macOS arm64, Rust/Cargo 1.97.1. 저장소에 추적되는 `Cargo.lock`이 없어 최초 의존성 해석 후 생성된 로컬 lockfile로 검증했으며, lockfile은 PR에 포함하지 않습니다.

참고: 전체 `cargo fmt --check`는 기존 upstream 포맷 차이로 실패합니다. 기준 커밋에서도 동일한 출력임을 확인했으며, 무관한 포맷 수정은 포함하지 않았습니다. GitHub CI도 동일 HEAD `fff70a9144f1eea3d51bf93d46f29b65a80a04c9`에서 Linux/macOS/Windows 빌드·테스트와 Linux coverage 모두 통과했습니다. 독립 코드 리뷰 및 CodeRabbit 리뷰에서도 수정 요청은 없습니다.
