### PR TITLE
[#221] perf: read indexed rows by frame offset

### DIFF
--- a/docs/row-offset-reads.md
+++ b/docs/row-offset-reads.md
@@ -1,0 +1,41 @@
+# Indexed row reads by frame offset (#221)
+
+## Contract
+
+The existing B-tree row IDs and row/WAL formats are unchanged. A rebuildable in-memory directory maps logical row slots to frame-body offsets. A cold directory walks five-byte frame headers and skips bodies. Warm point/range lookups request only matched bodies, in index order, without cloning all cached rows.
+
+Buffered appends and dirty decoded rows take precedence over disk. Successful append flushes extend a warm directory; rewrites and failed writes invalidate it. DROP removes pending, decoded, unsynced and offset state under the storage lock. Physical rename invalidates derived offsets under old/new namespaces even when the later config update fails; it does not repair existing rename semantics.
+
+One directory retains up to 16 MiB of offset entries. The limit is a cache bound, not a table-size limit: an uncached suffix is located by header traversal. Appending to an incomplete directory preserves its contiguous prefix. Cold construction remains O(number of frames); suffix lookups and switching tables can require additional walks. Each uncached match restarts at the retained prefix boundary: selecting the first K suffix rows therefore performs K*(K+1)/2 header reads. The benchmark below stays below the cap and does not establish above-cap range scalability.
+
+Frame bounds are checked before payload allocation. Query memory is reserved before directory growth, payload allocation, decode estimates and selected-row clones. Cold statistics count live headers rather than decoding the row segment. Index metadata/statistics work is not eliminated.
+
+## Verification
+
+Tests cover point/range read requests, unrelated invalid payloads, malformed/truncated frames, stale pointers, memory limits, pending rows, growth/shrink rewrites, tombstones, append, reopen, namespace reuse, failure invalidation and WAL-before-apply replay. A separate model test performs 96 SQL mutations and 24 engine reopens, comparing indexed/full reads to a BTreeMap reference.
+
+The original applied-SQL-tail crash fixture also fails on the base revision: already-persisted index changes can conflict with replay while buffered row changes are lost. This PR does not fix that existing WAL/index crash window, general flush-retry durability, or existing decoded/pending/index/config rename defects. Passing WAL-before-apply tests is not a claim that all crash windows are safe.
+
+## Reproducible benchmark
+
+```sh
+cargo test --release --lib offset_read_benchmark -- --ignored --nocapture
+```
+
+The benchmark asserts results for 1,000 and 10,000 rows, point queries and 64-row ranges. It invokes row-read methods directly, not SQL planning. Cold means decoded/offset caches are reset; **OS caches are not evicted**. Warm offset runs retain offsets but no decoded-row cache. Full scans materialize all rows and then filter the same locations.
+
+Example run: macOS ARM64, Rust 1.97.1, release build; 10,000 rows, 10,960,000-byte segment. Means are illustrative, not latency assertions:
+
+| Case | Mean per lookup | Row-segment bytes per lookup |
+| --- | ---: | ---: |
+| Full scan, cold decoded cache, point | 12,292.9 us | 10,960,000 expected |
+| Offset point, cold directory | 125,430.6 us | 51,091 requested |
+| Offset point, warm directory | 58.8 us | 1,091 requested |
+| Offset range, cold directory | 121,151.1 us | 119,824 requested |
+| Offset range, warm directory | 864.2 us | 69,824 requested |
+| Full scan, cold decoded cache, range | 2,731.7 us | 10,960,000 expected |
+| Full scan, warm decoded cache, range | 1,138.4 us | 0 expected |
+
+Requested bytes are observed application-level random-read lengths, not physical device I/O. Full-scan expected bytes are derived from file length and cache resets because its existing direct reader bypasses the random-access decorator. Index-file I/O is not counted. Output counters aggregate all repetitions; divide by `repeats` for per-lookup values.
+
+Cold per-header asynchronous seeks can be substantially slower than sequential materialization despite requesting fewer bytes. Small warm ranges can also lose to an already-decoded full cache. This is not a universal speedup claim. Cost constants remain unchanged: the existing formula describes matched-row random access, while cold-directory cost and cache state remain limitations rather than unmeasured reasons to lower costs.

--- a/src/common/fs.rs
+++ b/src/common/fs.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
 /// One open handle for header walks and selected frame reads. No read-ahead.
+#[mockall::automock]
 #[async_trait::async_trait]
 pub trait RandomAccessFile: Send + Sync {
     async fn file_len(&self) -> io::Result<u64>;
@@ -34,12 +35,24 @@ pub struct FileSystemEntry {
 #[async_trait::async_trait]
 pub trait FileSystem {
     /// Open once per scan, then seek past unrelated frame bodies (#221).
-    /// Default preserves compatibility with existing filesystem implementations.
-    async fn open_random_access(&self, path: &Path) -> io::Result<Box<dyn RandomAccessFile>> {
-        Ok(Box::new(RealRandomAccessFile(
-            tokio::fs::File::open(path).await?,
-        )))
-    }
+    /// Each backend must explicitly implement random access to its own storage.
+    /// A backend cannot silently inherit host-filesystem access:
+    ///
+    /// ```compile_fail,E0046
+    /// use rrdb::common::fs::{FileSystem, FileSystemEntry};
+    /// use std::{io, path::Path};
+    /// struct Backend;
+    /// #[async_trait::async_trait]
+    /// impl FileSystem for Backend {
+    ///     async fn create_dir(&self, _: &str) -> io::Result<()> { Ok(()) }
+    ///     async fn write_file(&self, _: &str, _: &[u8]) -> io::Result<()> { Ok(()) }
+    ///     async fn read_dir(&self, _: &str) -> io::Result<Vec<FileSystemEntry>> { Ok(vec![]) }
+    ///     async fn read(&self, _: &Path) -> io::Result<Vec<u8>> { Ok(vec![]) }
+    ///     async fn truncate(&self, _: &Path, _: u64) -> io::Result<()> { Ok(()) }
+    ///     async fn metadata(&self, _: &Path) -> io::Result<u64> { Ok(0) }
+    /// }
+    /// ```
+    async fn open_random_access(&self, path: &Path) -> io::Result<Box<dyn RandomAccessFile>>;
     async fn create_dir(&self, path: &str) -> io::Result<()>;
     async fn write_file(&self, path: &str, content: &[u8]) -> io::Result<()>;
     async fn read_dir(&self, path: &str) -> io::Result<Vec<FileSystemEntry>>;
@@ -64,6 +77,12 @@ pub struct RealFileSystem;
 
 #[async_trait::async_trait]
 impl FileSystem for RealFileSystem {
+    async fn open_random_access(&self, path: &Path) -> io::Result<Box<dyn RandomAccessFile>> {
+        Ok(Box::new(RealRandomAccessFile(
+            tokio::fs::File::open(path).await?,
+        )))
+    }
+
     async fn create_dir(&self, path: &str) -> io::Result<()> {
         tokio::fs::create_dir(path).await
     }
@@ -102,5 +121,28 @@ impl FileSystem for RealFileSystem {
 
     async fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
         tokio::fs::remove_dir_all(path).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mock_random_access_file_supports_exact_offset_reads() {
+        let mut file = MockRandomAccessFile::new();
+        file.expect_file_len().times(1).returning(|| Ok(6));
+        file.expect_read_exact_at()
+            .withf(|offset, buffer| *offset == 2 && buffer.len() == 3)
+            .times(1)
+            .returning(|_, buffer| {
+                buffer.copy_from_slice(b"cde");
+                Ok(())
+            });
+        let mut file: Box<dyn RandomAccessFile> = Box::new(file);
+        assert_eq!(file.file_len().await.unwrap(), 6);
+        let mut buffer = [0; 3];
+        file.read_exact_at(2, &mut buffer).await.unwrap();
+        assert_eq!(&buffer, b"cde");
     }
 }

--- a/src/common/fs.rs
+++ b/src/common/fs.rs
@@ -1,5 +1,28 @@
 use futures::io;
 use std::path::{Path, PathBuf};
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+/// One open handle for header walks and selected frame reads. No read-ahead.
+#[async_trait::async_trait]
+pub trait RandomAccessFile: Send + Sync {
+    async fn file_len(&self) -> io::Result<u64>;
+    async fn read_exact_at(&mut self, offset: u64, buffer: &mut [u8]) -> io::Result<()>;
+}
+
+struct RealRandomAccessFile(tokio::fs::File);
+
+#[async_trait::async_trait]
+impl RandomAccessFile for RealRandomAccessFile {
+    async fn file_len(&self) -> io::Result<u64> {
+        Ok(self.0.metadata().await?.len())
+    }
+
+    async fn read_exact_at(&mut self, offset: u64, buffer: &mut [u8]) -> io::Result<()> {
+        self.0.seek(std::io::SeekFrom::Start(offset)).await?;
+        self.0.read_exact(buffer).await?;
+        Ok(())
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FileSystemEntry {
@@ -10,6 +33,13 @@ pub struct FileSystemEntry {
 #[mockall::automock]
 #[async_trait::async_trait]
 pub trait FileSystem {
+    /// Open once per scan, then seek past unrelated frame bodies (#221).
+    /// Default preserves compatibility with existing filesystem implementations.
+    async fn open_random_access(&self, path: &Path) -> io::Result<Box<dyn RandomAccessFile>> {
+        Ok(Box::new(RealRandomAccessFile(
+            tokio::fs::File::open(path).await?,
+        )))
+    }
     async fn create_dir(&self, path: &str) -> io::Result<()>;
     async fn write_file(&self, path: &str, content: &[u8]) -> io::Result<()>;
     async fn read_dir(&self, path: &str) -> io::Result<Vec<FileSystemEntry>>;

--- a/src/engine/actions/ddl/alter_database.rs
+++ b/src/engine/actions/ddl/alter_database.rs
@@ -37,6 +37,7 @@ impl DBEngine {
                     from_path.push(from_database_name);
                     to_path.push(to_database_name.clone());
 
+                    let _storage_guard = self.row_storage_lock.lock().await;
                     // 디렉터리명 변경
                     let result = tokio::fs::rename(&from_path, &to_path).await;
 
@@ -52,6 +53,12 @@ impl DBEngine {
                             }
                         }
                     }
+
+                    // Invalidate after the physical move, even if config rewriting fails.
+                    let mut pool = self.row_buffer_pool.lock().await;
+                    pool.invalidate_directory_under(&from_path);
+                    pool.invalidate_directory_under(&to_path);
+                    drop(pool);
 
                     // config data 파일 내용 변경
                     let mut config_path = to_path.clone();

--- a/src/engine/actions/ddl/alter_table.rs
+++ b/src/engine/actions/ddl/alter_table.rs
@@ -41,6 +41,7 @@ impl DBEngine {
                 )?;
                 let change_path = database_path.clone().join(&change_name);
 
+                let _storage_guard = self.row_storage_lock.lock().await;
                 // table 디렉터리명 변경
                 if let Err(error) = tokio::fs::rename(&table_path, &change_path).await {
                     return Err(ExecuteError::wrap(format!(
@@ -48,6 +49,11 @@ impl DBEngine {
                         error
                     )));
                 }
+
+                let mut pool = self.row_buffer_pool.lock().await;
+                pool.invalidate_directory_under(&table_path);
+                pool.invalidate_directory_under(&change_path);
+                drop(pool);
 
                 // config data 파일 내용 변경
                 let config_path = change_path.clone().join("table.config");

--- a/src/engine/actions/ddl/drop_database.rs
+++ b/src/engine/actions/ddl/drop_database.rs
@@ -23,6 +23,7 @@ impl DBEngine {
 
         // 인덱스 메모리 상태 및 통계 정리 (인덱스 파일은 데이터베이스 디렉토리와 함께 삭제됨)
         self.ensure_indices_loaded().await?;
+        let _storage_guard = self.row_storage_lock.lock().await;
         self.index_manager
             .remove_database_indices(&database_name)
             .await;
@@ -30,7 +31,7 @@ impl DBEngine {
             .invalidate_database(&database_name)
             .await;
 
-        if let Err(error) = tokio::fs::remove_dir_all(database_path.clone()).await {
+        if let Err(error) = self.file_system.remove_dir_all(&database_path).await {
             match error.kind() {
                 IOErrorKind::NotFound => {
                     if !query.if_exists {
@@ -42,6 +43,11 @@ impl DBEngine {
                 }
             }
         }
+
+        self.row_buffer_pool
+            .lock()
+            .await
+            .remove_under(&database_path);
 
         Ok(ExecuteResult::new(
             vec![ExecuteColumn {

--- a/src/engine/actions/ddl/drop_table.rs
+++ b/src/engine/actions/ddl/drop_table.rs
@@ -19,6 +19,7 @@ impl DBEngine {
 
         // 인덱스 메모리 상태 및 통계 정리 (인덱스 파일은 테이블 디렉토리와 함께 삭제됨)
         self.ensure_indices_loaded().await?;
+        let _storage_guard = self.row_storage_lock.lock().await;
         self.index_manager.remove_table_indices(&table).await;
         self.statistics_manager.invalidate(&table).await;
 
@@ -33,7 +34,7 @@ impl DBEngine {
             .join("tables")
             .join(&table_name);
 
-        if let Err(error) = tokio::fs::remove_dir_all(table_path).await {
+        if let Err(error) = self.file_system.remove_dir_all(&table_path).await {
             match error.kind() {
                 IOErrorKind::NotFound => {
                     if !query.if_exists {
@@ -45,6 +46,8 @@ impl DBEngine {
                 }
             }
         }
+
+        self.row_buffer_pool.lock().await.remove_under(&table_path);
 
         Ok(ExecuteResult::new(
             vec![ExecuteColumn {

--- a/src/engine/actions/dml/scan.rs
+++ b/src/engine/actions/dml/scan.rs
@@ -2,6 +2,9 @@ use std::collections::{HashMap, HashSet};
 use std::io::ErrorKind as IOErrorKind;
 use std::path::{Path, PathBuf};
 
+use crate::common::fs::RandomAccessFile;
+use crate::engine::row_offsets::{FRAME_HEADER_LEN, FrameDirectory, FrameOffset};
+use bincode::Options;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 
@@ -426,6 +429,15 @@ impl DBEngine {
         write: &RowBufferWrite,
         durable: bool,
     ) -> errors::Result<()> {
+        // Invalidate BEFORE destructive I/O; a partial rewrite cannot leave
+        // stale offsets usable. Appends retain their directory only if its
+        // physical base still agrees, then complete_write extends new frames.
+        if write.replace_existing {
+            self.row_buffer_pool
+                .lock()
+                .await
+                .invalidate_directory(&write.segment_path);
+        }
         let existing_len = if write.replace_existing {
             0
         } else {
@@ -435,6 +447,16 @@ impl DBEngine {
                 Err(error) => return Err(ExecuteError::wrap(error.to_string())),
             }
         };
+
+        {
+            let mut pool = self.row_buffer_pool.lock().await;
+            if pool
+                .directory(&write.segment_path)
+                .is_some_and(|directory| directory.file_len != existing_len)
+            {
+                pool.invalidate_directory(&write.segment_path);
+            }
+        }
 
         if let Some(parent) = write.segment_path.parent() {
             tokio::fs::create_dir_all(parent)
@@ -576,6 +598,126 @@ impl DBEngine {
             .map_err(|error| ExecuteError::wrap(error.to_string()))
     }
 
+    /// Called only under row_storage_lock. Walk headers with ONE handle and
+    /// skip bodies. No partially built directory is published on failure.
+    async fn ensure_frame_directory(
+        &self,
+        path: &Path,
+        file: &mut dyn RandomAccessFile,
+    ) -> errors::Result<()> {
+        let file_len = file
+            .file_len()
+            .await
+            .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+        let expected_count = {
+            let mut pool = self.row_buffer_pool.lock().await;
+            if pool
+                .directory(path)
+                .is_some_and(|directory| directory.file_len == file_len)
+            {
+                return Ok(());
+            }
+            // Evict before building: retained + building capacities stay bounded.
+            pool.evict_directory();
+            pool.persisted_row_count(path)
+        };
+        let tracker = self.query_memory().await;
+        let mut directory = FrameDirectory::default();
+        let mut offset = 0;
+        while offset < file_len {
+            if file_len - offset < FRAME_HEADER_LEN {
+                return Err(ExecuteError::wrap("truncated row segment frame header"));
+            }
+            let mut header = [0; 5];
+            file.read_exact_at(offset, &mut header)
+                .await
+                .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+            let frame = FrameOffset::from_header(header, offset, file_len)?;
+            offset = frame.end();
+            directory.push(frame, tracker.as_deref())?;
+        }
+        if expected_count.is_some_and(|count| count != directory.row_count) {
+            // In particular do not reinterpret a failed append's uncommitted
+            // physical suffix as additional logical rows alongside pending rows.
+            return Err(ExecuteError::wrap(
+                "row segment does not match committed row count",
+            ));
+        }
+        self.row_buffer_pool
+            .lock()
+            .await
+            .cache_directory(path.to_path_buf(), directory);
+        Ok(())
+    }
+
+    /// Above the cache cap, walk only the uncached suffix. The bounded cache
+    /// must never turn a large otherwise-readable table into a storage error.
+    async fn selected_frame(
+        &self,
+        path: &Path,
+        row_index: usize,
+        file: &mut dyn RandomAccessFile,
+    ) -> errors::Result<Option<FrameOffset>> {
+        let (mut index, mut offset, file_len) = {
+            let pool = self.row_buffer_pool.lock().await;
+            let Some(directory) = pool.directory(path) else {
+                return Ok(None);
+            };
+            if row_index >= directory.row_count {
+                return Ok(None);
+            }
+            if let Some(frame) = directory.frames.get(row_index) {
+                return Ok(Some(*frame));
+            }
+            (
+                directory.frames.len(),
+                directory.frames.last().map_or(0, |frame| frame.end()),
+                directory.file_len,
+            )
+        };
+        loop {
+            let mut header = [0; 5];
+            file.read_exact_at(offset, &mut header)
+                .await
+                .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+            let frame = FrameOffset::from_header(header, offset, file_len)?;
+            if index == row_index {
+                return Ok(Some(frame));
+            }
+            offset = frame.end();
+            index += 1;
+        }
+    }
+
+    /// Live-row count for cold optimizer statistics without decoding row bodies.
+    pub(crate) async fn row_count_for_statistics(
+        &self,
+        table: &TableName,
+    ) -> errors::Result<usize> {
+        let _guard = self.row_storage_lock.lock().await;
+        let path = self.row_segment_path(table)?;
+        if let Some(count) = self
+            .row_buffer_pool
+            .lock()
+            .await
+            .cached_live_row_count(&path)
+        {
+            return Ok(count);
+        }
+        match self.file_system.open_random_access(&path).await {
+            Ok(mut file) => self.ensure_frame_directory(&path, file.as_mut()).await?,
+            Err(error) if error.kind() == IOErrorKind::NotFound => {
+                return Ok(self.row_buffer_pool.lock().await.pending_row_count(&path));
+            }
+            Err(error) => return Err(ExecuteError::wrap(error.to_string())),
+        }
+        let pool = self.row_buffer_pool.lock().await;
+        Ok(pool
+            .directory(&path)
+            .map_or(0, |directory| directory.live_count)
+            + pool.pending_row_count(&path))
+    }
+
     /// 인덱스 스캔: 인덱스에서 row index 목록을 조회한 뒤 해당 행만 반환합니다.
     pub(crate) async fn index_scan(
         &self,
@@ -605,19 +747,18 @@ impl DBEngine {
 
         let _guard = self.row_storage_lock.lock().await;
         let segment_path = self.row_segment_path(&table_name)?;
-        let cached_rows = { self.row_buffer_pool.lock().await.cached_rows(&segment_path) };
-        let all_rows = match cached_rows {
-            Some(rows) => rows,
-            None => {
-                let disk_rows = self.read_segment_rows(&segment_path).await?;
-                self.row_buffer_pool
-                    .lock()
-                    .await
-                    .read_rows(segment_path, || disk_rows)
-            }
-        };
-
-        let mut result = Vec::with_capacity(row_paths.len());
+        let tracker = self.query_memory().await;
+        if let Some(tracker) = &tracker {
+            tracker.reserve(
+                (row_paths.len() as u64)
+                    .saturating_mul(size_of::<(RowLocation, TableDataRow)>() as u64),
+            )?;
+        }
+        let mut result = Vec::new();
+        result.try_reserve_exact(row_paths.len()).map_err(|error| {
+            ExecuteError::wrap(format!("row result allocation failed: {error}"))
+        })?;
+        let mut reader: Option<Box<dyn RandomAccessFile>> = None;
 
         for row_path in row_paths {
             let row_index = row_path.parse::<usize>().map_err(|_| {
@@ -627,26 +768,93 @@ impl DBEngine {
                 ))
             })?;
 
-            match all_rows.get(row_index) {
-                Some(Some(row)) => {
-                    // 메모리 예산 추적 (#265): 결과 행이 앱드될 때마다 크기를 reserve.
-                    if let Some(tracker) = self.query_memory().await {
-                        tracker.reserve(row.estimated_bytes() + ESTIMATED_FIELD_OVERHEAD)?;
+            let cached = {
+                let pool = self.row_buffer_pool.lock().await;
+                match pool.cached_row(&segment_path, row_index) {
+                    Some(Some(row)) => {
+                        if let Some(tracker) = &tracker {
+                            tracker.reserve(row.estimated_bytes() + ESTIMATED_FIELD_OVERHEAD)?;
+                        }
+                        Some(Some(row.clone()))
                     }
-                    result.push((RowLocation { row_index }, row.clone()));
+                    Some(None) => Some(None),
+                    None => None,
                 }
-                Some(None) | None => {
-                    return Err(ExecuteError::wrap(format!(
-                        "index '{}' is out of sync with table data; drop and recreate the index",
-                        plan.index_name
-                    )));
+            };
+            let row = match cached {
+                Some(row) => row,
+                None => {
+                    if reader.is_none() {
+                        reader = match self.file_system.open_random_access(&segment_path).await {
+                            Ok(mut file) => {
+                                self.ensure_frame_directory(&segment_path, file.as_mut())
+                                    .await?;
+                                Some(file)
+                            }
+                            Err(error) if error.kind() == IOErrorKind::NotFound => None,
+                            Err(error) => return Err(ExecuteError::wrap(error.to_string())),
+                        };
+                    }
+                    let frame = if let Some(file) = reader.as_mut() {
+                        self.selected_frame(&segment_path, row_index, file.as_mut())
+                            .await?
+                    } else {
+                        None
+                    };
+                    match (frame, reader.as_mut()) {
+                        (Some(frame), Some(file)) if frame.live => {
+                            // Bounds were checked against this handle's length while
+                            // the storage lock was held. Reserve before allocation and
+                            // decoding, including conservative decoded field overhead.
+                            if let Some(tracker) = &tracker {
+                                tracker.reserve(
+                                    u64::from(frame.len).saturating_mul(8)
+                                        + size_of::<TableDataRow>() as u64,
+                                )?;
+                            }
+                            let mut body = Vec::new();
+                            body.try_reserve_exact(frame.len as usize)
+                                .map_err(|error| {
+                                    ExecuteError::wrap(format!(
+                                        "row frame allocation failed: {error}"
+                                    ))
+                                })?;
+                            body.resize(frame.len as usize, 0);
+                            file.read_exact_at(frame.body, &mut body)
+                                .await
+                                .map_err(|error| ExecuteError::wrap(error.to_string()))?;
+                            let row = bincode::DefaultOptions::new()
+                                .with_fixint_encoding()
+                                .allow_trailing_bytes()
+                                .with_limit(u64::from(frame.len))
+                                .deserialize::<TableDataRow>(&body)
+                                .map_err(|error| {
+                                    ExecuteError::wrap(format!(
+                                        "invalid row segment frame: {error}"
+                                    ))
+                                })?;
+                            Some(row)
+                        }
+                        _ => None,
+                    }
                 }
-            }
+            };
+            let row = row.ok_or_else(|| {
+                ExecuteError::wrap(format!(
+                    "index '{}' is out of sync with table data; drop and recreate the index",
+                    plan.index_name
+                ))
+            })?;
+            result.push((RowLocation { row_index }, row));
         }
 
         Ok(result)
     }
 }
+
+#[cfg(test)]
+#[path = "scan_offset_tests.rs"]
+mod offset_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/engine/actions/dml/scan_offset_integration.rs
+++ b/src/engine/actions/dml/scan_offset_integration.rs
@@ -257,9 +257,22 @@ async fn offset_physical_rename_forgets_old_namespace_even_if_config_update_fail
             .await
             .unwrap();
         let old_path = engine.row_segment_path(&table()).unwrap();
+        // The PK index holds open files inside the directory. Windows cannot
+        // rename a directory with open children; index-handle retargeting is an
+        // existing DDL limitation, outside this offset-invalidation regression.
+        engine.index_manager.remove_table_indices(&table()).await;
+        assert!(
+            engine
+                .row_buffer_pool
+                .lock()
+                .await
+                .directory(&old_path)
+                .is_some(),
+            "releasing index handles must leave the offset directory warm"
+        );
         // Table rename has an existing post-rename config lookup defect. Only
         // verify this change's namespace boundary, not that unrelated DDL behavior.
-        let _ = sql(
+        let rename_result = sql(
             &engine,
             wal,
             if database {
@@ -271,7 +284,7 @@ async fn offset_physical_rename_forgets_old_namespace_even_if_config_update_fail
         .await;
         assert!(
             !old_path.exists(),
-            "physical rename must actually have occurred"
+            "physical rename must actually have occurred (database={database}): {rename_result:?}"
         );
         assert!(
             engine

--- a/src/engine/actions/dml/scan_offset_integration.rs
+++ b/src/engine/actions/dml/scan_offset_integration.rs
@@ -1,0 +1,431 @@
+use super::*;
+use crate::engine::SharedWALManager;
+use crate::engine::parser::predule::{Parser, ParserContext};
+use crate::engine::types::ExecuteResult;
+use crate::engine::wal::endec::implements::bincode::{BincodeDecoder, BincodeEncoder};
+use crate::engine::wal::manager::builder::WALBuilder;
+
+async fn sql(engine: &DBEngine, wal: SharedWALManager, sql: &str) -> errors::Result<ExecuteResult> {
+    let statement = Parser::with_string(sql.to_string())?
+        .parse(ParserContext::default().set_default_database("rrdb".into()))?
+        .remove(0);
+    engine
+        .process_query(statement, wal, "offset-test".into())
+        .await
+}
+async fn sql_engine(label: &str) -> (DBEngine, SharedWALManager) {
+    let base =
+        PathBuf::from("target/test_row_offsets").join(format!("{label}-{}", uuid::Uuid::new_v4()));
+    let config = LaunchConfig::default_for_base_path(base);
+    tokio::fs::create_dir_all(&config.data_directory)
+        .await
+        .unwrap();
+    tokio::fs::create_dir_all(&config.wal_directory)
+        .await
+        .unwrap();
+    let wal = Arc::new(tokio::sync::Mutex::new(
+        WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .unwrap(),
+    ));
+    let engine = DBEngine::new(config);
+    sql(&engine, wal.clone(), "create database rrdb;")
+        .await
+        .unwrap();
+    sql(
+        &engine,
+        wal.clone(),
+        "create table offsets (id integer primary key, value varchar(4096));",
+    )
+    .await
+    .unwrap();
+    (engine, wal)
+}
+
+#[tokio::test]
+async fn offset_cold_sql_statistics_do_not_decode_or_read_unselected_bodies() {
+    let (engine, wal) = sql_engine("cold-sql").await;
+    let data = (0..1000)
+        .map(|id| format!("({id}, '{}')", "x".repeat(1024)))
+        .collect::<Vec<_>>()
+        .join(",");
+    sql(
+        &engine,
+        wal.clone(),
+        &format!("insert into offsets (id, value) values {data};"),
+    )
+    .await
+    .unwrap();
+    engine.flush_row_buffers_durable().await.unwrap();
+    let mut config = (*engine.config).clone();
+    config.max_query_memory_bytes = 64 * 1024;
+    assert!(
+        std::fs::metadata(engine.row_segment_path(&table()).unwrap())
+            .unwrap()
+            .len()
+            > config.max_query_memory_bytes
+    );
+    let mut reopened = DBEngine::new(config);
+    let counts = instrument(&mut reopened);
+    let selected = sql(&reopened, wal, "select id from offsets where id = 999;")
+        .await
+        .unwrap();
+    assert_eq!(selected.rows.len(), 1);
+    let io = take(&counts);
+    assert_eq!(io.reads.iter().filter(|(_, len)| *len == 5).count(), 1000);
+    assert_eq!(io.reads.iter().filter(|(_, len)| *len > 5).count(), 1);
+    assert_eq!(
+        io.opens, 2,
+        "one statistics handle and one selected-row handle"
+    );
+    assert!(
+        reopened
+            .row_buffer_pool
+            .lock()
+            .await
+            .cached_rows(&reopened.row_segment_path(&table()).unwrap())
+            .is_none()
+    );
+    cleanup(&engine).await;
+}
+
+#[tokio::test]
+async fn offset_wal_recovery_rebuilds_indexed_reads() {
+    let (engine, wal) = sql_engine("recovery").await;
+    sql(
+        &engine,
+        wal.clone(),
+        "insert into offsets (id, value) values (1, 'old'), (2, 'remove');",
+    )
+    .await
+    .unwrap();
+    engine.flush_row_buffers_durable().await.unwrap();
+    wal.lock().await.flush().await.unwrap();
+    // Crash after WAL durability but BEFORE applying rows/index changes.
+    // Replaying a fully applied SQL tail with already-written unique-index
+    // pages is a known baseline failure, outside the direct-offset contract.
+    use crate::engine::ast::{DMLStatement, SQLStatement};
+    use crate::engine::parser::predule::{Parser, ParserContext};
+    use crate::engine::wal::types::{EntryType, InsertWALPayload};
+    for statement in [
+        "insert into offsets (id, value) values (3, 'replayed');".to_string(),
+        "update offsets set value = 'a much longer recovered value' where id = 1;".to_string(),
+        "delete from offsets where id = 2;".to_string(),
+    ] {
+        let statement = Parser::with_string(statement)
+            .unwrap()
+            .parse(ParserContext::default().set_default_database("rrdb".into()))
+            .unwrap()
+            .remove(0);
+        let (kind, payload) = match statement {
+            SQLStatement::DML(DMLStatement::InsertQuery(query)) => (
+                EntryType::Insert,
+                bincode::serialize(&InsertWALPayload {
+                    query,
+                    start_row_index: 2,
+                    row_count: 1,
+                })
+                .unwrap(),
+            ),
+            SQLStatement::DML(DMLStatement::UpdateQuery(query)) => {
+                (EntryType::Set, bincode::serialize(&query).unwrap())
+            }
+            SQLStatement::DML(DMLStatement::DeleteQuery(query)) => {
+                (EntryType::Delete, bincode::serialize(&query).unwrap())
+            }
+            other => panic!("unexpected replay statement: {other:?}"),
+        };
+        wal.lock()
+            .await
+            .append_record(kind, Some(payload), None)
+            .await
+            .unwrap();
+    }
+    wal.lock().await.sync().await.unwrap();
+    let config = (*engine.config).clone();
+    drop(engine); // buffered rows intentionally lost, WAL retained
+    drop(wal);
+    let recovered = DBEngine::new(config.clone());
+    let mut wal = WALBuilder::new(&config)
+        .build(BincodeDecoder::new(), BincodeEncoder::new())
+        .await
+        .unwrap();
+    assert!(!wal.pending_entries().is_empty());
+    recovered.recover_from_wal(&mut wal).await.unwrap();
+    let reopened = DBEngine::new(config);
+    let range = IndexScanPlan {
+        index_name: "rrdb.offsets_pkey".into(),
+        column_name: "id".into(),
+        eq_key: None,
+        start_key: None,
+        end_key: None,
+    };
+    let rows = reopened.index_scan(table(), &range).await.unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(
+        rows.iter()
+            .map(|(_, row)| row.fields[0].data.clone())
+            .collect::<Vec<_>>(),
+        vec![
+            TableDataFieldType::Integer(1),
+            TableDataFieldType::Integer(3)
+        ]
+    );
+    assert_eq!(
+        rows[0].1.fields[1].data,
+        TableDataFieldType::String("a much longer recovered value".into())
+    );
+    assert_eq!(rows[1].0.row_index, 2, "tombstone retains logical slot");
+    cleanup(&reopened).await;
+}
+
+#[tokio::test]
+async fn offset_uncached_suffix_fallback_preserves_order_and_statistics() {
+    let mut engine = engine("suffix").await;
+    let counts = instrument(&mut engine);
+    engine
+        .append_table_rows(
+            &table(),
+            &(0..5).map(|id| row(&id.to_string())).collect::<Vec<_>>(),
+        )
+        .await
+        .unwrap();
+    engine.flush_row_buffers().await.unwrap();
+    pointer(&engine, "a", "4").await;
+    pointer(&engine, "b", "2").await;
+    engine.index_scan(table(), &plan(Some("a"))).await.unwrap();
+    let path = engine.row_segment_path(&table()).unwrap();
+    // Same cache shape as a real cap crossing, without a million I/O calls.
+    let mut directory = FrameDirectory::default();
+    for id in 0..5 {
+        directory
+            .extend(&encode_row_frames(&[Some(row(&id.to_string()))]).unwrap())
+            .unwrap();
+    }
+    directory.frames.truncate(2);
+    engine
+        .row_buffer_pool
+        .lock()
+        .await
+        .cache_directory(path, directory);
+    take(&counts);
+    assert_eq!(
+        values(engine.index_scan(table(), &plan(None)).await.unwrap()),
+        vec![(4, "4".into()), (2, "2".into())]
+    );
+    assert_eq!(
+        take(&counts)
+            .reads
+            .iter()
+            .filter(|(_, len)| *len == 5)
+            .count(),
+        4
+    );
+    assert_eq!(
+        engine.table_statistics(&table()).await.unwrap().row_count,
+        5
+    );
+    engine
+        .append_table_rows(&table(), &[row("5")])
+        .await
+        .unwrap();
+    engine.flush_row_buffers().await.unwrap();
+    pointer(&engine, "c", "5").await;
+    assert_eq!(
+        values(engine.index_scan(table(), &plan(Some("c"))).await.unwrap()),
+        vec![(5, "5".into())]
+    );
+    cleanup(&engine).await;
+}
+
+#[tokio::test]
+async fn offset_physical_rename_forgets_old_namespace_even_if_config_update_fails() {
+    for database in [false, true] {
+        let (engine, wal) = sql_engine("rename").await;
+        sql(
+            &engine,
+            wal.clone(),
+            "insert into offsets (id, value) values (1, 'old');",
+        )
+        .await
+        .unwrap();
+        engine.flush_row_buffers().await.unwrap();
+        engine.row_count_for_statistics(&table()).await.unwrap();
+        engine
+            .append_table_rows(&table(), &[row("pending")])
+            .await
+            .unwrap();
+        let old_path = engine.row_segment_path(&table()).unwrap();
+        // Table rename has an existing post-rename config lookup defect. Only
+        // verify this change's namespace boundary, not that unrelated DDL behavior.
+        let _ = sql(
+            &engine,
+            wal,
+            if database {
+                "alter database rrdb rename to moved;"
+            } else {
+                "alter table offsets rename to moved;"
+            },
+        )
+        .await;
+        assert!(
+            !old_path.exists(),
+            "physical rename must actually have occurred"
+        );
+        assert!(
+            engine
+                .row_buffer_pool
+                .lock()
+                .await
+                .directory(&old_path)
+                .is_none()
+        );
+        // Do not assert pending-row retargeting or the existing table-config
+        // rename behavior: those baseline issues are not changed by this PR.
+        cleanup(&engine).await;
+    }
+}
+
+#[tokio::test]
+async fn offset_failed_rename_retains_directory() {
+    for database in [false, true] {
+        let (engine, wal) = sql_engine("rename-failure").await;
+        sql(
+            &engine,
+            wal.clone(),
+            "insert into offsets (id, value) values (1, 'disk');",
+        )
+        .await
+        .unwrap();
+        engine.flush_row_buffers().await.unwrap();
+        engine.row_count_for_statistics(&table()).await.unwrap();
+        let old_path = engine.row_segment_path(&table()).unwrap();
+        let destination = if database {
+            engine.get_data_directory().join("moved")
+        } else {
+            engine.get_data_directory().join("rrdb/moved")
+        };
+        tokio::fs::write(&destination, b"blocks rename")
+            .await
+            .unwrap();
+        let query = if database {
+            "alter database rrdb rename to moved;"
+        } else {
+            "alter table offsets rename to moved;"
+        };
+        assert!(sql(&engine, wal, query).await.is_err());
+        assert!(
+            engine
+                .row_buffer_pool
+                .lock()
+                .await
+                .directory(&old_path)
+                .is_some()
+        );
+        assert!(old_path.exists());
+        cleanup(&engine).await;
+    }
+}
+
+#[test]
+fn offset_namespace_invalidation_is_component_aware() {
+    use crate::engine::row_offsets::FrameDirectory;
+    let mut pool = RowBufferPool::default();
+    let path = std::path::PathBuf::from("data/db_extra/tables/t/rows/00000001.rows");
+    pool.cache_directory(path.clone(), FrameDirectory::default());
+    pool.invalidate_directory_under(std::path::Path::new("data/db"));
+    assert!(pool.directory(&path).is_some());
+    pool.invalidate_directory_under(std::path::Path::new("data/db_extra"));
+    assert!(pool.directory(&path).is_none());
+}
+
+/// Run: cargo test --release --lib offset_read_benchmark -- --ignored --nocapture
+/// Every "cold-directory" sample clears decoded rows and offsets, NOT OS pages.
+/// Warm index samples retain offsets, never a full decoded-row cache. Full scan
+/// samples include filtering identical row-index ranges after materialization.
+#[tokio::test]
+#[ignore = "release-mode I/O benchmark, not a timing assertion"]
+async fn offset_read_benchmark() {
+    use std::time::Instant;
+    for n in [1000, 10_000] {
+        let mut engine = engine("bench").await;
+        let counts = instrument(&mut engine);
+        let rows: Vec<_> = (0..n)
+            .map(|id| row(&format!("{id:05}:{}", "x".repeat(1024))))
+            .collect();
+        engine.append_table_rows(&table(), &rows).await.unwrap();
+        engine.flush_row_buffers_durable().await.unwrap();
+        let start = n / 2;
+        for id in start..start + 64 {
+            pointer(&engine, &format!("{id:05}"), &id.to_string()).await;
+        }
+        let point = plan(Some(&format!("{start:05}")));
+        let range = plan(None);
+        let bytes = std::fs::metadata(engine.row_segment_path(&table()).unwrap())
+            .unwrap()
+            .len();
+        println!("DATA rows={n} segment_bytes={bytes} range_matches=64 OS_CACHE=not_evicted");
+        for (name, repeats, cold, full, ranged) in [
+            ("full-cold-decoded-point", 3, true, true, false),
+            ("offset-cold-directory-point", 3, true, false, false),
+            ("offset-warm-point", 30, false, false, false),
+            ("offset-cold-directory-range", 3, true, false, true),
+            ("offset-warm-range", 10, false, false, true),
+            ("full-cold-decoded-range", 3, true, true, true),
+            ("full-warm-decoded-range", 10, false, true, true),
+        ] {
+            let mut elapsed = std::time::Duration::ZERO;
+            take(&counts);
+            for _ in 0..repeats {
+                if cold {
+                    *engine.row_buffer_pool.lock().await = RowBufferPool::default();
+                }
+                let timer = Instant::now();
+                let result = if full {
+                    engine
+                        .full_scan(table())
+                        .await
+                        .unwrap()
+                        .into_iter()
+                        .filter(|(location, _)| {
+                            if ranged {
+                                (start..start + 64).contains(&location.row_index)
+                            } else {
+                                location.row_index == start
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                } else {
+                    engine
+                        .index_scan(table(), if ranged { &range } else { &point })
+                        .await
+                        .unwrap()
+                };
+                elapsed += timer.elapsed();
+                assert_eq!(result.len(), if ranged { 64 } else { 1 });
+                for (location, data) in result {
+                    assert_eq!(data.fields, rows[location.row_index].fields);
+                }
+            }
+            let io = take(&counts);
+            // Full scans use tokio::fs::read directly, outside CountingFile.
+            // Report their expected bytes from file length + reset cache state,
+            // not a measured disk-I/O counter. Random read lengths are observed.
+            println!(
+                "BENCH n={n} mode={name} repeats={repeats} mean_us={:.1} random_opens={} headers={} body_reads={} random_requested_bytes={} full_segment_bytes_expected={}",
+                elapsed.as_secs_f64() * 1e6 / f64::from(repeats),
+                io.opens,
+                io.reads.iter().filter(|(_, len)| *len == 5).count(),
+                io.reads.iter().filter(|(_, len)| *len != 5).count(),
+                io.reads.iter().map(|(_, len)| *len).sum::<usize>(),
+                if full && cold {
+                    bytes * repeats as u64
+                } else {
+                    0
+                }
+            );
+        }
+        cleanup(&engine).await;
+    }
+}

--- a/src/engine/actions/dml/scan_offset_integration.rs
+++ b/src/engine/actions/dml/scan_offset_integration.rs
@@ -317,7 +317,7 @@ async fn offset_failed_rename_retains_directory() {
         let destination = if database {
             engine.get_data_directory().join("moved")
         } else {
-            engine.get_data_directory().join("rrdb/moved")
+            engine.get_data_directory().join("rrdb").join("moved")
         };
         tokio::fs::write(&destination, b"blocks rename")
             .await

--- a/src/engine/actions/dml/scan_offset_io.rs
+++ b/src/engine/actions/dml/scan_offset_io.rs
@@ -1,0 +1,436 @@
+#[path = "scan_offset_integration.rs"]
+mod integration;
+use super::*;
+use crate::common::fs::{FileSystem, FileSystemEntry, RandomAccessFile, RealFileSystem};
+use crate::engine::QUERY_MEMORY_TRACKER;
+use crate::engine::query_memory::{QueryMemoryTracker, QueryMemoryTrackerRef};
+use crate::engine::row_buffer::RowBufferPool;
+use std::sync::{Arc, Mutex as StdMutex};
+
+#[derive(Default, Debug, Clone)]
+struct IoCounts {
+    opens: usize,
+    reads: Vec<(u64, usize)>,
+}
+struct CountingFs(Arc<StdMutex<IoCounts>>);
+struct CountingFile {
+    inner: Box<dyn RandomAccessFile>,
+    counts: Arc<StdMutex<IoCounts>>,
+}
+#[async_trait::async_trait]
+impl RandomAccessFile for CountingFile {
+    async fn file_len(&self) -> std::io::Result<u64> {
+        self.inner.file_len().await
+    }
+    async fn read_exact_at(&mut self, offset: u64, buffer: &mut [u8]) -> std::io::Result<()> {
+        self.counts
+            .lock()
+            .unwrap()
+            .reads
+            .push((offset, buffer.len()));
+        self.inner.read_exact_at(offset, buffer).await
+    }
+}
+#[async_trait::async_trait]
+impl FileSystem for CountingFs {
+    async fn open_random_access(&self, path: &Path) -> std::io::Result<Box<dyn RandomAccessFile>> {
+        self.0.lock().unwrap().opens += 1;
+        Ok(Box::new(CountingFile {
+            inner: RealFileSystem.open_random_access(path).await?,
+            counts: self.0.clone(),
+        }))
+    }
+    async fn create_dir(&self, path: &str) -> std::io::Result<()> {
+        RealFileSystem.create_dir(path).await
+    }
+    async fn write_file(&self, path: &str, content: &[u8]) -> std::io::Result<()> {
+        RealFileSystem.write_file(path, content).await
+    }
+    async fn read_dir(&self, path: &str) -> std::io::Result<Vec<FileSystemEntry>> {
+        RealFileSystem.read_dir(path).await
+    }
+    async fn read(&self, path: &Path) -> std::io::Result<Vec<u8>> {
+        RealFileSystem.read(path).await
+    }
+    async fn metadata(&self, path: &Path) -> std::io::Result<u64> {
+        RealFileSystem.metadata(path).await
+    }
+    async fn truncate(&self, path: &Path, len: u64) -> std::io::Result<()> {
+        RealFileSystem.truncate(path, len).await
+    }
+}
+
+fn instrument(engine: &mut DBEngine) -> Arc<StdMutex<IoCounts>> {
+    let counts = Arc::new(StdMutex::new(IoCounts::default()));
+    engine.file_system = Arc::new(CountingFs(counts.clone()));
+    counts
+}
+fn take(counts: &Arc<StdMutex<IoCounts>>) -> IoCounts {
+    std::mem::take(&mut *counts.lock().unwrap())
+}
+async fn budget<T>(limit: u64, task: impl std::future::Future<Output = T>) -> T {
+    let tracker = Arc::new(QueryMemoryTracker::new(limit));
+    let handle = QueryMemoryTrackerRef(Some(std::ptr::NonNull::from(tracker.as_ref())));
+    QUERY_MEMORY_TRACKER.scope(handle, task).await
+}
+
+#[tokio::test]
+async fn offset_io_is_headers_then_only_selected_bodies_and_incremental_appends() {
+    let mut engine = engine("io").await;
+    let counts = instrument(&mut engine);
+    let rows: Vec<_> = (0..100)
+        .map(|id| row(&format!("{id}:{}", "x".repeat(1000))))
+        .collect();
+    engine.append_table_rows(&table(), &rows).await.unwrap();
+    engine.flush_row_buffers().await.unwrap();
+    pointer(&engine, "a", "99").await;
+    pointer(&engine, "b", "0").await;
+    let result = engine.index_scan(table(), &plan(Some("a"))).await.unwrap();
+    assert_eq!(result[0].1.fields, rows[99].fields);
+    let cold = take(&counts);
+    assert_eq!(cold.opens, 1);
+    assert_eq!(cold.reads.iter().filter(|(_, len)| *len == 5).count(), 100);
+    assert_eq!(cold.reads.len(), 101);
+    assert!(
+        engine
+            .row_buffer_pool
+            .lock()
+            .await
+            .cached_rows(&engine.row_segment_path(&table()).unwrap())
+            .is_none()
+    );
+    engine.index_scan(table(), &plan(None)).await.unwrap();
+    let hot = take(&counts);
+    assert_eq!(hot.opens, 1);
+    assert_eq!(hot.reads.len(), 2);
+    assert!(hot.reads.iter().all(|(_, len)| *len > 5));
+    for id in 100..120 {
+        engine
+            .append_table_rows(&table(), &[row(&id.to_string())])
+            .await
+            .unwrap();
+        engine.flush_row_buffers().await.unwrap();
+        pointer(&engine, &id.to_string(), &id.to_string()).await;
+        assert_eq!(
+            values(
+                engine
+                    .index_scan(table(), &plan(Some(&id.to_string())))
+                    .await
+                    .unwrap()
+            ),
+            vec![(id, id.to_string())]
+        );
+        let io = take(&counts);
+        assert_eq!(io.opens, 1);
+        assert_eq!(
+            io.reads.len(),
+            1,
+            "append flush must not rescan existing headers"
+        );
+    }
+    cleanup(&engine).await;
+}
+
+#[tokio::test]
+async fn offset_memory_budget_precedes_directory_body_and_cached_clone_allocations() {
+    let mut engine = engine("budget").await;
+    let counts = instrument(&mut engine);
+    engine
+        .append_table_rows(&table(), &[row("selected"), row(&"x".repeat(1_000_000))])
+        .await
+        .unwrap();
+    engine.flush_row_buffers().await.unwrap();
+    pointer(&engine, "a", "0").await;
+    // Refuses directory allocation while only one five-byte header has been read.
+    let error = budget(100, engine.index_scan(table(), &plan(Some("a"))))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("memory limit exceeded"));
+    assert!(take(&counts).reads.iter().all(|(_, len)| *len == 5));
+    assert_eq!(
+        values(
+            budget(10_000, engine.index_scan(table(), &plan(Some("a"))))
+                .await
+                .unwrap()
+        ),
+        vec![(0, "selected".into())]
+    );
+    take(&counts);
+    let error = budget(100, engine.index_scan(table(), &plan(Some("a"))))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("memory limit exceeded"));
+    assert!(
+        take(&counts).reads.is_empty(),
+        "reserve body budget before I/O/allocation"
+    );
+    engine.full_scan(table()).await.unwrap();
+    assert_eq!(
+        values(
+            budget(1000, engine.index_scan(table(), &plan(Some("a"))))
+                .await
+                .unwrap()
+        ),
+        vec![(0, "selected".into())]
+    );
+    assert!(
+        take(&counts).reads.is_empty(),
+        "clone only selected cached row, no disk access"
+    );
+    cleanup(&engine).await;
+}
+
+#[tokio::test]
+async fn offset_rewrite_growth_shrink_delete_append_and_reopen() {
+    let engine = engine("rewrite").await;
+    engine
+        .append_table_rows(&table(), &[row("zero"), row("one"), row("two")])
+        .await
+        .unwrap();
+    engine.flush_row_buffers().await.unwrap();
+    for id in 0..3 {
+        pointer(&engine, &id.to_string(), &id.to_string()).await;
+    }
+    engine.index_scan(table(), &plan(None)).await.unwrap();
+    for text in ["x".repeat(20_000), "s".into()] {
+        engine
+            .update_table_rows(&table(), HashMap::from([(0, row(&text))]))
+            .await
+            .unwrap();
+        // Dirty rows beat old on-disk offsets, with no forced flush.
+        assert_eq!(
+            values(engine.index_scan(table(), &plan(Some("0"))).await.unwrap()),
+            vec![(0, text.clone())]
+        );
+        engine.flush_row_buffers().await.unwrap();
+        assert!(
+            engine
+                .row_buffer_pool
+                .lock()
+                .await
+                .directory(&engine.row_segment_path(&table()).unwrap())
+                .is_none()
+        );
+        *engine.row_buffer_pool.lock().await = RowBufferPool::default();
+        assert_eq!(
+            values(engine.index_scan(table(), &plan(Some("2"))).await.unwrap()),
+            vec![(2, "two".into())]
+        );
+    }
+    engine
+        .delete_table_rows(&table(), HashSet::from([1]))
+        .await
+        .unwrap();
+    assert!(
+        engine
+            .index_scan(table(), &plan(Some("1")))
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("out of sync")
+    );
+    engine.flush_row_buffers().await.unwrap();
+    assert_eq!(
+        engine
+            .append_table_rows(&table(), &[row("three")])
+            .await
+            .unwrap(),
+        3
+    );
+    pointer(&engine, "3", "3").await;
+    engine.flush_row_buffers_durable().await.unwrap();
+    let reopened = DBEngine::new((*engine.config).clone());
+    assert_eq!(
+        values(
+            reopened
+                .index_scan(table(), &plan(Some("3")))
+                .await
+                .unwrap()
+        ),
+        vec![(3, "three".into())]
+    );
+    assert!(
+        reopened
+            .index_scan(table(), &plan(Some("1")))
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("out of sync")
+    );
+    assert_eq!(
+        reopened.table_statistics(&table()).await.unwrap().row_count,
+        3
+    );
+    cleanup(&engine).await;
+}
+
+#[tokio::test]
+async fn offset_bad_frames_and_stale_pointers_fail_without_panics() {
+    let mut engine = engine("malformed").await;
+    let counts = instrument(&mut engine);
+    pointer(&engine, "a", "0").await;
+    let path = engine.row_segment_path(&table()).unwrap();
+    for bytes in [
+        vec![0],
+        vec![0, 0xff, 0xff, 0xff, 0xff],
+        vec![0, 1, 0, 0, 0, 0xff],
+    ] {
+        *engine.row_buffer_pool.lock().await = RowBufferPool::default();
+        tokio::fs::write(&path, bytes).await.unwrap();
+        assert!(engine.index_scan(table(), &plan(Some("a"))).await.is_err());
+        assert!(take(&counts).reads.iter().all(|(_, len)| *len <= 5));
+    }
+    for marker in [1, 255] {
+        // preserve historical nonzero tombstone semantics
+        *engine.row_buffer_pool.lock().await = RowBufferPool::default();
+        tokio::fs::write(&path, [marker, 0, 0, 0, 0]).await.unwrap();
+        assert!(
+            engine
+                .index_scan(table(), &plan(Some("a")))
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("out of sync")
+        );
+    }
+    pointer(&engine, "invalid", "not-an-index").await;
+    pointer(&engine, "missing", "99999").await;
+    assert!(
+        engine
+            .index_scan(table(), &plan(Some("invalid")))
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("invalid row path")
+    );
+    assert!(
+        engine
+            .index_scan(table(), &plan(Some("missing")))
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("out of sync")
+    );
+    assert!(
+        engine
+            .index_scan(table(), &plan(Some("empty")))
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    cleanup(&engine).await;
+}
+
+#[tokio::test]
+async fn offset_drop_recreate_discards_all_row_state_and_not_prefix_siblings() {
+    use crate::engine::ast::ddl::drop_database::DropDatabaseQuery;
+    use crate::engine::ast::ddl::drop_table::DropTableQuery;
+    for database in [false, true] {
+        let engine = engine("drop").await;
+        engine
+            .append_table_rows(&table(), &[row("old")])
+            .await
+            .unwrap();
+        engine.flush_row_buffers().await.unwrap();
+        pointer(&engine, "a", "0").await;
+        engine.index_scan(table(), &plan(Some("a"))).await.unwrap();
+        engine
+            .append_table_rows(&table(), &[row("unflushed")])
+            .await
+            .unwrap();
+        let sibling = if database {
+            TableName::new(Some("rrdb_other".into()), "offsets".into())
+        } else {
+            TableName::new(Some("rrdb".into()), "offsets_other".into())
+        };
+        engine
+            .append_table_rows(&sibling, &[row("sibling")])
+            .await
+            .unwrap();
+        if database {
+            engine
+                .drop_database(DropDatabaseQuery::builder().set_name("rrdb".into()))
+                .await
+                .unwrap();
+        } else {
+            engine
+                .drop_table(DropTableQuery::builder().set_table(table()))
+                .await
+                .unwrap();
+        }
+        engine.flush_row_buffers_durable().await.unwrap();
+        assert!(
+            !engine.row_segment_path(&table()).unwrap().exists(),
+            "dropped buffer resurrected namespace"
+        );
+        assert_eq!(engine.full_scan(sibling).await.unwrap().len(), 1);
+        assert_eq!(
+            engine
+                .append_table_rows(&table(), &[row("new")])
+                .await
+                .unwrap(),
+            0
+        );
+        engine.flush_row_buffers().await.unwrap();
+        engine
+            .index_manager
+            .create_index(IndexMeta::new(
+                "rrdb.offset_idx".into(),
+                table(),
+                "value".into(),
+                false,
+            ))
+            .await
+            .unwrap();
+        pointer(&engine, "a", "0").await;
+        // Equal serialized length deliberately defeats length-only generation checks.
+        assert_eq!(
+            values(engine.index_scan(table(), &plan(Some("a"))).await.unwrap()),
+            vec![(0, "new".into())]
+        );
+        cleanup(&engine).await;
+    }
+}
+
+#[tokio::test]
+async fn offset_failed_rewrite_does_not_leave_stale_directory() {
+    let engine = engine("failed-rewrite").await;
+    engine
+        .append_table_rows(&table(), &[row("old"), row("other")])
+        .await
+        .unwrap();
+    engine.flush_row_buffers().await.unwrap();
+    pointer(&engine, "a", "1").await;
+    engine.index_scan(table(), &plan(Some("a"))).await.unwrap();
+    engine
+        .update_table_rows(&table(), HashMap::from([(0, row(&"grown".repeat(1000)))]))
+        .await
+        .unwrap();
+    // Force metadata publication failure AFTER data replacement, without new production hooks.
+    let meta_temp = engine
+        .row_segment_meta_path(&table())
+        .unwrap()
+        .with_extension("bin.tmp");
+    tokio::fs::create_dir(&meta_temp).await.unwrap();
+    assert!(engine.flush_row_buffers().await.is_err());
+    assert!(
+        engine
+            .row_buffer_pool
+            .lock()
+            .await
+            .directory(&engine.row_segment_path(&table()).unwrap())
+            .is_none()
+    );
+    assert_eq!(
+        values(engine.index_scan(table(), &plan(Some("a"))).await.unwrap()),
+        vec![(1, "other".into())]
+    );
+    tokio::fs::remove_dir(&meta_temp).await.unwrap();
+    engine.flush_row_buffers().await.unwrap();
+    *engine.row_buffer_pool.lock().await = RowBufferPool::default();
+    assert_eq!(
+        values(engine.index_scan(table(), &plan(Some("a"))).await.unwrap()),
+        vec![(1, "other".into())]
+    );
+    cleanup(&engine).await;
+}

--- a/src/engine/actions/dml/scan_offset_tests.rs
+++ b/src/engine/actions/dml/scan_offset_tests.rs
@@ -1,0 +1,139 @@
+//! Regression tests and the reproducible row-read benchmark for #221.
+#[path = "scan_offset_io.rs"]
+mod io;
+use super::*;
+use crate::config::launch_config::LaunchConfig;
+use crate::engine::index::IndexMeta;
+use crate::engine::row_buffer::encode_row_frames;
+use crate::engine::schema::row::{TableDataField, TableDataFieldType};
+
+fn table() -> TableName {
+    TableName::new(Some("rrdb".into()), "offsets".into())
+}
+
+fn row(value: &str) -> TableDataRow {
+    TableDataRow {
+        fields: vec![TableDataField {
+            table_name: table(),
+            column_name: "value".into(),
+            data: TableDataFieldType::String(value.into()),
+        }],
+    }
+}
+
+fn values(rows: Vec<(RowLocation, TableDataRow)>) -> Vec<(usize, String)> {
+    rows.into_iter()
+        .map(|(location, row)| {
+            let TableDataFieldType::String(value) = row.fields[0].data.clone() else {
+                panic!("expected string")
+            };
+            (location.row_index, value)
+        })
+        .collect()
+}
+
+async fn engine(label: &str) -> DBEngine {
+    let base = std::env::temp_dir().join(format!("rrdb-offset-{label}-{}", uuid::Uuid::new_v4()));
+    let engine = DBEngine::new(LaunchConfig::default_for_base_path(&base));
+    tokio::fs::create_dir_all(engine.row_segment_path(&table()).unwrap().parent().unwrap())
+        .await
+        .unwrap();
+    engine.indices_loaded.set(()).unwrap();
+    engine
+        .index_manager
+        .create_index(IndexMeta::new(
+            "rrdb.offset_idx".into(),
+            table(),
+            "value".into(),
+            false,
+        ))
+        .await
+        .unwrap();
+    engine
+}
+
+fn plan(eq: Option<&str>) -> IndexScanPlan {
+    IndexScanPlan {
+        index_name: "rrdb.offset_idx".into(),
+        column_name: "value".into(),
+        eq_key: eq.map(str::to_owned),
+        start_key: None,
+        end_key: None,
+    }
+}
+
+async fn pointer(engine: &DBEngine, key: &str, location: &str) {
+    engine
+        .index_manager
+        .insert("rrdb.offset_idx", key.into(), location.into())
+        .await
+        .unwrap();
+}
+
+async fn cleanup(engine: &DBEngine) {
+    // All fixtures have unique directories, including concurrent lib/bin runs.
+    tokio::fs::remove_dir_all(engine.get_data_directory().parent().unwrap())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn offset_point_and_range_skip_unrelated_invalid_body() {
+    let engine = engine("skip-body").await;
+    let mut bytes = encode_live_row_frames(&[row("zero")]).unwrap();
+    bytes.push(ROW_FRAME_LIVE);
+    bytes.extend_from_slice(&100_000u32.to_le_bytes());
+    bytes.extend_from_slice(&vec![0xff; 100_000]); // framed but not valid bincode
+    bytes.extend_from_slice(&encode_live_row_frames(&[row("two")]).unwrap());
+    tokio::fs::write(engine.row_segment_path(&table()).unwrap(), bytes)
+        .await
+        .unwrap();
+    pointer(&engine, "a", "2").await;
+    pointer(&engine, "b", "0").await;
+    let point = engine.index_scan(table(), &plan(Some("a"))).await.unwrap();
+    assert_eq!(values(point), vec![(2, "two".into())]);
+    let range = engine.index_scan(table(), &plan(None)).await.unwrap();
+    assert_eq!(values(range), vec![(2, "two".into()), (0, "zero".into())]);
+    cleanup(&engine).await;
+}
+
+#[tokio::test]
+async fn offset_statistics_skip_bodies_and_count_live_slots() {
+    let engine = engine("statistics").await;
+    let mut bytes = encode_row_frames(&[Some(row("zero")), None]).unwrap();
+    bytes.extend_from_slice(&[0, 1, 0, 0, 0, 255]); // live, invalid payload
+    tokio::fs::write(engine.row_segment_path(&table()).unwrap(), bytes)
+        .await
+        .unwrap();
+    let stats = engine.table_statistics(&table()).await.unwrap();
+    assert_eq!(stats.row_count, 2);
+    cleanup(&engine).await;
+}
+
+#[tokio::test]
+async fn offset_mixed_pending_and_disk_preserve_order() {
+    let engine = engine("pending").await;
+    engine
+        .append_table_rows(&table(), &[row("disk")])
+        .await
+        .unwrap();
+    engine.flush_row_buffers().await.unwrap();
+    engine
+        .append_table_rows(&table(), &[row("pending")])
+        .await
+        .unwrap();
+    pointer(&engine, "a", "1").await;
+    pointer(&engine, "b", "0").await;
+    let rows = engine.index_scan(table(), &plan(None)).await.unwrap();
+    assert_eq!(
+        values(rows),
+        vec![(1, "pending".into()), (0, "disk".into())]
+    );
+    assert_eq!(
+        tokio::fs::read(engine.row_segment_path(&table()).unwrap())
+            .await
+            .unwrap(),
+        encode_live_row_frames(&[row("disk")]).unwrap()
+    );
+    cleanup(&engine).await;
+}

--- a/src/engine/actions/index.rs
+++ b/src/engine/actions/index.rs
@@ -145,13 +145,10 @@ impl DBEngine {
             return Ok(statistics);
         }
 
-        let row_count = self.full_scan(table_name.clone()).await?.len();
+        let row_count = self.row_count_for_statistics(table_name).await?;
 
         let segment_path = self.row_segment_path(table_name)?;
-        let file_size = tokio::fs::metadata(&segment_path)
-            .await
-            .map(|metadata| metadata.len())
-            .unwrap_or(0);
+        let file_size = self.file_system.metadata(&segment_path).await.unwrap_or(0);
         let block_count = file_size.div_ceil(BLOCK_SIZE).max(1) as usize;
 
         let mut distinct_values = HashMap::new();

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -7,6 +7,9 @@ pub mod parser;
 pub mod path_identifier;
 pub mod query_memory;
 pub mod row_buffer;
+#[cfg(test)]
+mod row_offset_model_tests;
+mod row_offsets;
 pub mod schema;
 pub mod server;
 pub mod wal;

--- a/src/engine/optimizer/cost.rs
+++ b/src/engine/optimizer/cost.rs
@@ -23,6 +23,13 @@ pub fn full_scan_cost(row_count: usize, block_count: usize) -> f64 {
 }
 
 /// 인덱스 스캔 비용: B-tree 탐색 + 매칭 튜플별 임의 접근
+///
+/// #221: This now describes warm direct-frame reads, not full-segment decoding.
+/// Keep RANDOM_PAGE_COST conservative: cold directory construction still walks
+/// every frame header; uncached suffixes above the directory cap also need header
+/// walks. Without cache-aware statistics and device-independent measurements,
+/// lowering constants would over-favor broad ranges. See the ignored release
+/// `offset_read_benchmark` for cold-directory and warm point/range comparisons.
 pub fn index_scan_cost(row_count: usize, selectivity: f64) -> f64 {
     let rows = row_count as f64;
     let matched = (rows * selectivity).max(1.0);

--- a/src/engine/row_buffer.rs
+++ b/src/engine/row_buffer.rs
@@ -1,5 +1,6 @@
+use crate::engine::row_offsets::FrameDirectory;
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::engine::encoder::schema_encoder::StorageEncoder;
 use crate::engine::schema::row::TableDataRow;
@@ -13,6 +14,9 @@ pub(crate) const ROW_FRAME_TOMBSTONE: u8 = 1;
 pub(crate) struct RowBufferPool {
     segments: HashMap<PathBuf, RowSegmentBuffer>,
     unsynced_segments: HashSet<PathBuf>,
+    // Deliberately a single bounded, replaceable directory, not an unbounded
+    // cache per table. Queries never clone this Vec.
+    directory: Option<(PathBuf, FrameDirectory)>,
 }
 
 #[derive(Default)]
@@ -38,6 +42,95 @@ enum RowBufferWriteKind {
 }
 
 impl RowBufferPool {
+    /// None: consult disk; Some(None): deleted or outside known logical slots.
+    /// Borrow first so the caller can reserve memory before cloning one row.
+    pub(crate) fn cached_row(&self, path: &Path, index: usize) -> Option<Option<&TableDataRow>> {
+        let segment = self.segments.get(path)?;
+        if let Some(rows) = &segment.persisted_rows {
+            if index < rows.len() {
+                return Some(rows[index].as_ref());
+            }
+            return Some(segment.pending_append_rows.get(index - rows.len()));
+        }
+        let count = segment.persisted_row_count?;
+        if index >= count {
+            return Some(segment.pending_append_rows.get(index - count));
+        }
+        None
+    }
+
+    pub(crate) fn cached_live_row_count(&self, path: &Path) -> Option<usize> {
+        let segment = self.segments.get(path)?;
+        Some(
+            segment
+                .persisted_rows
+                .as_ref()?
+                .iter()
+                .filter(|row| row.is_some())
+                .count()
+                + segment.pending_append_rows.len(),
+        )
+    }
+
+    pub(crate) fn pending_row_count(&self, path: &Path) -> usize {
+        self.segments
+            .get(path)
+            .map_or(0, |segment| segment.pending_append_rows.len())
+    }
+
+    pub(crate) fn persisted_row_count(&self, path: &Path) -> Option<usize> {
+        self.segments.get(path)?.persisted_row_count
+    }
+
+    pub(crate) fn directory(&self, path: &Path) -> Option<&FrameDirectory> {
+        self.directory
+            .as_ref()
+            .filter(|(cached, _)| cached == path)
+            .map(|(_, directory)| directory)
+    }
+
+    pub(crate) fn cache_directory(&mut self, path: PathBuf, directory: FrameDirectory) {
+        self.seed_row_count(path.clone(), directory.row_count);
+        self.directory = Some((path, directory));
+    }
+
+    pub(crate) fn invalidate_directory(&mut self, path: &Path) {
+        if self.directory(path).is_some() {
+            self.directory = None;
+        }
+    }
+
+    pub(crate) fn evict_directory(&mut self) {
+        self.directory = None;
+    }
+
+    /// Derived offsets cannot outlive a physical namespace move. Keep this
+    /// separate from the existing decoded/pending-row rename behavior.
+    pub(crate) fn invalidate_directory_under(&mut self, path: &Path) {
+        if self
+            .directory
+            .as_ref()
+            .is_some_and(|(segment, _)| segment.starts_with(path))
+        {
+            self.directory = None;
+        }
+    }
+
+    /// Path::starts_with is component-aware (does not delete prefix-like siblings).
+    pub(crate) fn remove_under(&mut self, path: &Path) {
+        self.segments
+            .retain(|segment, _| !segment.starts_with(path));
+        self.unsynced_segments
+            .retain(|segment| !segment.starts_with(path));
+        if self
+            .directory
+            .as_ref()
+            .is_some_and(|(segment, _)| segment.starts_with(path))
+        {
+            self.directory = None;
+        }
+    }
+
     pub(crate) fn seed_row_count(&mut self, segment_path: PathBuf, row_count: usize) {
         let segment = self.segments.entry(segment_path).or_default();
         segment.persisted_row_count.get_or_insert(row_count);
@@ -136,6 +229,22 @@ impl RowBufferPool {
     }
 
     pub(crate) fn complete_write(&mut self, write: RowBufferWrite, durable: bool) {
+        if let Some((path, directory)) = &mut self.directory
+            && *path == write.segment_path
+        {
+            let extended = match &write.kind {
+                RowBufferWriteKind::Append { rows }
+                    if directory.row_count == write.next_row_index - rows.len() =>
+                {
+                    directory.extend(&write.content).is_ok()
+                }
+                _ => false,
+            };
+            if !extended {
+                self.directory = None;
+            }
+        }
+
         let segment_path = write.segment_path;
         let segment = self.segments.entry(segment_path.clone()).or_default();
         match write.kind {
@@ -159,6 +268,7 @@ impl RowBufferPool {
     }
 
     pub(crate) fn restore_write(&mut self, write: RowBufferWrite) {
+        self.invalidate_directory(&write.segment_path);
         let segment = self.segments.entry(write.segment_path).or_default();
         match write.kind {
             RowBufferWriteKind::Append { rows } => {

--- a/src/engine/row_offset_model_tests.rs
+++ b/src/engine/row_offset_model_tests.rs
@@ -1,0 +1,179 @@
+//! Model-based coverage for indexed reads across mutations and engine reopen.
+use crate::{
+    config::launch_config::LaunchConfig,
+    engine::{
+        DBEngine, SharedWALManager,
+        ast::{dml::plan::select::scan::IndexScanPlan, types::TableName},
+        index::field_to_key,
+        parser::predule::{Parser, ParserContext},
+        schema::row::{TableDataFieldType, TableDataRow},
+        wal::{
+            endec::implements::bincode::{BincodeDecoder, BincodeEncoder},
+            manager::builder::WALBuilder,
+        },
+    },
+};
+use std::{collections::BTreeMap, sync::Arc};
+use tokio::sync::Mutex;
+
+async fn sql(engine: &DBEngine, wal: SharedWALManager, text: &str) {
+    let mut parser = Parser::with_string(text.to_string()).unwrap();
+    let statement = parser
+        .parse(ParserContext::default().set_default_database("rrdb".to_string()))
+        .unwrap()
+        .remove(0);
+    engine
+        .process_query(statement, wal, "independent-model".to_string())
+        .await
+        .unwrap();
+}
+fn pair(row: TableDataRow) -> (i64, String) {
+    let id = row.fields.iter().find(|f| f.column_name == "id").unwrap();
+    let value = row
+        .fields
+        .iter()
+        .find(|f| f.column_name == "payload")
+        .unwrap();
+    let TableDataFieldType::Integer(id) = &id.data else {
+        panic!("id is not integer")
+    };
+    let TableDataFieldType::String(value) = &value.data else {
+        panic!("payload is not string")
+    };
+    (*id, value.clone())
+}
+fn plan(eq: Option<i64>, start: Option<i64>, end: Option<i64>) -> IndexScanPlan {
+    let key = |id| field_to_key(&TableDataFieldType::Integer(id));
+    IndexScanPlan {
+        index_name: "rrdb.items_pkey".to_string(),
+        column_name: "id".to_string(),
+        eq_key: eq.map(key),
+        start_key: start.map(key),
+        end_key: end.map(key),
+    }
+}
+
+#[tokio::test]
+async fn independent_offset_reads_match_model_across_mutation_and_reopen() {
+    let base = std::path::PathBuf::from(format!(
+        "target/independent_offset_model_{}",
+        std::process::id()
+    ));
+    if base.exists() {
+        tokio::fs::remove_dir_all(&base).await.unwrap();
+    }
+    let config = LaunchConfig::default_for_base_path(&base);
+    tokio::fs::create_dir_all(&config.data_directory)
+        .await
+        .unwrap();
+    tokio::fs::create_dir_all(&config.wal_directory)
+        .await
+        .unwrap();
+    let wal = Arc::new(Mutex::new(
+        WALBuilder::new(&config)
+            .build(BincodeDecoder::new(), BincodeEncoder::new())
+            .await
+            .unwrap(),
+    ));
+    let mut engine = DBEngine::new(config.clone());
+    sql(&engine, wal.clone(), "create database rrdb;").await;
+    sql(
+        &engine,
+        wal.clone(),
+        "create table items (id integer primary key, payload varchar(4096));",
+    )
+    .await;
+    let table = TableName::new(Some("rrdb".to_string()), "items".to_string());
+    let mut expected = BTreeMap::<i64, String>::new();
+    let mut seed = 0x221_cafe_u64;
+    for step in 0..96 {
+        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        let id = ((seed >> 32) % 24) as i64;
+        let payload = "v".repeat(1 + ((seed >> 8) % 2048) as usize);
+        match (expected.contains_key(&id), step % 3) {
+            (false, _) => {
+                sql(
+                    &engine,
+                    wal.clone(),
+                    &format!("insert into items (id, payload) values ({id}, '{payload}');"),
+                )
+                .await;
+                expected.insert(id, payload);
+            }
+            (true, 0) => {
+                sql(
+                    &engine,
+                    wal.clone(),
+                    &format!("delete from items where id = {id};"),
+                )
+                .await;
+                expected.remove(&id);
+            }
+            (true, _) => {
+                sql(
+                    &engine,
+                    wal.clone(),
+                    &format!("update items set payload = '{payload}' where id = {id};"),
+                )
+                .await;
+                expected.insert(id, payload);
+            }
+        }
+        // A reopened engine has neither decoded rows nor an offset directory.
+        // Other iterations verify buffered/dirty rows immediately after mutation.
+        if step % 4 == 0 {
+            engine.flush_row_buffers_durable().await.unwrap();
+            engine = DBEngine::new(config.clone());
+        }
+        let indexed: Vec<_> = engine
+            .index_scan(table.clone(), &plan(None, None, None))
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(_, r)| pair(r))
+            .collect();
+        let model: Vec<_> = expected
+            .iter()
+            .map(|(id, value)| (*id, value.clone()))
+            .collect();
+        assert_eq!(indexed, model, "unbounded range at step {step}");
+        let bounded: Vec<_> = engine
+            .index_scan(table.clone(), &plan(None, Some(5), Some(18)))
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(_, r)| pair(r))
+            .collect();
+        let model_range: Vec<_> = expected
+            .range(5..18)
+            .map(|(id, value)| (*id, value.clone()))
+            .collect();
+        assert_eq!(bounded, model_range, "half-open range at step {step}");
+        let point: Vec<_> = engine
+            .index_scan(table.clone(), &plan(Some(id), None, None))
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(_, r)| pair(r))
+            .collect();
+        let model_point: Vec<_> = expected
+            .get(&id)
+            .map(|value| (id, value.clone()))
+            .into_iter()
+            .collect();
+        assert_eq!(point, model_point, "point/missing at step {step}");
+        let mut full: Vec<_> = engine
+            .full_scan(table.clone())
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(_, r)| pair(r))
+            .collect();
+        full.sort_by_key(|(id, _)| *id);
+        assert_eq!(full, model, "full scan oracle at step {step}");
+    }
+    engine.flush_row_buffers_durable().await.unwrap();
+    drop(engine);
+    drop(wal);
+    tokio::fs::remove_dir_all(base).await.unwrap();
+}

--- a/src/engine/row_offsets.rs
+++ b/src/engine/row_offsets.rs
@@ -1,0 +1,140 @@
+//! Rebuildable row-index -> frame-body directory. The row/WAL formats are unchanged.
+use crate::engine::query_memory::QueryMemoryTracker;
+use crate::engine::row_buffer::ROW_FRAME_LIVE;
+use crate::errors;
+use crate::errors::execute_error::ExecuteError;
+
+pub(crate) const FRAME_HEADER_LEN: u64 = 5;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn offset_cache_cap_is_not_a_row_count_limit() {
+        let mut directory = FrameDirectory::default();
+        for index in 0..MAX_DIRECTORY_BYTES / size_of::<FrameOffset>() + 2 {
+            directory
+                .push(
+                    FrameOffset {
+                        body: index as u64 * 5 + 5,
+                        len: 0,
+                        live: false,
+                    },
+                    None,
+                )
+                .unwrap();
+        }
+        assert!(directory.frames.capacity() * size_of::<FrameOffset>() <= MAX_DIRECTORY_BYTES);
+    }
+    #[test]
+    fn offset_header_bounds_do_not_overflow() {
+        assert!(FrameOffset::from_header([0; 5], u64::MAX, u64::MAX).is_err());
+        assert!(
+            FrameOffset::from_header([0, 0xff, 0xff, 0xff, 0xff], u64::MAX - 5, u64::MAX).is_err()
+        );
+    }
+}
+/// One directory retained by the buffer pool, including Vec capacity slack.
+/// This bound applies even outside a query (e.g. recovery / internal callers).
+pub(crate) const MAX_DIRECTORY_BYTES: usize = 16 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct FrameOffset {
+    pub(crate) body: u64,
+    pub(crate) len: u32,
+    pub(crate) live: bool,
+}
+
+impl FrameOffset {
+    pub(crate) fn from_header(header: [u8; 5], offset: u64, file_len: u64) -> errors::Result<Self> {
+        let body = offset
+            .checked_add(FRAME_HEADER_LEN)
+            .filter(|end| *end <= file_len)
+            .ok_or_else(|| ExecuteError::wrap("truncated row segment frame header"))?;
+        let len = u32::from_le_bytes(header[1..].try_into().unwrap());
+        body.checked_add(u64::from(len))
+            .filter(|end| *end <= file_len)
+            .ok_or_else(|| ExecuteError::wrap("truncated row segment frame body"))?;
+        // Match the existing reader: every nonzero flag is a tombstone.
+        Ok(Self {
+            body,
+            len,
+            live: header[0] == ROW_FRAME_LIVE,
+        })
+    }
+
+    pub(crate) fn end(self) -> u64 {
+        self.body + u64::from(self.len)
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct FrameDirectory {
+    pub(crate) frames: Vec<FrameOffset>,
+    pub(crate) file_len: u64,
+    pub(crate) live_count: usize,
+    pub(crate) row_count: usize,
+}
+
+impl FrameDirectory {
+    pub(crate) fn push(
+        &mut self,
+        frame: FrameOffset,
+        tracker: Option<&QueryMemoryTracker>,
+    ) -> errors::Result<()> {
+        // The cap limits cached offsets, not table size. Retain a prefix;
+        // callers can header-walk the uncached suffix without allocations.
+        // Never fill a hole in the prefix with a later row's ordinal.
+        if self.frames.len() != self.row_count
+            || self.row_count >= MAX_DIRECTORY_BYTES / size_of::<FrameOffset>()
+        {
+            self.live_count += usize::from(frame.live);
+            self.row_count += 1;
+            self.file_len = frame.end();
+            return Ok(());
+        }
+        if self.frames.len() == self.frames.capacity() {
+            let max = MAX_DIRECTORY_BYTES / size_of::<FrameOffset>();
+            let capacity = (self.frames.capacity().max(128) * 2).min(max);
+            if capacity <= self.frames.len() {
+                return Err(ExecuteError::wrap("row offset directory limit exceeded"));
+            }
+            let additional = capacity - self.frames.len();
+            if let Some(tracker) = tracker {
+                tracker.reserve((additional * size_of::<FrameOffset>()) as u64)?;
+            }
+            self.frames.try_reserve_exact(additional).map_err(|error| {
+                ExecuteError::wrap(format!("row offset allocation failed: {error}"))
+            })?;
+        }
+        self.live_count += usize::from(frame.live);
+        self.file_len = frame.end();
+        self.frames.push(frame);
+        self.row_count += 1;
+        Ok(())
+    }
+
+    /// Only inspect new encoded frames, never rescan/clone the old directory.
+    /// Failure evicts this optional cache; it must not turn a successful flush
+    /// into a retry of data that has already been written.
+    pub(crate) fn extend(&mut self, content: &[u8]) -> errors::Result<()> {
+        let base = self.file_len;
+        let file_len = base
+            .checked_add(content.len() as u64)
+            .ok_or_else(|| ExecuteError::wrap("row segment offset overflow"))?;
+        let mut offset = 0;
+        while offset < content.len() {
+            let header = content
+                .get(offset..offset + 5)
+                .ok_or_else(|| ExecuteError::wrap("truncated row segment frame header"))?;
+            let frame = FrameOffset::from_header(
+                header.try_into().unwrap(),
+                base + offset as u64,
+                file_len,
+            )?;
+            offset = (frame.end() - base) as usize;
+            self.push(frame, None)?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Closes #221.

- Materialize indexed point/range matches through a rebuildable frame-offset directory instead of loading/cloning the entire row segment.
- Preserve existing B-tree row IDs, row framing and WAL formats. Pending/dirty rows take precedence; append extends offsets and rewrite/failure/namespace changes invalidate them safely.
- Count cold optimizer statistics from headers without decoding unrelated rows. Keep cost constants unchanged and document cache-state limitations.
- Add bounded allocation/corruption, I/O, mutation/reopen, namespace, recovery and independent model-based regression coverage.

## Verification

On macOS ARM64 / Rust 1.97.1:

- `cargo build` — passed.
- `cargo test` — 440 library + 444 main-binary + 5 test-binary executions passed; 0 failed. The benchmark is ignored in ordinary lib/bin runs.
- `cargo clippy --all-targets` — passed, no new warning messages relative to base `828af74`.
- `cargo test --release --lib offset_read_benchmark -- --ignored --nocapture` — passed, including result equivalence assertions.
- Regression sensitivity checked independently: restoring the old `index_scan` makes the unrelated-invalid-body test fail; restoring the new implementation passes.
- Independent 96-mutation / 24-reopen model workload passes on baseline and candidate. Independent pre-PR source/security review found no blocking introduced defect.
- `git diff --check` passes. `cargo fmt --check` still reports existing baseline formatting differences; baseline-relative checking found no new formatter drift. Unrelated formatting was deliberately not changed.

## Performance and limits

See [design, benchmark and caveats](docs/row-offset-reads.md).

In one release run with a 10,960,000-byte / 10,000-row segment, a warm point lookup requested 1,091 row-body bytes and averaged 58.8 us. These are application-level requests, not physical disk-I/O measurements.

This is **not a universal speedup**: directory-cold point lookup averaged 125,430.6 us versus 12,292.9 us for cold decoded-cache full materialization in that run. OS caches were not evicted; the benchmark bypasses SQL planning. The single directory retains up to 16 MiB of entries; uncached suffix ranges can incur quadratic header traversal and are not covered by the below-cap benchmark.

The WAL test covers durable WAL before application. Existing partial index/data persistence, general flush-retry durability and broader rename semantics are not repaired here; the original applied-tail crash fixture also fails on the pinned baseline. No storage-format migration or new fsync-on-insert policy is introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 필요한 데이터 프레임만 읽는 오프셋 기반 인덱스 스캔을 지원합니다.
  * 메모리 예산을 고려해 대규모 조회의 메모리 사용을 제한합니다.
  * 데이터베이스·테이블 변경 후 관련 캐시가 올바르게 갱신됩니다.

* **성능 개선**
  * 선택적 조회와 통계 계산에서 불필요한 디스크 읽기를 줄였습니다.
  * 캐시된 데이터와 새로 추가된 데이터를 일관되게 조회합니다.

* **문서**
  * 오프셋 기반 행 읽기의 동작, 캐시 규칙, 제한 사항 및 벤치마크 결과를 추가했습니다.

* **버그 수정**
  * 데이터 변경, 재시작, 손상된 데이터 및 실패한 작업 이후에도 조회 상태가 일관되도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->